### PR TITLE
feat: Docker Sandbox (sbx) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Docker Sandbox support: optionally run Claude Code inside a `sbx` microVM
+  for hard process isolation. Configurable globally and per-project with a
+  toggle and optional `sbx run` flags. Canopy validates that Docker Desktop
+  and `sbx` are installed before enabling. Session resume is automatically
+  disabled in sandbox mode (session files are ephemeral). A shield icon in
+  the sidebar indicates sandboxed sessions.
+
 ## [0.9.2] - 2026-04-14
 
 ### Fixed

--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		54F01BBD042D8ED56E51C8C2 /* EditProjectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE733A0978C4D68242BD92DF /* EditProjectSheet.swift */; };
 		56EC12B4E8F87D40411C840B /* CLAUDE.md in Resources */ = {isa = PBXBuildFile; fileRef = ABDE785C75EE225F22CA2DCF /* CLAUDE.md */; };
 		5887EDBFB7E0736EE8C93FA2 /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92BEEFDE99541D50A1CA3D3 /* Sidebar.swift */; };
+		5A1B2C3D4E5F6A7B8C9D0E1F /* SandboxChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A8B9C0D1E2F /* SandboxChecker.swift */; };
+		5A2B3C4D5E6F7A8B9C0D1E2F /* SandboxCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3B4C5D6E7F8A9B0C1D2E3F /* SandboxCheckerTests.swift */; };
 		5ADD93F25B00D2714A1EFD72 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9414820607B039974EEC65B0 /* AboutView.swift */; };
 		5B557A590AB2A2D60DD1F4B1 /* SessionCostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D974FBD7BD5BBBDF64BE541 /* SessionCostService.swift */; };
 		61F597B57855CED664F26FF0 /* WorktreeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB9373875A0B260C472271A /* WorktreeSheet.swift */; };
@@ -116,6 +118,8 @@
 		8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDataService.swift; sourceTree = "<group>"; };
 		9414820607B039974EEC65B0 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		96866F8C0F3D4596B7B10674 /* ModelTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTypeTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7A8B9C0D1E2F /* SandboxChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxChecker.swift; sourceTree = "<group>"; };
+		2A3B4C5D6E7F8A9B0C1D2E3F /* SandboxCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxCheckerTests.swift; sourceTree = "<group>"; };
 		9697FE4298A6EA5B8C4971A4 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		9CF6A405D64E374EAF900972 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		9D974FBD7BD5BBBDF64BE541 /* SessionCostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCostService.swift; sourceTree = "<group>"; };
@@ -195,6 +199,7 @@
 				8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */,
 				380F49104F9CB7D2D472F216 /* GitService.swift */,
 				39E41572F63722BAF89C330B /* NotificationService.swift */,
+				1A2B3C4D5E6F7A8B9C0D1E2F /* SandboxChecker.swift */,
 				9D974FBD7BD5BBBDF64BE541 /* SessionCostService.swift */,
 				27744AE57F084B3F805FCE26 /* TerminalSession.swift */,
 				3577FDAC3BB3B716543493D2 /* UpdateChecker.swift */,
@@ -274,6 +279,7 @@
 				BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */,
 				46D422E570979B7E618CD81A /* ProjectResolutionTests.swift */,
 				DB01F64B012648D641FF741D /* ProjectTests.swift */,
+				2A3B4C5D6E7F8A9B0C1D2E3F /* SandboxCheckerTests.swift */,
 				4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */,
 				EB57402CEF34C579AE3ED054 /* SettingsEdgeCaseTests.swift */,
 				2104528AB64BB407CE23FBDE /* SettingsTests.swift */,
@@ -426,6 +432,7 @@
 				5B557A590AB2A2D60DD1F4B1 /* SessionCostService.swift in Sources */,
 				8AE649C33D49CF076C84EDE2 /* SessionInfoSheet.swift in Sources */,
 				6C71862F4AA78E6A8389F514 /* SessionTabBar.swift in Sources */,
+				5A1B2C3D4E5F6A7B8C9D0E1F /* SandboxChecker.swift in Sources */,
 				FDEDB0A944CA58BA42876DF5 /* Settings.swift in Sources */,
 				7B8CB07FC35DC6C87C6F2776 /* SettingsView.swift in Sources */,
 				091307491980509F1BCDCBB3 /* ShortcutsView.swift in Sources */,
@@ -459,6 +466,7 @@
 				F947F0BD6885AEF08CEF331A /* ProjectResolutionTests.swift in Sources */,
 				2C1B79B946E6AD50EB0EC424 /* ProjectTests.swift in Sources */,
 				7403E7DA09BC3CAD7004D877 /* SessionCostServiceTests.swift in Sources */,
+				5A2B3C4D5E6F7A8B9C0D1E2F /* SandboxCheckerTests.swift in Sources */,
 				47572C3FF5F7C52C77D0B4C5 /* SettingsEdgeCaseTests.swift in Sources */,
 				CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */,
 				1C354EB4E51F588DBD773A0C /* TerminalSessionEdgeCaseTests.swift in Sources */,

