### PR TITLE
First Opus 4.7 review: three AppState bugs + characterization tests

### DIFF
--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -222,8 +222,10 @@ final class AppState: ObservableObject {
             activeGitStatus = nil
             return
         }
+        let sessionId = session.id
         let path = session.workingDirectory
         guard await git.isGitRepo(path: path) else {
+            guard activeSessionId == sessionId else { return }
             activeGitStatus = nil
             return
         }
@@ -241,6 +243,9 @@ final class AppState: ObservableObject {
         } else {
             prs = cachedPRsByRepo[path] ?? []
         }
+
+        // Guard against stale results if the session changed during async work.
+        guard activeSessionId == sessionId else { return }
 
         activeGitStatus = GitStatusInfo(
             diffStat: diff, commitsAhead: ahead,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -562,6 +562,9 @@ final class AppState: ObservableObject {
         terminalSessions[id]?.stop()
         terminalSessions.removeValue(forKey: id)
         closeSplitTerminal(for: id)
+        sessionDiffStats.removeValue(forKey: id)
+        sessionCommitsAhead.removeValue(forKey: id)
+        sessionPRCount.removeValue(forKey: id)
         withAnimation(.easeOut(duration: 0.25)) {
             sessions.removeAll { $0.id == id }
             if activeSessionId == id {

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -169,7 +169,10 @@ final class AppState: ObservableObject {
     }
 
     /// When selecting a session, clear the project selection (and vice versa).
+    /// No-op when `id` does not match a live session (stale notification
+    /// for a closed session, or observer on a different AppState instance).
     func selectSession(_ id: UUID) {
+        guard sessions.contains(where: { $0.id == id }) else { return }
         activeSessionId = id
         selectedProjectId = nil
         showActivity = false

--- a/Tests/AppStateSelectionTests.swift
+++ b/Tests/AppStateSelectionTests.swift
@@ -120,6 +120,29 @@ struct AppStateSelectionTests {
         #expect(state.terminalSessions[info.id] == nil)
     }
 
+    /// Sidebar per-session git dicts must be cleaned up when a session
+    /// closes. Otherwise entries grow unbounded over the app's lifetime
+    /// and any future code iterating the dicts will see dead UUIDs.
+    @Test @MainActor func closeSessionClearsSidebarGitDicts() {
+        let state = AppState()
+        state.settings.confirmBeforeClosing = false
+        state.createSession(name: "Test", directory: "/tmp")
+        let id = state.sessions[0].id
+
+        // Simulate what the pollers would populate.
+        state.sessionDiffStats[id] = GitDiffStat(
+            filesChanged: 1, insertions: 3, deletions: 0, changedFiles: ["x"]
+        )
+        state.sessionCommitsAhead[id] = 2
+        state.sessionPRCount[id] = 1
+
+        state.closeSession(id: id)
+
+        #expect(state.sessionDiffStats[id] == nil)
+        #expect(state.sessionCommitsAhead[id] == nil)
+        #expect(state.sessionPRCount[id] == nil)
+    }
+
     // MARK: - Session Naming
 
     @Test @MainActor func createSessionDefaultsToSessionNumber() {

--- a/Tests/AppStateTests.swift
+++ b/Tests/AppStateTests.swift
@@ -5,6 +5,22 @@ import Foundation
 @Suite("AppState")
 struct AppStateTests {
 
+    // MARK: - Session-selection safety
+
+    /// `selectSession(id)` is reachable from notification callbacks (stale
+    /// banner for a closed session) and in-process observers on other
+    /// AppState instances. It must no-op when the id isn't in `sessions`;
+    /// otherwise activeSessionId points at a ghost and the UI breaks.
+    @Test @MainActor func selectSessionIgnoresUnknownSessionId() {
+        let state = AppState()
+        state.createSession(name: "real", directory: "/tmp")
+        let originalId = state.activeSessionId
+
+        state.selectSession(UUID())  // not in state.sessions
+
+        #expect(state.activeSessionId == originalId)
+    }
+
     // MARK: - Session Management
 
     @Test @MainActor func createSession() {

--- a/Tests/GitStatusPollingTests.swift
+++ b/Tests/GitStatusPollingTests.swift
@@ -201,6 +201,83 @@ struct GitStatusPollingTests {
         #expect(state.sessionDiffStats[dirtyId]?.isClean == false)
     }
 
+    @Test @MainActor func refreshAllSessionDiffStatsTracksCommitsAhead() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let git = GitService()
+        let wt = repo + "-ahead-wt"
+        defer { try? fm.removeItem(atPath: wt) }
+        try await git.createWorktree(
+            repoPath: repo, worktreePath: wt,
+            branch: "feat/ahead", createBranch: true
+        )
+        // Add a commit on the feature branch so it's ahead of main.
+        try "new".write(toFile: "\(wt)/new.txt", atomically: true, encoding: .utf8)
+        try shell("git add -A && git commit -m 'ahead'", in: wt)
+
+        let state = AppState()
+        state.createSession(name: "feat", directory: wt)
+
+        await state.refreshAllSessionDiffStats()
+
+        let id = state.sessions[0].id
+        #expect(state.sessionCommitsAhead[id] == 1)
+    }
+
+    // MARK: - refreshAllSessionPRCounts throttling
+
+    @Test @MainActor func refreshAllSessionPRCountsReturnsEmptyForNoSessions() async {
+        let state = AppState()
+        await state.refreshAllSessionPRCounts(force: true)
+        #expect(state.sessionPRCount.isEmpty)
+    }
+
+    @Test @MainActor func refreshAllSessionPRCountsThrottlesRapidCalls() async throws {
+        // With `force: false` and a fresh AppState, the first call passes the
+        // throttle (lastSessionPRRefresh starts at distantPast). A second
+        // immediate call must bail early without touching the state.
+        // We seed a fake entry and verify the second call doesn't clear it,
+        // which would happen if it re-ran the "rebuild from scratch" block.
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let state = AppState()
+        state.createSession(name: "s", directory: repo)
+        let id = state.sessions[0].id
+
+        // First call updates lastSessionPRRefresh. Since there's no `gh` PR
+        // matching the branch, sessionPRCount is set to [:].
+        await state.refreshAllSessionPRCounts(force: false)
+
+        // Seed a value a non-forced second call would clobber if it ran.
+        state.sessionPRCount[id] = 42
+
+        await state.refreshAllSessionPRCounts(force: false)
+
+        #expect(state.sessionPRCount[id] == 42,
+                "Throttle should have prevented the rebuild")
+    }
+
+    @Test @MainActor func refreshAllSessionPRCountsForceOverridesThrottle() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+
+        let state = AppState()
+        state.createSession(name: "s", directory: repo)
+        let id = state.sessions[0].id
+
+        await state.refreshAllSessionPRCounts(force: false)
+        state.sessionPRCount[id] = 42
+
+        // force: true must bypass the throttle and rebuild, clearing the
+        // stale seed since no gh match exists in tests.
+        await state.refreshAllSessionPRCounts(force: true)
+
+        #expect(state.sessionPRCount[id] == nil,
+                "Force must bypass throttle and rebuild session PR counts")
+    }
+
     @Test @MainActor func refreshAllSessionDiffStatsSkipsNonGit() async {
         let tempDir = NSTemporaryDirectory() + "canopy-nongitall-\(UUID().uuidString)"
         try? fm.createDirectory(atPath: tempDir, withIntermediateDirectories: true)

--- a/Tests/GitStatusPollingTests.swift
+++ b/Tests/GitStatusPollingTests.swift
@@ -118,6 +118,40 @@ struct GitStatusPollingTests {
         #expect(state.activeGitStatus?.diffStat?.isClean == false)
     }
 
+    /// Regression: `refreshGitStatus` must not overwrite `activeGitStatus`
+    /// with data from a session that was active when the refresh started but
+    /// was switched away from before the git operations completed. Without
+    /// the stale-session guard, the 10s poller racing with a tab switch
+    /// writes the *previous* session's git state onto the new selection.
+    @Test @MainActor func refreshGitStatusDoesNotOverwriteAfterSessionSwitch() async throws {
+        let repo = try makeTempRepo()
+        defer { try? fm.removeItem(atPath: repo) }
+        let tempDir = NSTemporaryDirectory() + "canopy-pollrace-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: tempDir) }
+
+        let state = AppState()
+        state.createSession(name: "git-session", directory: repo)
+        state.createSession(name: "plain-session", directory: tempDir)
+
+        // Activate the git session and kick off a refresh. The async git
+        // operations suspend; before they resume, we switch to the non-git
+        // session. The guard must prevent the in-flight refresh from
+        // writing the git-session's status onto the plain-session.
+        state.activeSessionId = state.sessions[0].id
+        let refresh = Task { @MainActor in await state.refreshGitStatus() }
+        // Yield so the refresh task actually starts and captures the git
+        // session before we swap the selection. Without this, the task
+        // begins after the swap and reads the already-updated selection,
+        // which wouldn't exercise the stale-write race at all.
+        await Task.yield()
+        state.activeSessionId = state.sessions[1].id
+        await refresh.value
+
+        #expect(state.activeGitStatus == nil,
+                "Stale git status wrote over fresh non-git selection")
+    }
+
     @Test @MainActor func refreshGitStatusInWorktree() async throws {
         let repo = try makeTempRepo()
         defer { try? fm.removeItem(atPath: repo) }

--- a/Tests/GitStatusPollingTests.swift
+++ b/Tests/GitStatusPollingTests.swift
@@ -140,10 +140,14 @@ struct GitStatusPollingTests {
         // writing the git-session's status onto the plain-session.
         state.activeSessionId = state.sessions[0].id
         let refresh = Task { @MainActor in await state.refreshGitStatus() }
-        // Yield so the refresh task actually starts and captures the git
-        // session before we swap the selection. Without this, the task
-        // begins after the swap and reads the already-updated selection,
-        // which wouldn't exercise the stale-write race at all.
+        // MainActor is cooperative: both this test and the refresh task are
+        // MainActor-isolated, so tasks run FIFO to their next suspension.
+        // `await Task.yield()` lets the refresh task run its synchronous
+        // prefix (capture `activeSession`, read `sessionId`, `path`) up to
+        // its first real suspension at `await git.isGitRepo` (GitService is
+        // non-isolated, so that await hops off the main actor). By the time
+        // control returns here, the refresh has already captured the git
+        // session — now we can swap `activeSessionId` to exercise the race.
         await Task.yield()
         state.activeSessionId = state.sessions[1].id
         await refresh.value


### PR DESCRIPTION
First review pass by Claude Opus 4.7 (1M context). Four commits, each
independently reviewable.

## Summary

Three bugs surfaced while re-reading the git-status polling work
introduced in #8–#10, plus a gap in test coverage for the PR-count
polling path.

### 1. Stale-session guard regression (`915b711`)

#10 silently removed the guard that prevents the 10s polling loop
from stamping a previous session's git data onto `activeGitStatus`
when the user switches tabs mid-refresh. The guard was originally
added in #9 with an explicit comment (\"Guard against stale results
if session changed during async work\"). The regression test drives
the race deterministically via `Task.yield()` between tab-state
mutations.

### 2. Sidebar dicts leak on close (`3d0308a`)

`performCloseSession` removed the terminal session and split but
left orphaned entries in `sessionDiffStats`, `sessionCommitsAhead`,
and `sessionPRCount`. Minor leak today, future-proofing against any
code that iterates dict keys assuming each is a live session.

### 3. `selectSession` accepted unknown IDs (`a37cb68`)

Reachable from notification callbacks — user clicks a banner whose
session was closed in the meantime — and from cross-instance
observers on the shared `NotificationCenter`. Would clobber
`activeSessionId` with a dead UUID and break the UI.

Finding this also uncovered a subtle test-contamination pattern:
every `AppState()` installs an observer on `NotificationCenter.default`,
so any test that posts `.canopySelectSession` (e.g.
`NotificationServiceTests.routeResponsePostsSelectSessionForValidId`)
affected every other parallel test's state. The guard closes that
too.

### 4. Characterization tests for `refreshAllSessionPRCounts` (`ffc9829`)

Four non-obvious behaviors were completely untested:
- tracks commits-ahead separately from diff stats
- returns empty on empty session list
- throttles non-forced calls to once per 60s
- exposes a `force: true` override

Locked down so the next refactor can't silently change them.

## Test plan

- [x] `swift test` — 432/432 pass in ~3.2s, three consecutive clean runs (no flakes)
- [x] `scripts/bundle.sh` — signed release build installs to `/Applications/Canopy.app`
- [x] Each commit verified independently by running its specific filter

## Flagged for follow-up (not in this PR)

- `GitService.runGH` ignores `CanopySettings.ghPath`. User-configurable path in Settings is a no-op for PR lookup. Needs to thread the setting into the Process executor.
- `Package.swift` emits an \"unhandled files\" warning for `Canopy/Assets.xcassets` and `Canopy/Models/CLAUDE.md`.
- `loadProjects` backs up after decode — a decodable-but-corrupted file overwrites the good backup.
- Polling awaits three git refreshes serially every 10s; `async let` parallelism would cut tail latency ~3×.
- `CommandPaletteItem.filter` doesn't test subtitle/keywords matching (the UX value of finding a session by branch or project name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)