### PR TITLE
fix(activity): labels invisible in light mode (#5)

### DIFF
--- a/Canopy/Views/ActivityHeatmap.swift
+++ b/Canopy/Views/ActivityHeatmap.swift
@@ -5,6 +5,11 @@ import SwiftUI
 struct ActivityHeatmap: View {
     let hourlyBuckets: [String: HourlyBucket]
 
+    // Heatmap card has a fixed dark background, so labels need an
+    // explicit light color — semantic styles flip on light mode and
+    // disappear against the dark fill.
+    static let labelColor = Color.white.opacity(0.72)
+
     // Forest green palette: dark moss → emerald → bright canopy
     private static let colors: [Color] = [
         Color(red: 0.08, green: 0.10, blue: 0.08),   // empty — dark forest floor
@@ -30,7 +35,7 @@ struct ActivityHeatmap: View {
             HStack {
                 Text("Last 12 Weeks")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Self.labelColor)
                 Spacer()
                 legend
             }
@@ -60,7 +65,7 @@ struct ActivityHeatmap: View {
         HStack(spacing: 3) {
             Text("Less")
                 .font(.system(size: 9))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Self.labelColor)
             ForEach(0..<7, id: \.self) { level in
                 RoundedRectangle(cornerRadius: 1)
                     .fill(Self.colors[level])
@@ -68,7 +73,7 @@ struct ActivityHeatmap: View {
             }
             Text("More")
                 .font(.system(size: 9))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Self.labelColor)
         }
     }
 
@@ -147,7 +152,7 @@ struct ActivityHeatmap: View {
                     let spanWidth = colWidth * CGFloat(span.columns) + CGFloat(span.columns - 1)
                     Text(span.name)
                         .font(.system(size: 9, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(Self.labelColor)
                         .frame(width: spanWidth, alignment: .leading)
                         .clipped()
                 }
@@ -161,7 +166,7 @@ struct ActivityHeatmap: View {
             ForEach(0..<24, id: \.self) { hour in
                 Text(hour % 3 == 0 ? "\(hour)" : "")
                     .font(.system(size: 7))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Self.labelColor)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
             }
         }

--- a/Canopy/Views/ActivityHeatmap.swift
+++ b/Canopy/Views/ActivityHeatmap.swift
@@ -8,7 +8,7 @@ struct ActivityHeatmap: View {
     // Heatmap card has a fixed dark background, so labels need an
     // explicit light color — semantic styles flip on light mode and
     // disappear against the dark fill.
-    static let labelColor = Color.white.opacity(0.72)
+    private static let labelColor = Color.white.opacity(0.72)
 
     // Forest green palette: dark moss → emerald → bright canopy
     private static let colors: [Color] = [

--- a/Canopy/Views/ActivityView.swift
+++ b/Canopy/Views/ActivityView.swift
@@ -10,6 +10,11 @@ struct ActivityView: View {
     private let cardBackground = Color(red: 0.06, green: 0.08, blue: 0.06)
     private let cardBorder    = Color(red: 0.12, green: 0.18, blue: 0.12)
     private let accentGreen   = Color(red: 0.30, green: 0.75, blue: 0.32)
+    // Cards have a fixed dark background, so text colors must not follow
+    // system appearance — otherwise light mode renders dark-on-dark.
+    static let primaryText   = Color.white
+    static let secondaryText = Color.white.opacity(0.72)
+    static let tertiaryText  = Color.white.opacity(0.5)
 
     var body: some View {
         VStack(spacing: 12) {
@@ -43,7 +48,7 @@ struct ActivityView: View {
                     if appState.activityIndexing {
                         Text("Indexing sessions...")
                             .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ActivityView.secondaryText)
                     }
                 }
             }
@@ -60,7 +65,7 @@ struct ActivityView: View {
                 .foregroundStyle(accentGreen)
             Text("In: \(abbreviatedTokenCount(summary.allTimeInput))  Out: \(abbreviatedTokenCount(summary.allTimeOutput))")
                 .font(.system(size: 9))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ActivityView.tertiaryText)
         }
     }
 
@@ -68,9 +73,10 @@ struct ActivityView: View {
         StatCard(title: "LAST 12 WEEKS", cardBackground: cardBackground, cardBorder: cardBorder) {
             Text(abbreviatedTokenCount(summary.periodTotal))
                 .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(ActivityView.primaryText)
             Text("In: \(abbreviatedTokenCount(summary.periodInput))  Out: \(abbreviatedTokenCount(summary.periodOutput))")
                 .font(.system(size: 9))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ActivityView.tertiaryText)
         }
     }
 
@@ -78,9 +84,10 @@ struct ActivityView: View {
         StatCard(title: "SESSIONS", cardBackground: cardBackground, cardBorder: cardBorder) {
             Text("\(summary.periodSessionCount)")
                 .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(ActivityView.primaryText)
             Text("Last 12 Weeks")
                 .font(.system(size: 9))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ActivityView.tertiaryText)
         }
     }
 
@@ -88,9 +95,10 @@ struct ActivityView: View {
         StatCard(title: "BUSIEST DAY", cardBackground: cardBackground, cardBorder: cardBorder) {
             Text(abbreviatedTokenCount(summary.busiestDayTokens))
                 .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(ActivityView.primaryText)
             Text(formattedBusiestDate(summary.busiestDayDate))
                 .font(.system(size: 9))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ActivityView.tertiaryText)
         }
     }
 
@@ -103,12 +111,12 @@ struct ActivityView: View {
                 ForEach(summary.modelBreakdown.dropFirst().prefix(2), id: \.name) { entry in
                     Text("\(shortModelName(entry.name)) \(entry.percentage)%")
                         .font(.system(size: 9))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ActivityView.tertiaryText)
                 }
             } else {
                 Text("—")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ActivityView.secondaryText)
             }
         }
     }