--- a/Canopy/Models/Project.swift
+++ b/Canopy/Models/Project.swift
@@ -27,6 +27,12 @@ struct Project: Identifiable, Codable {
     /// Override global Claude flags for this project. nil = use global.
     var claudeFlags: String?
 
+    /// Override global sandbox setting for this project. nil = use global.
+    var useSandbox: Bool?
+
+    /// Override global sbx flags for this project. nil = use global.
+    var sbxFlags: String?
+
     /// Color index into ProjectColor palette. Auto-assigned on creation, user-overridable.
     var colorIndex: Int?
 
@@ -38,6 +44,8 @@ struct Project: Identifiable, Codable {
         setupCommands: [String] = [],
         autoStartClaude: Bool? = nil,
         claudeFlags: String? = nil,
+        useSandbox: Bool? = nil,
+        sbxFlags: String? = nil,
         colorIndex: Int? = nil
     ) {
         self.id = UUID()
@@ -48,6 +56,8 @@ struct Project: Identifiable, Codable {
         self.setupCommands = setupCommands
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
+        self.useSandbox = useSandbox
+        self.sbxFlags = sbxFlags
         self.colorIndex = colorIndex
     }
 
@@ -63,6 +73,8 @@ struct Project: Identifiable, Codable {
         worktreeBaseDir = try container.decodeIfPresent(String.self, forKey: .worktreeBaseDir)
         autoStartClaude = try container.decodeIfPresent(Bool.self, forKey: .autoStartClaude)
         claudeFlags = try container.decodeIfPresent(String.self, forKey: .claudeFlags)
+        useSandbox = try container.decodeIfPresent(Bool.self, forKey: .useSandbox)
+        sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags)
         colorIndex = try container.decodeIfPresent(Int.self, forKey: .colorIndex)
     }
 
@@ -81,13 +93,32 @@ struct Project: Identifiable, Codable {
     }
 
     /// Resolves the Claude command, falling back to global settings.
+    ///
+    /// When sandbox mode is enabled, `--` separates sbx flags from claude flags:
+    /// `sbx run [sbx-flags] claude -- [claude-flags]`
     func resolvedClaudeCommand(globalSettings: CanopySettings) -> String {
-        var cmd = "claude"
+        let sandbox = useSandbox ?? globalSettings.useSandbox
+        let sbxFlagsResolved = sbxFlags ?? globalSettings.sbxFlags
         let flags = claudeFlags ?? globalSettings.claudeFlags
         let trimmed = flags.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            cmd += " " + trimmed
+
+        var parts: [String] = []
+        if sandbox {
+            parts.append("sbx run")
+            let trimmedSbx = sbxFlagsResolved.trimmingCharacters(in: .whitespaces)
+            if !trimmedSbx.isEmpty {
+                parts.append(trimmedSbx)
+            }
+            parts.append("claude --")
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
+        } else {
+            parts.append("claude")
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
         }
-        return cmd
+        return parts.joined(separator: " ")
     }
 }

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -25,6 +25,12 @@ struct CanopySettings: Codable {
     /// Whether to check GitHub for a newer Canopy release on launch (rate-limited to once per day).
     var checkForUpdatesOnLaunch: Bool
 
+    /// Whether to run Claude Code inside a Docker Sandbox (sbx) microVM.
+    var useSandbox: Bool
+
+    /// Additional flags passed to `sbx run` (e.g. "--memory 8g").
+    var sbxFlags: String
+
     var ideName: String {
         ((idePath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
@@ -33,7 +39,7 @@ struct CanopySettings: Codable {
         ((terminalPath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 
-    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true) {
+    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, useSandbox: Bool = false, sbxFlags: String = "") {
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
         self.confirmBeforeClosing = confirmBeforeClosing
@@ -41,6 +47,8 @@ struct CanopySettings: Codable {
         self.terminalPath = terminalPath
         self.notifyOnFinish = notifyOnFinish
         self.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
+        self.useSandbox = useSandbox
+        self.sbxFlags = sbxFlags
     }
 
     init(from decoder: Decoder) throws {
@@ -52,16 +60,37 @@ struct CanopySettings: Codable {
         terminalPath = try container.decodeIfPresent(String.self, forKey: .terminalPath) ?? "/System/Applications/Utilities/Terminal.app"
         notifyOnFinish = try container.decodeIfPresent(Bool.self, forKey: .notifyOnFinish) ?? true
         checkForUpdatesOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .checkForUpdatesOnLaunch) ?? true
+        useSandbox = try container.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false
+        sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags) ?? ""
     }
 
     /// The full command sent to the terminal when auto-starting.
+    ///
+    /// When sandbox mode is enabled, `--` separates sbx flags from claude flags:
+    /// `sbx run [sbx-flags] claude -- [claude-flags]`
+    /// The `--` is always included in sandbox mode so that flags appended later
+    /// (like `--resume`) are correctly passed to claude, not to sbx.
     var claudeCommand: String {
-        var cmd = "claude"
-        let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            cmd += " " + trimmed
+        var parts: [String] = []
+        if useSandbox {
+            parts.append("sbx run")
+            let trimmedSbx = sbxFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmedSbx.isEmpty {
+                parts.append(trimmedSbx)
+            }
+            parts.append("claude --")
+            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
+        } else {
+            parts.append("claude")
+            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
         }
-        return cmd
+        return parts.joined(separator: " ")
     }
 
     // MARK: - Persistence

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -18,14 +18,28 @@ struct SandboxChecker {
         return .available
     }
 
+    /// Returns a shell path that supports `-ilc` for login/interactive command execution.
+    ///
+    /// Falls back to `/bin/zsh` when the user's configured shell is incompatible
+    /// (for example, `fish`) so command checks don't fail incorrectly.
+    static func loginShell() -> String {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let name = URL(fileURLWithPath: shell).lastPathComponent
+        switch name {
+        case "zsh", "bash":
+            return shell
+        default:
+            return "/bin/zsh"
+        }
+    }
+
     /// Returns true if the given command name is found in the user's shell PATH.
     ///
     /// Uses `-ilc` (interactive login) so that both `.zprofile` and `.zshrc` are
     /// sourced -- Homebrew's PATH is often configured in `.zshrc` only.
     static func commandExists(_ name: String) async -> Bool {
-        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: shell)
+        process.executableURL = URL(fileURLWithPath: loginShell())
         process.arguments = ["-ilc", "which \(name)"]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Checks whether Docker and the `sbx` CLI are available on the system.
+///
+/// Uses a login shell to resolve PATH so that tools installed via Homebrew
+/// or Docker Desktop are found even when running from a GUI app.
+struct SandboxChecker {
+    enum Status: Equatable {
+        case available
+        case missingDocker
+        case missingSbx
+    }
+
+    /// Checks for both `docker` and `sbx` in PATH.
+    static func check() async -> Status {
+        guard await commandExists("docker") else { return .missingDocker }
+        guard await commandExists("sbx") else { return .missingSbx }
+        return .available
+    }
+
+    /// Returns true if the given command name is found in the user's shell PATH.
+    ///
+    /// Uses `-ilc` (interactive login) so that both `.zprofile` and `.zshrc` are
+    /// sourced -- Homebrew's PATH is often configured in `.zshrc` only.
+    static func commandExists(_ name: String) async -> Bool {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-ilc", "which \(name)"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -18,6 +18,7 @@ struct AddProjectSheet: View {
     @State private var useSandbox = false
     @State private var sbxFlags = ""
     @State private var sandboxStatus: SandboxChecker.Status?
+    @State private var checkingSandbox = false
     @State private var isValidRepo = false
     @State private var validationMessage = ""
     @State private var selectedColorIndex: Int = 0
@@ -155,11 +156,13 @@ struct AddProjectSheet: View {
                             get: { useSandbox },
                             set: { newValue in
                                 if newValue {
-                                    Task {
+                                    checkingSandbox = true
+                                    Task.detached(priority: .utility) {
                                         let status = await SandboxChecker.check()
                                         await MainActor.run {
                                             sandboxStatus = status
                                             useSandbox = status == .available
+                                            checkingSandbox = false
                                         }
                                     }
                                 } else {
@@ -170,6 +173,7 @@ struct AddProjectSheet: View {
                         ))
                             .font(.subheadline)
                             .padding(.leading, 16)
+                            .disabled(checkingSandbox)
 
                         if let status = sandboxStatus, status != .available {
                             Text(status == .missingDocker

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -15,6 +15,9 @@ struct AddProjectSheet: View {
     @State private var overrideClaude = false
     @State private var autoStartClaude = false
     @State private var claudeFlags = ""
+    @State private var useSandbox = false
+    @State private var sbxFlags = ""
+    @State private var sandboxStatus: SandboxChecker.Status?
     @State private var isValidRepo = false
     @State private var validationMessage = ""
     @State private var selectedColorIndex: Int = 0
@@ -147,6 +150,46 @@ struct AddProjectSheet: View {
                                 .font(.system(size: 12, design: .monospaced))
                         }
                         .padding(.leading, 16)
+
+                        Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
+                            get: { useSandbox },
+                            set: { newValue in
+                                if newValue {
+                                    Task {
+                                        let status = await SandboxChecker.check()
+                                        await MainActor.run {
+                                            sandboxStatus = status
+                                            useSandbox = status == .available
+                                        }
+                                    }
+                                } else {
+                                    useSandbox = false
+                                    sandboxStatus = nil
+                                }
+                            }
+                        ))
+                            .font(.subheadline)
+                            .padding(.leading, 16)
+
+                        if let status = sandboxStatus, status != .available {
+                            Text(status == .missingDocker
+                                ? "Docker not found. Install Docker Desktop from docker.com."
+                                : "sbx not found. Install with: brew install docker/tap/sbx")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                                .padding(.leading, 16)
+                        }
+
+                        if useSandbox {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Sandbox flags")
+                                    .font(.subheadline)
+                                TextField("e.g. --memory 8g", text: $sbxFlags)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                            }
+                            .padding(.leading, 16)
+                        }
                     }
                 }
             }
@@ -215,7 +258,9 @@ struct AddProjectSheet: View {
             symlinkPaths: parseCommaSeparated(symlinkPaths),
             setupCommands: parseCommaSeparated(setupCommands),
             autoStartClaude: overrideClaude ? autoStartClaude : nil,
-            claudeFlags: overrideClaude ? claudeFlags : nil
+            claudeFlags: overrideClaude ? claudeFlags : nil,
+            useSandbox: overrideClaude ? useSandbox : nil,
+            sbxFlags: overrideClaude ? sbxFlags : nil
         )
         project.colorIndex = selectedColorIndex
         appState.addProject(project)

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -14,6 +14,9 @@ struct EditProjectSheet: View {
     @State private var overrideClaude: Bool
     @State private var autoStartClaude: Bool
     @State private var claudeFlags: String
+    @State private var useSandbox: Bool
+    @State private var sbxFlags: String
+    @State private var sandboxStatus: SandboxChecker.Status?
     @State private var selectedColorIndex: Int
 
     init(project: Project) {
@@ -22,9 +25,13 @@ struct EditProjectSheet: View {
         self._filesToCopy = State(initialValue: project.filesToCopy.joined(separator: ", "))
         self._symlinkPaths = State(initialValue: project.symlinkPaths.joined(separator: ", "))
         self._setupCommands = State(initialValue: project.setupCommands.joined(separator: ", "))
-        self._overrideClaude = State(initialValue: project.autoStartClaude != nil || project.claudeFlags != nil)
+        self._overrideClaude = State(initialValue:
+            project.autoStartClaude != nil || project.claudeFlags != nil
+            || project.useSandbox != nil || project.sbxFlags != nil)
         self._autoStartClaude = State(initialValue: project.autoStartClaude ?? false)
         self._claudeFlags = State(initialValue: project.claudeFlags ?? "")
+        self._useSandbox = State(initialValue: project.useSandbox ?? false)
+        self._sbxFlags = State(initialValue: project.sbxFlags ?? "")
         self._selectedColorIndex = State(initialValue: project.colorIndex ?? 0)
     }
 
@@ -126,6 +133,46 @@ struct EditProjectSheet: View {
                                 .font(.system(size: 12, design: .monospaced))
                         }
                         .padding(.leading, 16)
+
+                        Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
+                            get: { useSandbox },
+                            set: { newValue in
+                                if newValue {
+                                    Task {
+                                        let status = await SandboxChecker.check()
+                                        await MainActor.run {
+                                            sandboxStatus = status
+                                            useSandbox = status == .available
+                                        }
+                                    }
+                                } else {
+                                    useSandbox = false
+                                    sandboxStatus = nil
+                                }
+                            }
+                        ))
+                            .font(.subheadline)
+                            .padding(.leading, 16)
+
+                        if let status = sandboxStatus, status != .available {
+                            Text(status == .missingDocker
+                                ? "Docker not found. Install Docker Desktop from docker.com."
+                                : "sbx not found. Install with: brew install docker/tap/sbx")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                                .padding(.leading, 16)
+                        }
+
+                        if useSandbox {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Sandbox flags")
+                                    .font(.subheadline)
+                                TextField("e.g. --memory 8g", text: $sbxFlags)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                            }
+                            .padding(.leading, 16)
+                        }
                     }
                 }
             }
@@ -155,6 +202,8 @@ struct EditProjectSheet: View {
         updated.setupCommands = parseCSV(setupCommands)
         updated.autoStartClaude = overrideClaude ? autoStartClaude : nil
         updated.claudeFlags = overrideClaude ? claudeFlags : nil
+        updated.useSandbox = overrideClaude ? useSandbox : nil
+        updated.sbxFlags = overrideClaude ? sbxFlags : nil
         updated.colorIndex = selectedColorIndex
         appState.updateProject(updated)
         dismiss()

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -17,6 +17,7 @@ struct EditProjectSheet: View {
     @State private var useSandbox: Bool
     @State private var sbxFlags: String
     @State private var sandboxStatus: SandboxChecker.Status?
+    @State private var checkingSandbox = false
     @State private var selectedColorIndex: Int
 
     init(project: Project) {
@@ -138,11 +139,13 @@ struct EditProjectSheet: View {
                             get: { useSandbox },
                             set: { newValue in
                                 if newValue {
-                                    Task {
+                                    checkingSandbox = true
+                                    Task.detached(priority: .utility) {
                                         let status = await SandboxChecker.check()
                                         await MainActor.run {
                                             sandboxStatus = status
                                             useSandbox = status == .available
+                                            checkingSandbox = false
                                         }
                                     }
                                 } else {
@@ -153,6 +156,7 @@ struct EditProjectSheet: View {
                         ))
                             .font(.subheadline)
                             .padding(.leading, 16)
+                            .disabled(checkingSandbox)
 
                         if let status = sandboxStatus, status != .available {
                             Text(status == .missingDocker

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -170,10 +170,12 @@ struct SessionView: View {
                 let shouldStart = project?.shouldAutoStartClaude(globalSettings: appState.settings)
                     ?? appState.settings.autoStartClaude
                 if shouldStart {
+                    let isSandboxed = project?.useSandbox ?? appState.settings.useSandbox
                     var command = project?.resolvedClaudeCommand(globalSettings: appState.settings)
                         ?? appState.settings.claudeCommand
-                    // Resume a specific Claude session if we have its ID
-                    if let sessionId = session.claudeSessionId {
+                    // Resume a specific Claude session if we have its ID.
+                    // Skip in sandbox mode -- session files live inside the ephemeral microVM.
+                    if !isSandboxed, let sessionId = session.claudeSessionId {
                         command += " --resume \(sessionId)"
                     }
                     Task { @MainActor in

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -12,6 +12,10 @@ struct SettingsView: View {
     @State private var terminalPath: String
     @State private var notifyOnFinish: Bool
     @State private var checkForUpdatesOnLaunch: Bool
+    @State private var useSandbox: Bool
+    @State private var sbxFlags: String
+    @State private var sandboxStatus: SandboxChecker.Status?
+    @State private var checkingSandbox = false
 
     init(settings: CanopySettings) {
         self._autoStartClaude = State(initialValue: settings.autoStartClaude)
@@ -21,6 +25,8 @@ struct SettingsView: View {
         self._terminalPath = State(initialValue: settings.terminalPath)
         self._notifyOnFinish = State(initialValue: settings.notifyOnFinish)
         self._checkForUpdatesOnLaunch = State(initialValue: settings.checkForUpdatesOnLaunch)
+        self._useSandbox = State(initialValue: settings.useSandbox)
+        self._sbxFlags = State(initialValue: settings.sbxFlags)
     }
 
     var body: some View {
@@ -59,6 +65,41 @@ struct SettingsView: View {
                                         .foregroundStyle(.primary)
                                 }
                                 .padding(.top, 4)
+
+                                Divider()
+
+                                Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
+                                    get: { useSandbox },
+                                    set: { newValue in
+                                        if newValue {
+                                            verifySandbox()
+                                        } else {
+                                            useSandbox = false
+                                            sandboxStatus = nil
+                                        }
+                                    }
+                                ))
+                                .disabled(checkingSandbox)
+
+                                if let status = sandboxStatus, status != .available {
+                                    Text(sandboxWarning(for: status))
+                                        .font(.caption)
+                                        .foregroundStyle(.red)
+                                }
+
+                                if useSandbox {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Sandbox flags")
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                        TextField("e.g. --memory 8g", text: $sbxFlags)
+                                            .textFieldStyle(.roundedBorder)
+                                            .font(.system(size: 12, design: .monospaced))
+                                        Text("Additional flags passed to `sbx run`.")
+                                            .font(.caption)
+                                            .foregroundStyle(.tertiary)
+                                    }
+                                }
                             }
                         }
                         .padding(4)
@@ -182,12 +223,50 @@ struct SettingsView: View {
     }
 
     private var previewCommand: String {
-        var cmd = "claude"
-        let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            cmd += " " + trimmed
+        var parts: [String] = []
+        if useSandbox {
+            parts.append("sbx run")
+            let trimmedSbx = sbxFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmedSbx.isEmpty {
+                parts.append(trimmedSbx)
+            }
+            parts.append("claude --")
+            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
+        } else {
+            parts.append("claude")
+            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
         }
-        return cmd
+        return parts.joined(separator: " ")
+    }
+
+    private func verifySandbox() {
+        checkingSandbox = true
+        sandboxStatus = nil
+        Task {
+            let status = await SandboxChecker.check()
+            await MainActor.run {
+                sandboxStatus = status
+                useSandbox = status == .available
+                checkingSandbox = false
+            }
+        }
+    }
+
+    private func sandboxWarning(for status: SandboxChecker.Status) -> String {
+        switch status {
+        case .missingDocker:
+            return "Docker not found. Install Docker Desktop from docker.com."
+        case .missingSbx:
+            return "sbx not found. Install with: brew install docker/tap/sbx"
+        case .available:
+            return ""
+        }
     }
 
     private func save() {
@@ -199,6 +278,8 @@ struct SettingsView: View {
         settings.terminalPath = terminalPath
         settings.notifyOnFinish = notifyOnFinish
         settings.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
+        settings.useSandbox = useSandbox
+        settings.sbxFlags = sbxFlags
         settings.save()
         appState.settings = settings
         dismiss()

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -248,7 +248,7 @@ struct SettingsView: View {
     private func verifySandbox() {
         checkingSandbox = true
         sandboxStatus = nil
-        Task {
+        Task.detached(priority: .utility) {
             let status = await SandboxChecker.check()
             await MainActor.run {
                 sandboxStatus = status

--- a/Canopy/Views/Sidebar.swift
+++ b/Canopy/Views/Sidebar.swift
@@ -142,9 +142,9 @@ struct Sidebar: View {
 
         HStack(spacing: 6) {
             if let ts = appState.terminalSessions[session.id] {
-                LiveSessionRow(session: session, terminalSession: ts, projectColor: color)
+                LiveSessionRow(session: session, terminalSession: ts, projectColor: color, isSandboxed: isSandboxed(session))
             } else {
-                SidebarSessionRow(session: session, projectColor: color)
+                SidebarSessionRow(session: session, projectColor: color, isSandboxed: isSandboxed(session))
             }
 
             Spacer()
@@ -330,6 +330,14 @@ struct Sidebar: View {
 
     // MARK: - Helpers
 
+    private func isSandboxed(_ session: SessionInfo) -> Bool {
+        if let projectId = session.projectId,
+           let project = appState.projects.first(where: { $0.id == projectId }) {
+            return project.useSandbox ?? appState.settings.useSandbox
+        }
+        return appState.settings.useSandbox
+    }
+
     private func projectColorFor(_ session: SessionInfo) -> Color {
         guard let projectId = session.projectId,
               let project = appState.projects.first(where: { $0.id == projectId }) else {
@@ -424,12 +432,14 @@ struct LiveSessionRow: View {
     let session: SessionInfo
     @ObservedObject var terminalSession: TerminalSession
     var projectColor: Color = .gray
+    var isSandboxed: Bool = false
 
     var body: some View {
         SidebarSessionRow(
             session: session,
             activity: terminalSession.activity,
-            projectColor: projectColor
+            projectColor: projectColor,
+            isSandboxed: isSandboxed
         )
     }
 }
@@ -440,6 +450,7 @@ struct SidebarSessionRow: View {
     let session: SessionInfo
     var activity: SessionActivity = .idle
     var projectColor: Color = .gray
+    var isSandboxed: Bool = false
 
     var body: some View {
         HStack(spacing: 8) {
@@ -451,6 +462,12 @@ struct SidebarSessionRow: View {
                     Text(session.name)
                         .font(.system(size: 12, weight: .medium))
                         .lineLimit(1)
+                    if isSandboxed {
+                        Image(systemName: "shield.lefthalf.filled")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .help("Running in Docker Sandbox")
+                    }
                 }
                 Text(subtitle)
                     .font(.system(size: 10))

--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ This is the feature I was most skeptical I'd use, and now I can't imagine workin
 
 ---
 
+### 🛡 Docker Sandbox — run Claude in isolation
+
+Enable **Run in Docker Sandbox** in Settings or per-project to launch Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM via `sbx run`. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system — network, Docker socket, home directory, and tools are all isolated.
+
+Canopy checks that both Docker Desktop and `sbx` are installed before enabling the toggle. When sandbox mode is active:
+
+- The command becomes `sbx run [sbx-flags] claude -- [claude-flags]`
+- Session resume is disabled (session files live inside the ephemeral microVM)
+- A shield icon appears next to the session name in the sidebar
+- The split terminal still opens a host shell (useful for inspecting the real filesystem)
+
+**Requirements:** [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
+
+---
+
 ### ✅ Merge & Finish — one click, one worktree retired
 
 ![Merge and Finish flow](docs/screenshots/merge-finish.png)
@@ -226,6 +241,8 @@ Every project can be configured independently from the **Add Project** sheet:
 | Worktree base directory | `~/worktrees/myproject` | Where new worktrees live (default: `../canopy-worktrees/<project>`) |
 | Auto-start Claude | on/off | Per-project override of the global default |
 | Claude flags | `--permission-mode auto` | Per-project override of the global flags |
+| Docker Sandbox | on/off | Run Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM |
+| Sandbox flags | `--memory 8g` | Additional flags passed to `sbx run` |
 
 All configuration lives in `~/.config/canopy/`:
 

--- a/Tests/ProjectResolutionTests.swift
+++ b/Tests/ProjectResolutionTests.swift
@@ -74,6 +74,115 @@ struct ProjectResolutionTests {
         #expect(project.resolvedClaudeCommand(globalSettings: settings) == "claude")
     }
 
+    // MARK: - Sandbox Resolution
+
+    @Test func claudeCommandSandboxFallsBackToGlobal() {
+        let project = Project(name: "test", repositoryPath: "/tmp")
+        var settings = CanopySettings()
+        settings.useSandbox = true
+
+        #expect(project.resolvedClaudeCommand(globalSettings: settings) == "sbx run claude -- --permission-mode auto")
+    }
+
+    @Test func claudeCommandProjectOverridesSandbox() {
+        let project = Project(
+            name: "test", repositoryPath: "/tmp",
+            useSandbox: false
+        )
+        var settings = CanopySettings()
+        settings.useSandbox = true
+
+        #expect(project.resolvedClaudeCommand(globalSettings: settings) == "claude --permission-mode auto")
+    }
+
+    @Test func claudeCommandProjectEnablesSandbox() {
+        let project = Project(
+            name: "test", repositoryPath: "/tmp",
+            useSandbox: true,
+            sbxFlags: "--memory 16g"
+        )
+        let settings = CanopySettings()
+
+        #expect(project.resolvedClaudeCommand(globalSettings: settings) == "sbx run --memory 16g claude -- --permission-mode auto")
+    }
+
+    @Test func claudeCommandSandboxWithResume() {
+        // When sandbox is on, --resume still lands after -- (passed to claude, not sbx)
+        let project = Project(name: "test", repositoryPath: "/tmp", useSandbox: true)
+        let settings = CanopySettings()
+
+        var command = project.resolvedClaudeCommand(globalSettings: settings)
+        command += " --resume abc-123"
+
+        #expect(command == "sbx run claude -- --permission-mode auto --resume abc-123")
+    }
+
+    @Test func sandboxResumeSkippedWhenSandboxed() {
+        // Simulates MainWindow logic: --resume is not appended in sandbox mode
+        // because session files are ephemeral inside the microVM.
+        let project = Project(name: "test", repositoryPath: "/tmp", useSandbox: true)
+        let settings = CanopySettings()
+
+        let isSandboxed = project.useSandbox ?? settings.useSandbox
+        var command = project.resolvedClaudeCommand(globalSettings: settings)
+        let sessionId = "277f18de-ba7a-440e-aaf4-66987b38f08d"
+        if !isSandboxed {
+            command += " --resume \(sessionId)"
+        }
+
+        // Resume must NOT be appended
+        #expect(!command.contains("--resume"))
+        #expect(command == "sbx run claude -- --permission-mode auto")
+    }
+
+    @Test func sandboxResumeAppendedWhenNotSandboxed() {
+        // Simulates MainWindow logic: --resume IS appended when not sandboxed
+        let project = Project(name: "test", repositoryPath: "/tmp")
+        let settings = CanopySettings()
+
+        let isSandboxed = project.useSandbox ?? settings.useSandbox
+        var command = project.resolvedClaudeCommand(globalSettings: settings)
+        let sessionId = "277f18de-ba7a-440e-aaf4-66987b38f08d"
+        if !isSandboxed {
+            command += " --resume \(sessionId)"
+        }
+
+        #expect(command.contains("--resume"))
+        #expect(command == "claude --permission-mode auto --resume \(sessionId)")
+    }
+
+    @Test func sandboxResolutionProjectNilFallsToGlobal() {
+        // useSandbox == nil on project means use global setting
+        let project = Project(name: "test", repositoryPath: "/tmp")
+        var settings = CanopySettings()
+
+        settings.useSandbox = false
+        #expect((project.useSandbox ?? settings.useSandbox) == false)
+
+        settings.useSandbox = true
+        #expect((project.useSandbox ?? settings.useSandbox) == true)
+    }
+
+    @Test func sandboxResolutionProjectOverridesGlobal() {
+        let projectOn = Project(name: "on", repositoryPath: "/tmp", useSandbox: true)
+        let projectOff = Project(name: "off", repositoryPath: "/tmp", useSandbox: false)
+        var settings = CanopySettings()
+        settings.useSandbox = false
+
+        #expect((projectOn.useSandbox ?? settings.useSandbox) == true)
+        #expect((projectOff.useSandbox ?? settings.useSandbox) == false)
+    }
+
+    @Test func sandboxEmptyClaudeFlagsStillHasSeparator() {
+        // Even with no claude flags, -- must be present so appended flags
+        // (like --resume from MainWindow) are passed to claude, not sbx.
+        var settings = CanopySettings()
+        settings.useSandbox = true
+        settings.claudeFlags = ""
+
+        #expect(settings.claudeCommand == "sbx run claude --")
+    }
+
     // MARK: - Forward-Compatible Decoding
 
     @Test func decodesWithMissingOptionalFields() throws {
@@ -95,6 +204,8 @@ struct ProjectResolutionTests {
         #expect(project.worktreeBaseDir == nil)
         #expect(project.autoStartClaude == nil)
         #expect(project.claudeFlags == nil)
+        #expect(project.useSandbox == nil)
+        #expect(project.sbxFlags == nil)
     }
 
     @Test func decodesWithPartialFields() throws {
@@ -124,7 +235,9 @@ struct ProjectResolutionTests {
             symlinkPaths: ["nm"],
             setupCommands: ["npm i"],
             autoStartClaude: true,
-            claudeFlags: "--verbose"
+            claudeFlags: "--verbose",
+            useSandbox: true,
+            sbxFlags: "--memory 8g"
         )
 
         let data = try JSONEncoder().encode(project)
@@ -133,5 +246,7 @@ struct ProjectResolutionTests {
         #expect(json["autoStartClaude"] as? Bool == true)
         #expect(json["claudeFlags"] as? String == "--verbose")
         #expect(json["setupCommands"] as? [String] == ["npm i"])
+        #expect(json["useSandbox"] as? Bool == true)
+        #expect(json["sbxFlags"] as? String == "--memory 8g")
     }
 }

--- a/Tests/SandboxCheckerTests.swift
+++ b/Tests/SandboxCheckerTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+@Suite("SandboxChecker")
+struct SandboxCheckerTests {
+
+    @Test func commandExistsFindsRealCommand() async {
+        // `ls` is always available on macOS
+        let exists = await SandboxChecker.commandExists("ls")
+        #expect(exists == true)
+    }
+
+    @Test func commandExistsReturnsFalseForBogus() async {
+        let exists = await SandboxChecker.commandExists("this-command-does-not-exist-xyz-123")
+        #expect(exists == false)
+    }
+
+    @Test func statusEquatable() {
+        #expect(SandboxChecker.Status.available == SandboxChecker.Status.available)
+        #expect(SandboxChecker.Status.missingDocker == SandboxChecker.Status.missingDocker)
+        #expect(SandboxChecker.Status.missingSbx == SandboxChecker.Status.missingSbx)
+        #expect(SandboxChecker.Status.missingDocker != SandboxChecker.Status.missingSbx)
+    }
+}

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -14,6 +14,8 @@ struct SettingsTests {
         #expect(settings.confirmBeforeClosing == true)
         #expect(settings.idePath == "/Applications/Cursor.app")
         #expect(settings.terminalPath == "/System/Applications/Utilities/Terminal.app")
+        #expect(settings.useSandbox == false)
+        #expect(settings.sbxFlags == "")
     }
 
     // MARK: - Claude Command
@@ -69,6 +71,8 @@ struct SettingsTests {
         #expect(decoded.claudeFlags == "--permission-mode auto")
         #expect(decoded.confirmBeforeClosing == true)
         #expect(decoded.terminalPath == "/System/Applications/Utilities/Terminal.app")
+        #expect(decoded.useSandbox == false)
+        #expect(decoded.sbxFlags == "")
     }
 
     // MARK: - IDE / Terminal Names
@@ -120,6 +124,55 @@ struct SettingsTests {
         let data = json.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(CanopySettings.self, from: data)
         #expect(decoded.notifyOnFinish == true)
+    }
+
+    // MARK: - Sandbox
+
+    @Test func claudeCommandWithSandbox() {
+        var settings = CanopySettings()
+        settings.useSandbox = true
+        #expect(settings.claudeCommand == "sbx run claude -- --permission-mode auto")
+    }
+
+    @Test func claudeCommandWithSandboxFlags() {
+        var settings = CanopySettings()
+        settings.useSandbox = true
+        settings.sbxFlags = "--memory 8g"
+        #expect(settings.claudeCommand == "sbx run --memory 8g claude -- --permission-mode auto")
+    }
+
+    @Test func claudeCommandSandboxOffIgnoresSbxFlags() {
+        var settings = CanopySettings()
+        settings.useSandbox = false
+        settings.sbxFlags = "--memory 8g"
+        #expect(settings.claudeCommand == "claude --permission-mode auto")
+    }
+
+    @Test func sandboxCodableRoundTrip() throws {
+        var original = CanopySettings()
+        original.useSandbox = true
+        original.sbxFlags = "--memory 8g"
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: data)
+
+        #expect(decoded.useSandbox == true)
+        #expect(decoded.sbxFlags == "--memory 8g")
+    }
+
+    @Test func claudeCommandSandboxTrimsWhitespace() {
+        var settings = CanopySettings()
+        settings.useSandbox = true
+        settings.sbxFlags = "  --memory 8g  "
+        #expect(settings.claudeCommand == "sbx run --memory 8g claude -- --permission-mode auto")
+    }
+
+    @Test func claudeCommandSandboxEmptyFlags() {
+        var settings = CanopySettings()
+        settings.useSandbox = true
+        settings.sbxFlags = "   "
+        settings.claudeFlags = ""
+        #expect(settings.claudeCommand == "sbx run claude --")
     }
 
     // MARK: - Persistence

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -54,6 +54,17 @@ When Canopy creates or opens a session, it can auto-start Claude Code with your 
 
 Session IDs are found automatically by scanning `~/.claude/projects/`.
 
+### Docker Sandbox mode
+
+Canopy can optionally run Claude Code inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM for hard process isolation. When enabled, the command becomes `sbx run claude -- [flags]` instead of `claude [flags]`. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system.
+
+Key behaviors in sandbox mode:
+- **Session resume is disabled** -- session files (`~/.claude/projects/`) live inside the ephemeral microVM and don't persist across runs
+- **A shield icon** appears next to the session name in the sidebar
+- **The split terminal** still opens a host shell (not sandboxed), which is useful for inspecting the real filesystem
+
+Sandbox mode requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`). Canopy validates both are installed before enabling the toggle.
+
 ## Workflows
 
 ### Starting a new feature
@@ -170,10 +181,12 @@ Shown when you click a project header in the sidebar. Displays:
 |---------|---------|---------|
 | Auto-start Claude | On | Launch Claude Code when opening a session |
 | Claude flags | `--permission-mode auto` | Flags passed to the `claude` command |
+| Docker Sandbox | Off | Run Claude inside a `sbx` microVM (requires Docker Desktop + `sbx`) |
+| Sandbox flags | *(empty)* | Additional flags passed to `sbx run` (e.g., `--memory 8g`) |
 | Confirm before closing | On | Ask before closing a session |
 | IDE path | `/Applications/Cursor.app` | App used for "Open in IDE" |
 
-Per-project overrides for auto-start and Claude flags are available in the project edit sheet.
+Per-project overrides for auto-start, Claude flags, and sandbox mode are available in the project edit sheet.
 
 ## Keyboard shortcuts
 
@@ -208,7 +221,7 @@ All configuration lives in `~/.config/canopy/`:
 
 - **Text selection in the terminal**: Hold `Option` while dragging. Claude Code enables mouse reporting which captures normal clicks -- `Option` bypasses it.
 - **Copy full session output**: Right-click a session > Copy Session Output. Useful for sharing Claude's work.
-- **Session resume**: When you reopen an existing worktree, Canopy finds the last Claude session ID automatically. You continue exactly where you left off.
+- **Session resume**: When you reopen an existing worktree, Canopy finds the last Claude session ID automatically. You continue exactly where you left off. Note: sandbox sessions are not resumable -- the session data lives inside the ephemeral microVM and is discarded when the sandbox stops.
 - **Worktree base directory**: By default, worktrees are created at `../canopy-worktrees/<project>/` (as siblings of your repo). Override this per-project if you prefer a different location.
 - **Quick rebuild**: Run `bash scripts/bundle.sh` then `open build/Canopy.app`.
 


### PR DESCRIPTION
## Summary

- Run Claude Code inside an isolated Docker Sandbox microVM via `sbx run` for hard process isolation
- Configurable globally (Settings) and per-project (Add/Edit Project) with a toggle and optional `sbx run` flags
- Validates Docker Desktop and `sbx` are installed before enabling — shows inline error if missing
- Session resume automatically disabled in sandbox mode (session files are ephemeral)
- Shield icon in sidebar indicates sandboxed sessions

## Test plan

- [x] Toggle sandbox on in Settings — verify command preview shows `sbx run claude -- ...`
- [x] Toggle sandbox without Docker/sbx installed — verify warning appears and toggle stays off
- [x] Open a sandboxed session — verify `sbx run claude -- --permission-mode auto` is sent
- [x] Verify sandboxed sessions do NOT append `--resume`
- [x] Check shield icon appears next to sandboxed session names in sidebar
- [ ] Edit a project, enable sandbox override — verify it persists and resolves correctly
- [ ] Run `swift test` — 389 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)