### PR TITLE
feat: add gh and sbx CLI path settings with auto-detection

### DIFF
--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -66,7 +66,7 @@ struct CanopySettings: Codable {
             "/usr/local/bin/\(name)",
             "/usr/bin/\(name)"
         ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? "/usr/bin/\(name)"
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? ""
     }
 
     init(from decoder: Decoder) throws {

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -31,6 +31,12 @@ struct CanopySettings: Codable {
     /// Additional flags passed to `sbx run` (e.g. "--memory 8g").
     var sbxFlags: String
 
+    /// Path to the GitHub CLI (`gh`). Used for PR status in the status bar.
+    var ghPath: String
+
+    /// Path to the sandbox CLI (`sbx`). Used for sandboxed sessions.
+    var sbxPath: String
+
     var ideName: String {
         ((idePath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
@@ -39,7 +45,7 @@ struct CanopySettings: Codable {
         ((terminalPath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 
-    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, useSandbox: Bool = false, sbxFlags: String = "") {
+    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, useSandbox: Bool = false, sbxFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil) {
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
         self.confirmBeforeClosing = confirmBeforeClosing
@@ -49,6 +55,18 @@ struct CanopySettings: Codable {
         self.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
         self.useSandbox = useSandbox
         self.sbxFlags = sbxFlags
+        self.ghPath = ghPath ?? Self.detectCLI("gh")
+        self.sbxPath = sbxPath ?? Self.detectCLI("sbx")
+    }
+
+    /// Detects a CLI tool by checking common Homebrew and system paths.
+    private static func detectCLI(_ name: String) -> String {
+        let candidates = [
+            "/opt/homebrew/bin/\(name)",
+            "/usr/local/bin/\(name)",
+            "/usr/bin/\(name)"
+        ]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? "/usr/bin/\(name)"
     }
 
     init(from decoder: Decoder) throws {
@@ -62,6 +80,8 @@ struct CanopySettings: Codable {
         checkForUpdatesOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .checkForUpdatesOnLaunch) ?? true
         useSandbox = try container.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false
         sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags) ?? ""
+        ghPath = try container.decodeIfPresent(String.self, forKey: .ghPath) ?? Self.detectCLI("gh")
+        sbxPath = try container.decodeIfPresent(String.self, forKey: .sbxPath) ?? Self.detectCLI("sbx")
     }
 
     /// The full command sent to the terminal when auto-starting.

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -16,6 +16,8 @@ struct SettingsView: View {
     @State private var sbxFlags: String
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
+    @State private var ghPath: String
+    @State private var sbxPath: String
 
     init(settings: CanopySettings) {
         self._autoStartClaude = State(initialValue: settings.autoStartClaude)
@@ -27,6 +29,8 @@ struct SettingsView: View {
         self._checkForUpdatesOnLaunch = State(initialValue: settings.checkForUpdatesOnLaunch)
         self._useSandbox = State(initialValue: settings.useSandbox)
         self._sbxFlags = State(initialValue: settings.sbxFlags)
+        self._ghPath = State(initialValue: settings.ghPath)
+        self._sbxPath = State(initialValue: settings.sbxPath)
     }
 
     var body: some View {
@@ -187,6 +191,44 @@ struct SettingsView: View {
                         Label("Terminal", systemImage: "terminal")
                     }
 
+                    // CLI Tools section
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 12) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("GitHub CLI (gh)")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                HStack {
+                                    TextField("/opt/homebrew/bin/gh", text: $ghPath)
+                                        .textFieldStyle(.roundedBorder)
+                                        .font(.system(size: 12, design: .monospaced))
+                                    cliStatusDot(ghPath)
+                                }
+                                Text("Used for PR status indicators. Auto-detected from Homebrew.")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Sandbox CLI (sbx)")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                HStack {
+                                    TextField("/opt/homebrew/bin/sbx", text: $sbxPath)
+                                        .textFieldStyle(.roundedBorder)
+                                        .font(.system(size: 12, design: .monospaced))
+                                    cliStatusDot(sbxPath)
+                                }
+                                Text("Used for sandboxed sessions.")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .padding(4)
+                    } label: {
+                        Label("CLI Tools", systemImage: "wrench")
+                    }
+
                     // Updates section
                     GroupBox {
                         VStack(alignment: .leading, spacing: 8) {
@@ -269,6 +311,13 @@ struct SettingsView: View {
         }
     }
 
+    private func cliStatusDot(_ path: String) -> some View {
+        Circle()
+            .fill(FileManager.default.isExecutableFile(atPath: path) ? Color.green : Color.red)
+            .frame(width: 8, height: 8)
+            .help(FileManager.default.isExecutableFile(atPath: path) ? "Found" : "Not found at this path")
+    }
+
     private func save() {
         var settings = appState.settings
         settings.autoStartClaude = autoStartClaude
@@ -280,6 +329,8 @@ struct SettingsView: View {
         settings.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
         settings.useSandbox = useSandbox
         settings.sbxFlags = sbxFlags
+        settings.ghPath = ghPath
+        settings.sbxPath = sbxPath
         settings.save()
         appState.settings = settings
         dismiss()

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -204,7 +204,7 @@ struct SettingsView: View {
                                         .font(.system(size: 12, design: .monospaced))
                                     cliStatusDot(ghPath)
                                 }
-                                Text("Used for PR status indicators. Auto-detected from Homebrew.")
+                                Text("Used for PR status indicators. Auto-detected from common install locations.")
                                     .font(.caption)
                                     .foregroundStyle(.tertiary)
                             }
@@ -312,10 +312,13 @@ struct SettingsView: View {
     }
 
     private func cliStatusDot(_ path: String) -> some View {
-        Circle()
-            .fill(FileManager.default.isExecutableFile(atPath: path) ? Color.green : Color.red)
-            .frame(width: 8, height: 8)
-            .help(FileManager.default.isExecutableFile(atPath: path) ? "Found" : "Not found at this path")
+        let isFound = !path.isEmpty && FileManager.default.isExecutableFile(atPath: path)
+        return Image(systemName: isFound ? "checkmark.circle.fill" : "xmark.circle.fill")
+            .foregroundStyle(isFound ? Color.green : Color.red)
+            .font(.system(size: 10))
+            .help(isFound ? "Found" : "Not found at this path")
+            .accessibilityLabel("CLI status")
+            .accessibilityValue(isFound ? "Found" : "Not found")
     }
 
     private func save() {


### PR DESCRIPTION
## Summary
- New CLI Tools section in Settings with configurable paths for `gh` and `sbx`
- Auto-detects from Homebrew locations (/opt/homebrew/bin, /usr/local/bin) on first use
- Green/red status dot shows whether each binary is found
- Needed because macOS apps don't inherit the user's shell PATH

## Independent PR
Can be merged independently or alongside the git status PRs (#8-#10).
When #10 is merged, GitService will read `ghPath` from settings instead of its own auto-detection.

## Test plan
- [x] Full suite (389 tests) passing
- [x] Visual: CLI Tools section renders in settings, dots reflect binary presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)