### PR TITLE
feat: add git status bar with polling and tooltips

### DIFF
--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -62,6 +62,14 @@ final class AppState: ObservableObject {
     /// Result of the most recent update check.
     @Published var updateStatus: UpdateStatus = .unknown
 
+    /// Git status for the currently active session.
+    @Published var activeGitStatus: GitStatusInfo?
+
+    /// Cached PR data to avoid hitting gh CLI every poll cycle.
+    private var cachedPRs: [GitPRInfo] = []
+    private var lastPRRefresh: Date = .distantPast
+    private var gitPollTask: Task<Void, Never>?
+
     private let lastUpdateCheckKey = "canopy.lastUpdateCheck"
     private let updateCheckInterval: TimeInterval = 24 * 60 * 60
 
@@ -195,6 +203,55 @@ final class AppState: ObservableObject {
             subtitle: session.name,
             sessionId: sessionId
         )
+    }
+
+    // MARK: - Git Status Polling
+
+    /// Fetches git status for the active session and updates `activeGitStatus`.
+    func refreshGitStatus() async {
+        guard let session = activeSession else {
+            activeGitStatus = nil
+            return
+        }
+        let path = session.workingDirectory
+        guard await git.isGitRepo(path: path) else {
+            activeGitStatus = nil
+            return
+        }
+
+        let diff = await git.diffStat(repoPath: path)
+        let ahead = await git.commitsAhead(repoPath: path)
+
+        let prs: [GitPRInfo]
+        if Date().timeIntervalSince(lastPRRefresh) > 60 {
+            prs = await git.openPRs(repoPath: path)
+            cachedPRs = prs
+            lastPRRefresh = Date()
+        } else {
+            prs = cachedPRs
+        }
+
+        activeGitStatus = GitStatusInfo(
+            diffStat: diff, commitsAhead: ahead,
+            openPRs: prs, changedFiles: diff?.changedFiles ?? []
+        )
+    }
+
+    /// Starts periodic git status polling.
+    func startGitStatusPolling() {
+        gitPollTask?.cancel()
+        gitPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshGitStatus()
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+    }
+
+    /// Stops git status polling.
+    func stopGitStatusPolling() {
+        gitPollTask?.cancel()
+        gitPollTask = nil
     }
 
     // MARK: - Update Checking

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -65,9 +65,9 @@ final class AppState: ObservableObject {
     /// Git status for the currently active session.
     @Published var activeGitStatus: GitStatusInfo?
 
-    /// Cached PR data to avoid hitting gh CLI every poll cycle.
-    private var cachedPRs: [GitPRInfo] = []
-    private var lastPRRefresh: Date = .distantPast
+    /// Cached PR data per repo path, to avoid hitting gh CLI every poll cycle.
+    private var cachedPRsByRepo: [String: [GitPRInfo]] = [:]
+    private var lastPRRefreshByRepo: [String: Date] = [:]
     private var gitPollTask: Task<Void, Never>?
 
     private let lastUpdateCheckKey = "canopy.lastUpdateCheck"
@@ -213,6 +213,7 @@ final class AppState: ObservableObject {
             activeGitStatus = nil
             return
         }
+        let sessionId = session.id
         let path = session.workingDirectory
         guard await git.isGitRepo(path: path) else {
             activeGitStatus = nil
@@ -222,14 +223,19 @@ final class AppState: ObservableObject {
         let diff = await git.diffStat(repoPath: path)
         let ahead = await git.commitsAhead(repoPath: path)
 
+        // Cache PRs per repo path (60s TTL)
         let prs: [GitPRInfo]
-        if Date().timeIntervalSince(lastPRRefresh) > 60 {
+        let lastRefresh = lastPRRefreshByRepo[path] ?? .distantPast
+        if Date().timeIntervalSince(lastRefresh) > 60 {
             prs = await git.openPRs(repoPath: path)
-            cachedPRs = prs
-            lastPRRefresh = Date()
+            cachedPRsByRepo[path] = prs
+            lastPRRefreshByRepo[path] = Date()
         } else {
-            prs = cachedPRs
+            prs = cachedPRsByRepo[path] ?? []
         }
+
+        // Guard against stale results if session changed during async work
+        guard activeSessionId == sessionId else { return }
 
         activeGitStatus = GitStatusInfo(
             diffStat: diff, commitsAhead: ahead,
@@ -242,7 +248,8 @@ final class AppState: ObservableObject {
         gitPollTask?.cancel()
         gitPollTask = Task { [weak self] in
             while !Task.isCancelled {
-                await self?.refreshGitStatus()
+                guard let self else { return }
+                await self.refreshGitStatus()
                 try? await Task.sleep(for: .seconds(10))
             }
         }

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -36,10 +36,20 @@ struct MainWindow: View {
                     }
                     .animation(.easeInOut(duration: 0.15), value: appState.activeSessionId)
 
-
+                    if appState.activeSession != nil {
+                        Divider()
+                        StatusBar()
+                    }
                 }
             }
             .navigationSplitViewStyle(.balanced)
+            .onAppear {
+                appState.startGitStatusPolling()
+            }
+            .onChange(of: appState.activeSessionId) { _, _ in
+                appState.activeGitStatus = nil
+                Task { await appState.refreshGitStatus() }
+            }
 
             // Command palette overlay
             if appState.showCommandPalette {

--- a/Canopy/Views/StatusBar.swift
+++ b/Canopy/Views/StatusBar.swift
@@ -207,7 +207,7 @@ struct StatusBar: View {
     private func abbreviatedPath(_ path: String) -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         if path.hasPrefix(home) {
-            return "~" + path.dropFirst(home.count)
+            return "~" + String(path.dropFirst(home.count))
         }
         return path
     }

--- a/Canopy/Views/StatusBar.swift
+++ b/Canopy/Views/StatusBar.swift
@@ -1,4 +1,39 @@
 import SwiftUI
+import AppKit
+
+// MARK: - Tooltip Modifier (reliable NSView-based tooltips for non-interactive views)
+
+/// SwiftUI's `.help()` only works reliably on interactive views (buttons).
+/// This modifier uses an `NSView` overlay with `toolTip` for guaranteed hover tooltips.
+private struct TooltipModifier: ViewModifier {
+    let text: String
+
+    func body(content: Content) -> some View {
+        content.overlay(TooltipOverlay(text: text))
+    }
+}
+
+private struct TooltipOverlay: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.toolTip = text
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.toolTip = text
+    }
+}
+
+extension View {
+    func tooltip(_ text: String) -> some View {
+        modifier(TooltipModifier(text: text))
+    }
+}
+
+// MARK: - Status Bar
 
 struct StatusBar: View {
     @EnvironmentObject var appState: AppState
@@ -20,22 +55,117 @@ struct StatusBar: View {
                 HStack(spacing: 4) {
                     Image(systemName: "folder")
                         .font(.system(size: 10))
-                    Text(session.workingDirectory)
+                    Text(abbreviatedPath(session.workingDirectory))
                         .font(.system(size: 11))
                         .lineLimit(1)
                 }
                 .foregroundStyle(.tertiary)
+
+                // Git status indicators
+                if let status = appState.activeGitStatus {
+                    gitIndicators(status)
+                }
             }
 
             Spacer()
 
-            // Activity summary with mini dots
             activitySummary
         }
         .padding(.horizontal, 12)
         .frame(height: 24)
         .background(.bar)
     }
+
+    // MARK: - Git Indicators
+
+    @ViewBuilder
+    private func gitIndicators(_ status: GitStatusInfo) -> some View {
+        // Changes indicator
+        if let diff = status.diffStat, !diff.isClean {
+            Divider()
+                .frame(height: 12)
+
+            HStack(spacing: 4) {
+                Image(systemName: "pencil.line")
+                    .font(.system(size: 9))
+                Text("\(diff.filesChanged) file\(diff.filesChanged == 1 ? "" : "s")")
+                    .font(.system(size: 11))
+                if diff.insertions > 0 {
+                    Text("+\(diff.insertions)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.green)
+                }
+                if diff.deletions > 0 {
+                    Text("−\(diff.deletions)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.red)
+                }
+            }
+            .foregroundStyle(.secondary)
+            .tooltip(changesHelpText(status))
+        }
+
+        // Commits ahead indicator
+        if let ahead = status.commitsAhead, ahead > 0 {
+            Divider()
+                .frame(height: 12)
+
+            HStack(spacing: 3) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 9, weight: .medium))
+                Text("\(ahead) ahead")
+                    .font(.system(size: 11))
+            }
+            .foregroundStyle(.secondary)
+            .tooltip("\(ahead) commit\(ahead == 1 ? "" : "s") not yet pushed")
+        }
+
+        // PR indicator
+        if !status.openPRs.isEmpty {
+            Divider()
+                .frame(height: 12)
+
+            let draftCount = status.openPRs.filter(\.isDraft).count
+
+            HStack(spacing: 3) {
+                Image(systemName: "arrow.triangle.pull")
+                    .font(.system(size: 9))
+                if draftCount > 0 && draftCount < status.openPRs.count {
+                    Text("\(status.openPRs.count) open (\(draftCount) draft)")
+                        .font(.system(size: 11))
+                } else if draftCount == status.openPRs.count {
+                    Text("\(status.openPRs.count) draft")
+                        .font(.system(size: 11))
+                } else {
+                    Text("\(status.openPRs.count) open")
+                        .font(.system(size: 11))
+                }
+            }
+            .foregroundStyle(.secondary)
+            .tooltip(prHelpText(status.openPRs))
+        }
+    }
+
+    // MARK: - Hover Tooltips
+
+    private func changesHelpText(_ status: GitStatusInfo) -> String {
+        if status.changedFiles.isEmpty { return "Uncommitted changes" }
+        let header = "Modified files:"
+        let files = status.changedFiles.prefix(15).joined(separator: "\n")
+        let suffix = status.changedFiles.count > 15
+            ? "\n... and \(status.changedFiles.count - 15) more"
+            : ""
+        return "\(header)\n\(files)\(suffix)"
+    }
+
+    private func prHelpText(_ prs: [GitPRInfo]) -> String {
+        prs.map { pr in
+            let draft = pr.isDraft ? " (draft)" : ""
+            return "#\(pr.number) \(pr.title)\(draft)"
+        }.joined(separator: "\n")
+    }
+
+    // MARK: - Activity Summary
 
     @ViewBuilder
     private var activitySummary: some View {
@@ -70,5 +200,15 @@ struct StatusBar: View {
         } else {
             return "\(working) working, \(total - working) idle"
         }
+    }
+
+    // MARK: - Helpers
+
+    private func abbreviatedPath(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
     }
 }