@@ -169,7 +177,7 @@ private struct StatCard<Content: View>: View {
             Text(title)
                 .font(.system(size: 9))
                 .tracking(0.5)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ActivityView.secondaryText)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             content

--- a/Canopy/Views/ActivityView.swift
+++ b/Canopy/Views/ActivityView.swift
@@ -12,9 +12,9 @@ struct ActivityView: View {
     private let accentGreen   = Color(red: 0.30, green: 0.75, blue: 0.32)
     // Cards have a fixed dark background, so text colors must not follow
     // system appearance — otherwise light mode renders dark-on-dark.
-    static let primaryText   = Color.white
-    static let secondaryText = Color.white.opacity(0.72)
-    static let tertiaryText  = Color.white.opacity(0.5)
+    fileprivate static let primaryText   = Color.white
+    fileprivate static let secondaryText = Color.white.opacity(0.72)
+    fileprivate static let tertiaryText  = Color.white.opacity(0.5)
 
     var body: some View {
         VStack(spacing: 12) {


### PR DESCRIPTION
Fix for https://github.com/juliensimon/canopy/issues/5 — labels not visible in the Activity window when macOS is in light mode.

## Summary
- The Activity tab cards and heatmap have a hardcoded near-black background but used SwiftUI's adaptive `.secondary` / `.tertiary` / default `.primary` foreground styles, which flip to dark in light mode → labels render invisibly on the dark fill.
- Replaced the adaptive styles with explicit white-with-opacity constants (`primaryText`, `secondaryText`, `tertiaryText` on `ActivityView`; `labelColor` on `ActivityHeatmap`) so the cards look identical in both system appearances.
- Other views are intentionally untouched: they render against native macOS window/sheet/sidebar chrome, where the adaptive semantic styles are the correct behavior.

Closes #5

## Test plan
- [x] Build with \`scripts/bundle.sh\` (clean)
- [x] Verify in dark mode — visually unchanged
- [x] Verify in light mode — all card labels (LAST 12 WEEKS, SESSIONS, BUSIEST DAY, MODELS, In/Out subtitles, heatmap month + hour axis, "Less"/"More" legend, "Indexing sessions..." overlay) are now legible against the dark forest fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)