--- a/Tests/GitStatusPollingTests.swift
+++ b/Tests/GitStatusPollingTests.swift
@@ -1,0 +1,166 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Tests for git status polling infrastructure in AppState.
+@Suite("Git Status Polling")
+struct GitStatusPollingTests {
+    private let fm = FileManager.default
+
+    private func makeTempRepo() throws -> String {
+        let repoPath = NSTemporaryDirectory() + "canopy-poll-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
+        try shell("git init -b main && git config user.email 'test@test.com' && git config user.name 'Test'", in: repoPath)
+        try "hello".write(toFile: "\(repoPath)/file.txt", atomically: true, encoding: .utf8)
+        try shell("git add -A && git commit -m 'initial'", in: repoPath)
+        return repoPath
+    }
+
+    // MARK: - GitStatusInfo type
+
+    @Test func gitStatusInfoInitialization() {
+        let stat = GitDiffStat(filesChanged: 3, insertions: 45, deletions: 12, changedFiles: ["a.swift", "b.swift", "c.swift"])
+        let info = GitStatusInfo(diffStat: stat, commitsAhead: 2, openPRs: [], changedFiles: ["a.swift", "b.swift", "c.swift"])
+
+        #expect(info.diffStat?.filesChanged == 3)
+        #expect(info.commitsAhead == 2)
+        #expect(info.openPRs.isEmpty)
+        #expect(info.changedFiles.count == 3)
+    }
+
+    @Test func gitStatusInfoNilsForNonGit() {
+        let info = GitStatusInfo(diffStat: nil, commitsAhead: nil, openPRs: [], changedFiles: [])
+        #expect(info.diffStat == nil)
+        #expect(info.commitsAhead == nil)
+    }
+
+    // MARK: - refreshGitStatus in AppState
+
+    @Test @MainActor func refreshGitStatusForGitRepo() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let state = AppState()
+        state.createSession(name: "test", directory: repo)
+
+        await state.refreshGitStatus()
+
+        #expect(state.activeGitStatus != nil)
+        #expect(state.activeGitStatus?.diffStat != nil)
+        #expect(state.activeGitStatus?.diffStat?.isClean == true)
+    }
+
+    @Test @MainActor func refreshGitStatusWithDirtyRepo() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let state = AppState()
+        state.createSession(name: "test", directory: repo)
+
+        // Dirty the repo
+        try "changed".write(toFile: "\(repo)/file.txt", atomically: true, encoding: .utf8)
+
+        await state.refreshGitStatus()
+
+        #expect(state.activeGitStatus != nil)
+        #expect(state.activeGitStatus?.diffStat?.isClean == false)
+        #expect(state.activeGitStatus?.diffStat?.filesChanged == 1)
+        #expect(state.activeGitStatus?.changedFiles.contains("file.txt") == true)
+    }
+
+    @Test @MainActor func refreshGitStatusForNonGitDir() async {
+        let tempDir = NSTemporaryDirectory() + "canopy-pollnogit-\(UUID().uuidString)"
+        try? fm.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: tempDir) }
+
+        let state = AppState()
+        state.createSession(name: "test", directory: tempDir)
+
+        await state.refreshGitStatus()
+
+        #expect(state.activeGitStatus == nil)
+    }
+
+    @Test @MainActor func refreshGitStatusNilWhenNoActiveSession() async {
+        let state = AppState()
+
+        await state.refreshGitStatus()
+
+        #expect(state.activeGitStatus == nil)
+    }
+
+    @Test @MainActor func refreshGitStatusClearsOnSessionSwitch() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let tempDir = NSTemporaryDirectory() + "canopy-pollswitch-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: tempDir) }
+
+        let state = AppState()
+
+        // Session 1: git repo with changes
+        state.createSession(name: "git-session", directory: repo)
+        try "changed".write(toFile: "\(repo)/file.txt", atomically: true, encoding: .utf8)
+        await state.refreshGitStatus()
+        #expect(state.activeGitStatus != nil)
+        #expect(state.activeGitStatus?.diffStat?.isClean == false)
+
+        // Session 2: non-git dir
+        state.createSession(name: "plain-session", directory: tempDir)
+        await state.refreshGitStatus()
+        #expect(state.activeGitStatus == nil)
+
+        // Switch back to session 1
+        state.activeSessionId = state.sessions[0].id
+        await state.refreshGitStatus()
+        #expect(state.activeGitStatus != nil)
+        #expect(state.activeGitStatus?.diffStat?.isClean == false)
+    }
+
+    @Test @MainActor func refreshGitStatusInWorktree() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let git = GitService()
+        let wtPath = repo + "-wt-poll"
+        defer { try? fm.removeItem(atPath: wtPath) }
+
+        try await git.createWorktree(
+            repoPath: repo, worktreePath: wtPath,
+            branch: "feat/poll-test", createBranch: true
+        )
+
+        let state = AppState()
+        state.createSession(name: "wt-session", directory: wtPath)
+
+        // Dirty the worktree
+        try "wt-change".write(toFile: "\(wtPath)/file.txt", atomically: true, encoding: .utf8)
+
+        await state.refreshGitStatus()
+
+        #expect(state.activeGitStatus != nil)
+        #expect(state.activeGitStatus?.diffStat?.isClean == false)
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func shell(_ command: String, in dir: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = URL(fileURLWithPath: dir)
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if process.terminationStatus != 0 {
+            throw NSError(domain: "test", code: Int(process.terminationStatus),
+                          userInfo: [NSLocalizedDescriptionKey: String(data: data, encoding: .utf8) ?? ""])
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}


### PR DESCRIPTION
## Summary
- Activates the unused StatusBar at the bottom of MainWindow
- Three indicator chips: uncommitted changes (+/-), commits ahead, open PRs
- NSView-based tooltip modifier for reliable hover on non-interactive views
- AppState polling: 10s for git status, 60s PR cache
- Immediate refresh on tab switch

## Stacked on
Builds on #8 (GitService methods)

## Test plan
- [x] 8 polling tests: git/non-git/worktree/session-switch scenarios
- [x] Full suite (423 tests) passing
- [x] Visual: indicators appear in status bar, tooltips show on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)