### PR TITLE
Apple container sandbox backend, per-session sandboxing, and pre-release stability audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Apple container sandbox backend**: the Docker Sandbox toggle is now a
+  picker -- Off / Docker Sandbox (sbx) / Apple container. The new backend runs
+  Claude Code inside a lightweight VM via Apple's open-source
+  [container](https://github.com/apple/container) runtime (macOS 26+, Apple
+  silicon) with no Docker Desktop dependency. The worktree is mounted at its
+  host path and `~/.claude` is mounted from the host, so session resume, Show
+  Transcript, and activity tracking work in sandboxed sessions (unlike sbx).
+  You supply the OCI image -- the user guide includes a Dockerfile recipe.
+  Settings gain Container image / Container flags fields (global and
+  per-project) plus a `container` CLI path row; Canopy validates the CLI is
+  installed and the runtime is started before enabling the backend.
+
+### Changed
+- Settings/projects persistence: `useSandbox` (bool) is superseded by
+  `sandboxBackend` (`off` / `dockerSbx` / `appleContainer`). Existing files
+  migrate automatically on load; the legacy key is still read.
+
 ## [0.9.5] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus a `container` CLI path row; Canopy validates the CLI is installed,
   the runtime is started, and whether the image exists locally.
 
+- **Per-session sandbox override**: the New Worktree Session sheet gains a
+  Sandbox picker (Use project default / Off / Docker Sandbox / Apple
+  container) that applies to that session only. Resolution order is
+  session → project → global.
+
 ### Changed
 - Settings/projects persistence: `useSandbox` (bool) is superseded by
   `sandboxBackend` (`off` / `dockerSbx` / `appleContainer`). Existing files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silicon) with no Docker Desktop dependency. The worktree is mounted at its
   host path and `~/.claude` is mounted from the host, so session resume, Show
   Transcript, and activity tracking work in sandboxed sessions (unlike sbx).
-  You supply the OCI image -- the user guide includes a Dockerfile recipe.
-  Settings gain Container image / Container flags fields (global and
-  per-project) plus a `container` CLI path row; Canopy validates the CLI is
-  installed and the runtime is started before enabling the backend.
+  The image defaults to `canopy-claude` and a **Build Image** button in
+  Settings creates it from Canopy's built-in recipe (native Claude Code
+  install, so `/doctor` is clean against the mounted host config). Settings
+  gain Container image / Container flags fields (global and per-project)
+  plus a `container` CLI path row; Canopy validates the CLI is installed,
+  the runtime is started, and whether the image exists locally.
 
 ### Changed
 - Settings/projects persistence: `useSandbox` (bool) is superseded by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sandboxBackend` (`off` / `dockerSbx` / `appleContainer`). Existing files
   migrate automatically on load; the legacy key is still read.
 
+### Fixed (pre-release app-wide audit)
+- **Closing a session now terminates its shell and claude process.** They
+  previously kept running (and an agent kept working/spending) invisibly
+  until the app quit.
+- **Session resume/transcripts/cost now work for paths with `_`, spaces,
+  and other special characters**: Canopy's encoding of Claude Code's
+  `~/.claude/projects/` directory names only handled `/` and `.`, while
+  Claude replaces every non-alphanumeric character -- so worktrees like
+  `fix_thing` silently lost resume and transcripts. `/tmp`-style paths now
+  resolve the way Claude's `process.cwd()` does.
+- **Merge & Finish** refuses to run when the main repository has
+  uncommitted changes (the merge switches its checked-out branch and would
+  drag them along), and it now restores the branch you had checked out
+  instead of leaving the repo on the merge target. Cleanup closes the
+  session only after the git operations succeed.
+- **The unmerged-commits warning before deleting a worktree now works on
+  master/develop repos** -- it was hardcoded to compare against `main` and
+  silently passed when that branch didn't exist. Unknown merge state now
+  warns instead of staying quiet.
+- sessions.json is written atomically and backed up on load (a crash
+  mid-write could previously corrupt it, and the next save erased all
+  sessions permanently).
+- Image build no longer hangs forever on builds with more than 64 KB of
+  output (the progress pipe was only drained after exit); builds also get
+  a 30-minute timeout. Settings save failures keep the sheet open with an
+  error instead of pretending success; a corrupt settings.json is backed
+  up to `settings.json.corrupt` before falling back to defaults.
+- Reordering plain sessions in the sidebar no longer moves the wrong
+  session when project sessions exist; Send Prompt is disabled for
+  sessions whose terminal hasn't been opened yet (it silently did
+  nothing); single quotes in Claude flags no longer break the sandbox
+  command; closed sessions no longer reappear in the git status bar.
+
 ### Fixed (Apple container hardening, from adversarial review + end-to-end probing)
 - **git now works in sandboxed worktree sessions**: the project's main
   repository is mounted alongside the worktree (a worktree's `.git` file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sandboxBackend` (`off` / `dockerSbx` / `appleContainer`). Existing files
   migrate automatically on load; the legacy key is still read.
 
+### Fixed (Apple container hardening, from adversarial review + end-to-end probing)
+- **git now works in sandboxed worktree sessions**: the project's main
+  repository is mounted alongside the worktree (a worktree's `.git` file
+  points there); `~/.gitconfig` is mounted so commits have your identity.
+- **Terminal no longer renders garbled** in container sessions: TERM,
+  COLORTERM, and a UTF-8 locale are passed into the VM, and claude starts
+  only after the VM terminal has its real window size (it briefly reports
+  0x0, which made claude lay out for 80 columns).
+- Home-directory sessions are blocked for the container backend with a clear
+  message -- mounting `~` overlaps the `~/.claude` mounts and breaks the VM.
+- Enabling "Override global Claude settings" on a project no longer silently
+  saves auto-start=off and empty flags; fields now seed from the effective
+  values, so saving without changes is a no-op.
+- Config files written by a newer Canopy (unknown sandbox backend value) no
+  longer silently factory-reset all settings/projects on load.
+- Validation now also detects a missing Linux kernel (`container system
+  status` passes even without one) and points at the exact fix command.
+- Saving Settings (or a project sheet) while backend validation is running
+  no longer persists a stale backend value.
+- Fresh machines: `~/.claude`, `~/.claude.json`, and `~/.gitconfig` are
+  created on first sandboxed launch instead of failing the mounts; the image
+  build command quotes user input; claude self-updates inside the ephemeral
+  VM are disabled (`DISABLE_AUTOUPDATER=1`).
+
 ## [0.9.5] - 2026-05-14
 
 ### Added

--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */; };
 		C20B1FD7CDB479CD9E788FA3 /* ProjectColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */; };
 		C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA12AC586A4E8219DE7BF6A /* CanopyApp.swift */; };
+		C727214786425B7141AE52A6 /* ContainerSandboxE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC067F40D9AF4F8D67CBC04 /* ContainerSandboxE2ETests.swift */; };
 		CAF1AB1BC545E41239724272 /* TerminalSessionOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B8F8AE3E1C9ADB56FB3F2C /* TerminalSessionOutputTests.swift */; };
 		CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104528AB64BB407CE23FBDE /* SettingsTests.swift */; };
 		D25D5684810B60D6B03D8100 /* GitServiceStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8815ACE4151F62175FCCC17 /* GitServiceStatusTests.swift */; };
@@ -105,6 +106,7 @@
 		0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
 		16DF06DA3F5EC110B202E67A /* ProjectColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColor.swift; sourceTree = "<group>"; };
 		1B64F1A3B9D1A7D162DFE72B /* ClaudeTranscriptLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptLoader.swift; sourceTree = "<group>"; };
+		1DC067F40D9AF4F8D67CBC04 /* ContainerSandboxE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSandboxE2ETests.swift; sourceTree = "<group>"; };
 		2104528AB64BB407CE23FBDE /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		211150E144900E5C953921DB /* canopy-logo.svg */ = {isa = PBXFileReference; path = "canopy-logo.svg"; sourceTree = "<group>"; };
 		22E1669D32944FC23A8BA7E8 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */,
 				3BC4F2B628227B82EA88FC92 /* CommandPaletteTests.swift */,
 				C81FDDD6955C0F98872E602B /* ContainerImageBuilderTests.swift */,
+				1DC067F40D9AF4F8D67CBC04 /* ContainerSandboxE2ETests.swift */,
 				051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */,
 				FCCD73E1AAF4DB1313798423 /* GitServiceEdgeCaseTests.swift */,
 				D8815ACE4151F62175FCCC17 /* GitServiceStatusTests.swift */,
@@ -514,6 +517,7 @@
 				5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */,
 				DCC63E6C6208E9ECCA4DAF7E /* CommandPaletteTests.swift in Sources */,
 				7D893C4E9CB4191632B869A6 /* ContainerImageBuilderTests.swift in Sources */,
+				C727214786425B7141AE52A6 /* ContainerSandboxE2ETests.swift in Sources */,
 				857F6B3E6BECD31A0EF8A30F /* GitServiceBranchTests.swift in Sources */,
 				A99747F00CB618221698BADC /* GitServiceEdgeCaseTests.swift in Sources */,
 				D25D5684810B60D6B03D8100 /* GitServiceStatusTests.swift in Sources */,

--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		D9227BD1898EF4FE74C4125D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F43DF5D5450E527968F656AF /* Assets.xcassets */; };
 		DAB3402FE894C41A5A2D75C7 /* CanopyLogo.png in Resources */ = {isa = PBXBuildFile; fileRef = F9715E211F7F3C1E0B155E9B /* CanopyLogo.png */; };
 		DCC63E6C6208E9ECCA4DAF7E /* CommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC4F2B628227B82EA88FC92 /* CommandPaletteTests.swift */; };
+		DCEC5FF914987D48A89E3D81 /* SessionSandboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E948527D5D146F27269411E /* SessionSandboxTests.swift */; };
 		E73A6C51EDB818ECA20D8A25 /* GitStatusPollingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357D44B70B337CBEA901EFC2 /* GitStatusPollingTests.swift */; };
 		E9221CF570EFEDB632B60747 /* AppStateSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACD793440D91EF9CE9D003D /* AppStateSelectionTests.swift */; };
 		EA5203931771989D35C133F1 /* ActivityDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D482C3938E22482339DC13E5 /* ActivityDot.swift */; };
@@ -100,6 +101,7 @@
 /* Begin PBXFileReference section */
 		028C5B5137B3ECE6C957B6EC /* AddProjectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProjectSheet.swift; sourceTree = "<group>"; };
 		051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBranchTests.swift; sourceTree = "<group>"; };
+		0E948527D5D146F27269411E /* SessionSandboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSandboxTests.swift; sourceTree = "<group>"; };
 		0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
 		16DF06DA3F5EC110B202E67A /* ProjectColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColor.swift; sourceTree = "<group>"; };
 		1B64F1A3B9D1A7D162DFE72B /* ClaudeTranscriptLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptLoader.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				71B9ED338BECE4C5A45CEF2F /* PromptLibraryTests.swift */,
 				850B26424BF5B827D9AC5AB2 /* SandboxCheckerTests.swift */,
 				4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */,
+				0E948527D5D146F27269411E /* SessionSandboxTests.swift */,
 				EB57402CEF34C579AE3ED054 /* SettingsEdgeCaseTests.swift */,
 				2104528AB64BB407CE23FBDE /* SettingsTests.swift */,
 				97282B824EEE8B84522D0A67 /* TerminalKeyPolicyTests.swift */,
@@ -525,6 +528,7 @@
 				5095CCFA8207BB832FE7702F /* PromptLibraryTests.swift in Sources */,
 				257BE9FBDC281CB300ADD349 /* SandboxCheckerTests.swift in Sources */,
 				7403E7DA09BC3CAD7004D877 /* SessionCostServiceTests.swift in Sources */,
+				DCEC5FF914987D48A89E3D81 /* SessionSandboxTests.swift in Sources */,
 				47572C3FF5F7C52C77D0B4C5 /* SettingsEdgeCaseTests.swift in Sources */,
 				CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */,
 				ECE0473E69F211CFA3DB65AA /* TerminalKeyPolicyTests.swift in Sources */,

--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		78D62DB77DC10FAD4E4A328F /* ClaudeTranscriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B64F1A3B9D1A7D162DFE72B /* ClaudeTranscriptLoader.swift */; };
 		7B8CB07FC35DC6C87C6F2776 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F6D24CB003F4162DB9E425 /* SettingsView.swift */; };
 		7D0C18601F227CEF202B5C4A /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF6A405D64E374EAF900972 /* AppState.swift */; };
+		7D893C4E9CB4191632B869A6 /* ContainerImageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81FDDD6955C0F98872E602B /* ContainerImageBuilderTests.swift */; };
 		7F4D62BD4537298C8412019E /* TerminalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACDA1B29536FED841DE8CD4 /* TerminalSessionTests.swift */; };
 		857F6B3E6BECD31A0EF8A30F /* GitServiceBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */; };
 		8AE649C33D49CF076C84EDE2 /* SessionInfoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3CE80C66F45F41E8AE88C5 /* SessionInfoSheet.swift */; };
@@ -55,6 +56,7 @@
 		A1669D51D797B9FBA7C424E6 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */; };
 		A3694563A13E7FD1C1DDEA32 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 221DC70B7598F4D564E6004E /* SwiftTerm */; };
 		A76F71582F1364D48A52A2D7 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380F49104F9CB7D2D472F216 /* GitService.swift */; };
+		A81E79BF1DEB7FDB08AE364B /* ContainerImageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */; };
 		A942B94AE83364B1A71E5560 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E1669D32944FC23A8BA7E8 /* ActivityView.swift */; };
 		A99747F00CB618221698BADC /* GitServiceEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCD73E1AAF4DB1313798423 /* GitServiceEdgeCaseTests.swift */; };
 		AB36D3222DD82D33B873783A /* ActivityDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */; };
@@ -62,6 +64,7 @@
 		B4670C2A691FC8A53E1BB919 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 85B38EAAB72CA93D542089E0 /* .gitkeep */; };
 		B5EBB6002FC4E7AE9B88B3B2 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */; };
 		B7E313D2316AD76F2C7CF7F9 /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC34A1B34310D4ECCF8BA6E /* StatusBar.swift */; };
+		BC77F021F5F299D5860A5611 /* CLAUDE.md in Resources */ = {isa = PBXBuildFile; fileRef = CDBEAF75E25AFDDABD93BA78 /* CLAUDE.md */; };
 		C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */; };
 		C20B1FD7CDB479CD9E788FA3 /* ProjectColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */; };
 		C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA12AC586A4E8219DE7BF6A /* CanopyApp.swift */; };
@@ -103,6 +106,7 @@
 		2104528AB64BB407CE23FBDE /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		211150E144900E5C953921DB /* canopy-logo.svg */ = {isa = PBXFileReference; path = "canopy-logo.svg"; sourceTree = "<group>"; };
 		22E1669D32944FC23A8BA7E8 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerImageBuilder.swift; sourceTree = "<group>"; };
 		27744AE57F084B3F805FCE26 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		2AEF32F025B580FFE656B31C /* TranscriptSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSheet.swift; sourceTree = "<group>"; };
 		2CD910CDF81D1FB6B5AE3840 /* Canopy.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Canopy.icns; sourceTree = "<group>"; };
@@ -154,9 +158,11 @@
 		BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColorTests.swift; sourceTree = "<group>"; };
 		C03CCFEC213EFB6F02C9FF5A /* TerminalSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSearchBar.swift; sourceTree = "<group>"; };
 		C1B8F8AE3E1C9ADB56FB3F2C /* TerminalSessionOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionOutputTests.swift; sourceTree = "<group>"; };
+		C81FDDD6955C0F98872E602B /* ContainerImageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerImageBuilderTests.swift; sourceTree = "<group>"; };
 		C92BEEFDE99541D50A1CA3D3 /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		CACD793440D91EF9CE9D003D /* AppStateSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSelectionTests.swift; sourceTree = "<group>"; };
 		CB3CE80C66F45F41E8AE88C5 /* SessionInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionInfoSheet.swift; sourceTree = "<group>"; };
+		CDBEAF75E25AFDDABD93BA78 /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		CE733A0978C4D68242BD92DF /* EditProjectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProjectSheet.swift; sourceTree = "<group>"; };
 		D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptLoaderTests.swift; sourceTree = "<group>"; };
 		D482C3938E22482339DC13E5 /* ActivityDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDot.swift; sourceTree = "<group>"; };
@@ -221,6 +227,7 @@
 			children = (
 				8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */,
 				1B64F1A3B9D1A7D162DFE72B /* ClaudeTranscriptLoader.swift */,
+				262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */,
 				380F49104F9CB7D2D472F216 /* GitService.swift */,
 				39E41572F63722BAF89C330B /* NotificationService.swift */,
 				43A620218A72BDE454D69504 /* SandboxChecker.swift */,
@@ -292,9 +299,11 @@
 				FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */,
 				CACD793440D91EF9CE9D003D /* AppStateSelectionTests.swift */,
 				8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */,
+				CDBEAF75E25AFDDABD93BA78 /* CLAUDE.md */,
 				BC1CBBF86B23C79D577B9030 /* ClaudeSessionFinderTests.swift */,
 				D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */,
 				3BC4F2B628227B82EA88FC92 /* CommandPaletteTests.swift */,
+				C81FDDD6955C0F98872E602B /* ContainerImageBuilderTests.swift */,
 				051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */,
 				FCCD73E1AAF4DB1313798423 /* GitServiceEdgeCaseTests.swift */,
 				D8815ACE4151F62175FCCC17 /* GitServiceStatusTests.swift */,
@@ -349,6 +358,7 @@
 			buildConfigurationList = 193FE9B32D1857E3CC0AB00F /* Build configuration list for PBXNativeTarget "CanopyTests" */;
 			buildPhases = (
 				FA634FAD8DC1494D07B3A56D /* Sources */,
+				878F427846FB7D22C9FFBC72 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -417,6 +427,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		878F427846FB7D22C9FFBC72 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC77F021F5F299D5860A5611 /* CLAUDE.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD86BA350B364D30868A59A0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -450,6 +468,7 @@
 				44FD7A8C10F00F715B09A452 /* ClaudeSessionFinder.swift in Sources */,
 				78D62DB77DC10FAD4E4A328F /* ClaudeTranscriptLoader.swift in Sources */,
 				216CA915FF3647FAB9BD25BB /* CommandPaletteView.swift in Sources */,
+				A81E79BF1DEB7FDB08AE364B /* ContainerImageBuilder.swift in Sources */,
 				54F01BBD042D8ED56E51C8C2 /* EditProjectSheet.swift in Sources */,
 				A76F71582F1364D48A52A2D7 /* GitService.swift in Sources */,
 				B44CE17C1CF9BA41D411CE90 /* HelpView.swift in Sources */,
@@ -491,6 +510,7 @@
 				248F3097C1BB13616D1D98BC /* ClaudeSessionFinderTests.swift in Sources */,
 				5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */,
 				DCC63E6C6208E9ECCA4DAF7E /* CommandPaletteTests.swift in Sources */,
+				7D893C4E9CB4191632B869A6 /* ContainerImageBuilderTests.swift in Sources */,
 				857F6B3E6BECD31A0EF8A30F /* GitServiceBranchTests.swift in Sources */,
 				A99747F00CB618221698BADC /* GitServiceEdgeCaseTests.swift in Sources */,
 				D25D5684810B60D6B03D8100 /* GitServiceStatusTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -467,10 +467,36 @@ final class AppState: ObservableObject {
     /// 3. Creates symlinks for heavy directories
     /// 4. Runs setup commands
     /// 5. Launches a terminal session in the worktree
+    /// Resolves the sandbox backend for a session:
+    /// session override → project override → global setting.
+    func sandboxBackend(for session: SessionInfo) -> SandboxBackend {
+        if let override = session.sandboxBackend {
+            return override
+        }
+        if let project = projects.first(where: { $0.id == session.projectId }) {
+            return project.resolvedSandboxBackend(globalSettings: settings)
+        }
+        return settings.sandboxBackend
+    }
+
+    /// Builds the claude command for a session. The backend comes from the
+    /// per-session resolution above; flags and image resolve through the
+    /// normal project → global chain.
+    func claudeCommand(for session: SessionInfo) -> String {
+        let project = projects.first { $0.id == session.projectId }
+        return sandboxBackend(for: session).claudeCommand(
+            claudeFlags: project?.claudeFlags ?? settings.claudeFlags,
+            sbxFlags: project?.sbxFlags ?? settings.sbxFlags,
+            containerImage: project?.containerImage ?? settings.containerImage,
+            containerFlags: project?.containerFlags ?? settings.containerFlags
+        )
+    }
+
     func createWorktreeSession(
         project: Project,
         branchName: String,
-        baseBranch: String
+        baseBranch: String,
+        sandboxBackend: SandboxBackend? = nil
     ) async throws {
         worktreeSetupInProgress = true
         worktreeSetupStatus = "Creating worktree..."
@@ -531,7 +557,8 @@ final class AppState: ObservableObject {
                 workingDirectory: worktreePath,
                 projectId: project.id,
                 branchName: branchName,
-                worktreePath: worktreePath
+                worktreePath: worktreePath,
+                sandboxBackend: sandboxBackend
             )
             withAnimation(.easeOut(duration: 0.25)) {
                 if tabSortMode == .manual {
@@ -800,6 +827,10 @@ struct SessionInfo: Identifiable, Codable {
     /// When set, Claude is started with `--resume <id>`.
     var claudeSessionId: String?
 
+    /// Per-session sandbox override chosen at creation time.
+    /// nil = inherit the project/global setting.
+    var sandboxBackend: SandboxBackend?
+
     init(
         id: UUID = UUID(),
         name: String,
@@ -808,6 +839,7 @@ struct SessionInfo: Identifiable, Codable {
         branchName: String? = nil,
         worktreePath: String? = nil,
         claudeSessionId: String? = nil,
+        sandboxBackend: SandboxBackend? = nil,
         createdAt: Date = Date()
     ) {
         self.id = id
@@ -817,6 +849,7 @@ struct SessionInfo: Identifiable, Codable {
         self.branchName = branchName
         self.worktreePath = worktreePath
         self.claudeSessionId = claudeSessionId
+        self.sandboxBackend = sandboxBackend
         self.createdAt = createdAt
     }
 }

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -467,6 +467,22 @@ final class AppState: ObservableObject {
     /// 3. Creates symlinks for heavy directories
     /// 4. Runs setup commands
     /// 5. Launches a terminal session in the worktree
+    /// Creates a session in an existing worktree directory (no git worktree
+    /// add), resuming the most recent Claude session found for it.
+    func openWorktreeSession(project: Project, worktreePath: String, branch: String?) {
+        let sessionId = ClaudeSessionFinder.findLatestSessionId(for: worktreePath)
+        let session = SessionInfo(
+            name: branch ?? "session",
+            workingDirectory: worktreePath,
+            projectId: project.id,
+            branchName: branch,
+            worktreePath: worktreePath,
+            claudeSessionId: sessionId
+        )
+        sessions.append(session)
+        saveSessions()
+    }
+
     /// Resolves the sandbox backend for a session:
     /// session override → project override → global setting.
     func sandboxBackend(for session: SessionInfo) -> SandboxBackend {

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -516,7 +516,10 @@ final class AppState: ObservableObject {
         var extraMounts: [String] = []
         if session.worktreePath != nil,
            let repoPath = project?.repositoryPath,
-           repoPath != session.workingDirectory {
+           // Compare resolved paths: /tmp vs /private/tmp spellings of the
+           // same directory must not produce a duplicate (overlapping) mount.
+           SandboxBackend.realResolvedPath(repoPath)
+               != SandboxBackend.realResolvedPath(session.workingDirectory) {
             extraMounts.append(repoPath)
         }
         return sandboxBackend(for: session).claudeCommand(

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -268,12 +268,17 @@ final class AppState: ObservableObject {
                 sessionCommitsAhead.removeValue(forKey: session.id)
                 continue
             }
-            if let diff = await git.diffStat(repoPath: path) {
+            let diff = await git.diffStat(repoPath: path)
+            let ahead = await git.commitsAhead(repoPath: path)
+            // The session may have been closed during the awaits above --
+            // writing then would resurrect its entries permanently.
+            guard sessions.contains(where: { $0.id == session.id }) else { continue }
+            if let diff {
                 sessionDiffStats[session.id] = diff
             } else {
                 sessionDiffStats.removeValue(forKey: session.id)
             }
-            if let ahead = await git.commitsAhead(repoPath: path), ahead > 0 {
+            if let ahead, ahead > 0 {
                 sessionCommitsAhead[session.id] = ahead
             } else {
                 sessionCommitsAhead.removeValue(forKey: session.id)
@@ -665,9 +670,25 @@ final class AppState: ObservableObject {
         sessions = result
     }
 
-    /// Moves sessions using IndexSet (for sidebar .onMove).
-    func moveSession(from source: IndexSet, to destination: Int) {
-        sessions.move(fromOffsets: source, toOffset: destination)
+    /// Reorders plain (non-project) sessions (sidebar .onMove).
+    /// `source`/`destination` are indices into the FILTERED plain-session
+    /// list -- applying them to the full array moved arbitrary other
+    /// sessions when project sessions interleave.
+    func movePlainSessions(from source: IndexSet, to destination: Int) {
+        var plain = sessions.filter { $0.projectId == nil }
+        plain.move(fromOffsets: source, toOffset: destination)
+
+        var result: [SessionInfo] = []
+        var plainIndex = 0
+        for session in sessions {
+            if session.projectId == nil {
+                result.append(plain[plainIndex])
+                plainIndex += 1
+            } else {
+                result.append(session)
+            }
+        }
+        sessions = result
         tabSortMode = .manual
     }
 
@@ -768,21 +789,36 @@ final class AppState: ObservableObject {
 
     func saveSessions() {
         guard !isTerminating else { return }
-        guard let data = try? JSONEncoder().encode(sessions) else { return }
-        FileManager.default.createFile(atPath: sessionsFilePath, contents: data)
+        guard let data = try? JSONEncoder().encode(sessions) else {
+            NSLog("Canopy: failed to encode sessions for persistence")
+            return
+        }
+        // Atomic: a crash mid-write must not corrupt the file (a corrupt
+        // file decodes as no sessions, and the next save makes that final).
+        do {
+            try data.write(to: URL(fileURLWithPath: sessionsFilePath), options: .atomic)
+        } catch {
+            NSLog("Canopy: failed to write %@ (%@)", sessionsFilePath, "\(error)")
+        }
     }
 
     /// Save sessions and mark as terminating so cleanup doesn't overwrite the file.
     func saveSessionsBeforeTermination() {
         guard let data = try? JSONEncoder().encode(sessions) else { return }
-        FileManager.default.createFile(atPath: sessionsFilePath, contents: data)
+        try? data.write(to: URL(fileURLWithPath: sessionsFilePath), options: .atomic)
         isTerminating = true
     }
 
     func loadSessions() {
         let path = sessionsFilePath
-        guard let data = FileManager.default.contents(atPath: path),
-              var decoded = try? JSONDecoder().decode([SessionInfo].self, from: data) else {
+        guard let data = FileManager.default.contents(atPath: path) else { return }
+        // Backup before decoding, like projects.json -- if this file is
+        // corrupt, the next save would otherwise overwrite it with [].
+        let backupPath = (path as NSString).deletingPathExtension + ".backup.json"
+        try? FileManager.default.removeItem(atPath: backupPath)
+        try? FileManager.default.copyItem(atPath: path, toPath: backupPath)
+        guard var decoded = try? JSONDecoder().decode([SessionInfo].self, from: data) else {
+            NSLog("Canopy: sessions.json failed to decode; previous content kept at %@", backupPath)
             return
         }
         // Refresh Claude session IDs from disk

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -469,7 +469,8 @@ final class AppState: ObservableObject {
     /// 5. Launches a terminal session in the worktree
     /// Creates a session in an existing worktree directory (no git worktree
     /// add), resuming the most recent Claude session found for it.
-    func openWorktreeSession(project: Project, worktreePath: String, branch: String?) {
+    /// `sandboxBackend` nil = inherit project/global, like everywhere else.
+    func openWorktreeSession(project: Project, worktreePath: String, branch: String?, sandboxBackend: SandboxBackend? = nil) {
         let sessionId = ClaudeSessionFinder.findLatestSessionId(for: worktreePath)
         let session = SessionInfo(
             name: branch ?? "session",
@@ -477,7 +478,8 @@ final class AppState: ObservableObject {
             projectId: project.id,
             branchName: branch,
             worktreePath: worktreePath,
-            claudeSessionId: sessionId
+            claudeSessionId: sessionId,
+            sandboxBackend: sandboxBackend
         )
         sessions.append(session)
         saveSessions()
@@ -498,13 +500,26 @@ final class AppState: ObservableObject {
     /// Builds the claude command for a session. The backend comes from the
     /// per-session resolution above; flags and image resolve through the
     /// normal project → global chain.
+    ///
+    /// Worktree sessions additionally mount the project's main repository:
+    /// the worktree's `.git` file points there, so git inside the container
+    /// is broken without it. Only for real worktrees -- a worktree is never
+    /// inside the repo, so the mounts can't overlap (overlapping virtiofs
+    /// mounts are silently dropped or hang the VM).
     func claudeCommand(for session: SessionInfo) -> String {
         let project = projects.first { $0.id == session.projectId }
+        var extraMounts: [String] = []
+        if session.worktreePath != nil,
+           let repoPath = project?.repositoryPath,
+           repoPath != session.workingDirectory {
+            extraMounts.append(repoPath)
+        }
         return sandboxBackend(for: session).claudeCommand(
             claudeFlags: project?.claudeFlags ?? settings.claudeFlags,
             sbxFlags: project?.sbxFlags ?? settings.sbxFlags,
             containerImage: project?.containerImage ?? settings.containerImage,
-            containerFlags: project?.containerFlags ?? settings.containerFlags
+            containerFlags: project?.containerFlags ?? settings.containerFlags,
+            extraMountPaths: extraMounts
         )
     }
 

--- a/Canopy/Models/Project.swift
+++ b/Canopy/Models/Project.swift
@@ -88,8 +88,11 @@ struct Project: Identifiable, Codable {
         worktreeBaseDir = try container.decodeIfPresent(String.self, forKey: .worktreeBaseDir)
         autoStartClaude = try container.decodeIfPresent(Bool.self, forKey: .autoStartClaude)
         claudeFlags = try container.decodeIfPresent(String.self, forKey: .claudeFlags)
-        if let backend = try container.decodeIfPresent(SandboxBackend.self, forKey: .sandboxBackend) {
-            sandboxBackend = backend
+        if let raw = try container.decodeIfPresent(String.self, forKey: .sandboxBackend) {
+            // Tolerant of unknown rawValues (file written by a newer
+            // version): throwing here would fail the whole-array decode and
+            // silently drop ALL projects. Unknown maps to nil (use global).
+            sandboxBackend = SandboxBackend(rawValue: raw)
         } else {
             // A legacy boolean was an explicit per-project override, so
             // false must migrate to .off (not nil, which means "use global").

--- a/Canopy/Models/Project.swift
+++ b/Canopy/Models/Project.swift
@@ -27,11 +27,17 @@ struct Project: Identifiable, Codable {
     /// Override global Claude flags for this project. nil = use global.
     var claudeFlags: String?
 
-    /// Override global sandbox setting for this project. nil = use global.
-    var useSandbox: Bool?
+    /// Override global sandbox backend for this project. nil = use global.
+    var sandboxBackend: SandboxBackend?
 
     /// Override global sbx flags for this project. nil = use global.
     var sbxFlags: String?
+
+    /// Override global container image for this project. nil = use global.
+    var containerImage: String?
+
+    /// Override global container flags for this project. nil = use global.
+    var containerFlags: String?
 
     /// Color index into ProjectColor palette. Auto-assigned on creation, user-overridable.
     var colorIndex: Int?
@@ -44,8 +50,10 @@ struct Project: Identifiable, Codable {
         setupCommands: [String] = [],
         autoStartClaude: Bool? = nil,
         claudeFlags: String? = nil,
-        useSandbox: Bool? = nil,
+        sandboxBackend: SandboxBackend? = nil,
         sbxFlags: String? = nil,
+        containerImage: String? = nil,
+        containerFlags: String? = nil,
         colorIndex: Int? = nil
     ) {
         self.id = UUID()
@@ -56,9 +64,16 @@ struct Project: Identifiable, Codable {
         self.setupCommands = setupCommands
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
-        self.useSandbox = useSandbox
+        self.sandboxBackend = sandboxBackend
         self.sbxFlags = sbxFlags
+        self.containerImage = containerImage
+        self.containerFlags = containerFlags
         self.colorIndex = colorIndex
+    }
+
+    /// Key used by versions before the backend enum existed. Decode-only.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case useSandbox
     }
 
     // Forward-compatible decoding
@@ -73,8 +88,17 @@ struct Project: Identifiable, Codable {
         worktreeBaseDir = try container.decodeIfPresent(String.self, forKey: .worktreeBaseDir)
         autoStartClaude = try container.decodeIfPresent(Bool.self, forKey: .autoStartClaude)
         claudeFlags = try container.decodeIfPresent(String.self, forKey: .claudeFlags)
-        useSandbox = try container.decodeIfPresent(Bool.self, forKey: .useSandbox)
+        if let backend = try container.decodeIfPresent(SandboxBackend.self, forKey: .sandboxBackend) {
+            sandboxBackend = backend
+        } else {
+            // A legacy boolean was an explicit per-project override, so
+            // false must migrate to .off (not nil, which means "use global").
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            sandboxBackend = (try legacy.decodeIfPresent(Bool.self, forKey: .useSandbox)).map { $0 ? .dockerSbx : .off }
+        }
         sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags)
+        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage)
+        containerFlags = try container.decodeIfPresent(String.self, forKey: .containerFlags)
         colorIndex = try container.decodeIfPresent(Int.self, forKey: .colorIndex)
     }
 
@@ -92,33 +116,19 @@ struct Project: Identifiable, Codable {
         autoStartClaude ?? globalSettings.autoStartClaude
     }
 
-    /// Resolves the Claude command, falling back to global settings.
-    ///
-    /// When sandbox mode is enabled, `--` separates sbx flags from claude flags:
-    /// `sbx run [sbx-flags] claude -- [claude-flags]`
-    func resolvedClaudeCommand(globalSettings: CanopySettings) -> String {
-        let sandbox = useSandbox ?? globalSettings.useSandbox
-        let sbxFlagsResolved = sbxFlags ?? globalSettings.sbxFlags
-        let flags = claudeFlags ?? globalSettings.claudeFlags
-        let trimmed = flags.trimmingCharacters(in: .whitespaces)
+    /// Resolves the sandbox backend, falling back to global settings.
+    func resolvedSandboxBackend(globalSettings: CanopySettings) -> SandboxBackend {
+        sandboxBackend ?? globalSettings.sandboxBackend
+    }
 
-        var parts: [String] = []
-        if sandbox {
-            parts.append("sbx run")
-            let trimmedSbx = sbxFlagsResolved.trimmingCharacters(in: .whitespaces)
-            if !trimmedSbx.isEmpty {
-                parts.append(trimmedSbx)
-            }
-            parts.append("claude --")
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        } else {
-            parts.append("claude")
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        }
-        return parts.joined(separator: " ")
+    /// Resolves the Claude command, falling back to global settings.
+    /// See `SandboxBackend.claudeCommand` for the per-backend shapes.
+    func resolvedClaudeCommand(globalSettings: CanopySettings) -> String {
+        resolvedSandboxBackend(globalSettings: globalSettings).claudeCommand(
+            claudeFlags: claudeFlags ?? globalSettings.claudeFlags,
+            sbxFlags: sbxFlags ?? globalSettings.sbxFlags,
+            containerImage: containerImage ?? globalSettings.containerImage,
+            containerFlags: containerFlags ?? globalSettings.containerFlags
+        )
     }
 }

--- a/Canopy/Models/Project.swift
+++ b/Canopy/Models/Project.swift
@@ -132,3 +132,22 @@ struct Project: Identifiable, Codable {
         )
     }
 }
+
+/// Seed values for the "Override global Claude settings" section of the
+/// project sheets. Must be the EFFECTIVE values (project override if set,
+/// else global): seeding hardcoded false/"" used to write unintended
+/// overrides that silently disabled claude auto-start when the user only
+/// wanted to change one setting.
+struct ClaudeOverrideDefaults {
+    let autoStartClaude: Bool
+    let claudeFlags: String
+    let sandboxBackend: SandboxBackend
+    let sbxFlags: String
+
+    init(project: Project?, settings: CanopySettings) {
+        autoStartClaude = project?.autoStartClaude ?? settings.autoStartClaude
+        claudeFlags = project?.claudeFlags ?? settings.claudeFlags
+        sandboxBackend = project?.sandboxBackend ?? settings.sandboxBackend
+        sbxFlags = project?.sbxFlags ?? settings.sbxFlags
+    }
+}

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -77,7 +77,11 @@ enum SandboxBackend: String, Codable {
             if !image.isEmpty {
                 parts.append(image)
             }
-            let claudeInvocation = flags.isEmpty ? "claude" : "claude \(flags)"
+            // The invocation lives inside the wrapper's single quotes: a
+            // single quote in user flags would terminate the string early
+            // and leak tokens into the shell. POSIX-escape them.
+            let escapedFlags = flags.replacingOccurrences(of: "'", with: #"'\''"#)
+            let claudeInvocation = escapedFlags.isEmpty ? "claude" : "claude \(escapedFlags)"
             parts.append(#"sh -c 'i=0; while [ "$(stty size 2>/dev/null)" = "0 0" ] && [ $i -lt 100 ]; do sleep 0.05; i=$((i+1)); done; exec \#(claudeInvocation) "$@"' claude"#)
             return parts.joined(separator: " ")
         }
@@ -245,15 +249,30 @@ struct CanopySettings: Codable {
     }
 
     static func load(from path: String = CanopySettings.defaultFilePath) -> CanopySettings {
-        guard let data = FileManager.default.contents(atPath: path),
-              let decoded = try? JSONDecoder().decode(CanopySettings.self, from: data) else {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            return CanopySettings() // no file yet: defaults are correct
+        }
+        do {
+            return try JSONDecoder().decode(CanopySettings.self, from: data)
+        } catch {
+            // Corrupt file: returning defaults silently flattens the user's
+            // config (including turning sandboxing OFF). Keep the evidence.
+            NSLog("Canopy: settings.json failed to decode (%@); backing up to settings.json.corrupt", "\(error)")
+            try? FileManager.default.removeItem(atPath: path + ".corrupt")
+            try? FileManager.default.copyItem(atPath: path, toPath: path + ".corrupt")
             return CanopySettings()
         }
-        return decoded
     }
 
-    func save(to path: String = CanopySettings.defaultFilePath) {
-        guard let data = try? JSONEncoder().encode(self) else { return }
-        FileManager.default.createFile(atPath: path, contents: data)
+    /// Returns false when the settings could not be written -- callers must
+    /// surface that: a user who picked a sandbox and "saved" must not
+    /// silently end up unsandboxed on next launch.
+    @discardableResult
+    func save(to path: String = CanopySettings.defaultFilePath) -> Bool {
+        guard let data = try? JSONEncoder().encode(self) else {
+            NSLog("Canopy: failed to encode settings")
+            return false
+        }
+        return FileManager.default.createFile(atPath: path, contents: data)
     }
 }

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -90,8 +90,8 @@ struct CanopySettings: Codable {
     /// Additional flags passed to `sbx run` (e.g. "--memory 8g").
     var sbxFlags: String
 
-    /// OCI image used by the Apple container backend (e.g. "canopy-claude").
-    /// Must contain claude, node, and git -- see docs/guide.md for a recipe.
+    /// OCI image used by the Apple container backend. The default is built
+    /// in-app (Settings > Build Image) from `ContainerImageBuilder.dockerfile`.
     var containerImage: String
 
     /// Additional flags passed to `container run` (e.g. "--memory 8g --cpus 8").
@@ -114,7 +114,7 @@ struct CanopySettings: Codable {
         ((terminalPath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 
-    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, sandboxBackend: SandboxBackend = .off, sbxFlags: String = "", containerImage: String = "", containerFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil, containerPath: String? = nil) {
+    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, sandboxBackend: SandboxBackend = .off, sbxFlags: String = "", containerImage: String = "canopy-claude", containerFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil, containerPath: String? = nil) {
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
         self.confirmBeforeClosing = confirmBeforeClosing
@@ -163,7 +163,7 @@ struct CanopySettings: Codable {
             sandboxBackend = useSandbox ? .dockerSbx : .off
         }
         sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags) ?? ""
-        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? ""
+        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? "canopy-claude"
         containerFlags = try container.decodeIfPresent(String.self, forKey: .containerFlags) ?? ""
         ghPath = try container.decodeIfPresent(String.self, forKey: .ghPath) ?? Self.detectCLI("gh")
         sbxPath = try container.decodeIfPresent(String.self, forKey: .sbxPath) ?? Self.detectCLI("sbx")
@@ -183,22 +183,24 @@ struct CanopySettings: Codable {
 
     // MARK: - Persistence
 
-    private static var filePath: String {
+    /// The real config file. Tests pass an explicit path instead so they
+    /// never clobber the user's settings.
+    private static var defaultFilePath: String {
         let configDir = (NSHomeDirectory() as NSString).appendingPathComponent(".config/canopy")
         try? FileManager.default.createDirectory(atPath: configDir, withIntermediateDirectories: true)
         return (configDir as NSString).appendingPathComponent("settings.json")
     }
 
-    static func load() -> CanopySettings {
-        guard let data = FileManager.default.contents(atPath: filePath),
+    static func load(from path: String = CanopySettings.defaultFilePath) -> CanopySettings {
+        guard let data = FileManager.default.contents(atPath: path),
               let decoded = try? JSONDecoder().decode(CanopySettings.self, from: data) else {
             return CanopySettings()
         }
         return decoded
     }
 
-    func save() {
+    func save(to path: String = CanopySettings.defaultFilePath) {
         guard let data = try? JSONEncoder().encode(self) else { return }
-        FileManager.default.createFile(atPath: Self.filePath, contents: data)
+        FileManager.default.createFile(atPath: path, contents: data)
     }
 }

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -20,15 +20,33 @@ enum SandboxBackend: String, Codable {
     /// - `.dockerSbx`: `sbx run [sbx-flags] claude -- [claude-flags]`.
     ///   The `--` is always included so flags appended later (like `--resume`)
     ///   are passed to claude, not to sbx.
-    /// - `.appleContainer`: `container run ... [container-flags] <image> claude [claude-flags]`.
+    /// - `.appleContainer`: host-side guards, then
+    ///   `container run ... [container-flags] <image> sh -c '<settle>; exec claude [claude-flags] "$@"' claude`.
     ///   `"$PWD"` / `"$HOME"` are expanded by the shell the command is typed
     ///   into, which already runs in the worktree. The worktree is mounted at
     ///   its host path so session JSONLs land in the same
     ///   `~/.claude/projects/<munged-cwd>` directory as unsandboxed runs.
-    ///   With an empty image the command still targets `container run` --
-    ///   it fails loudly rather than silently dropping isolation.
-    func claudeCommand(claudeFlags: String, sbxFlags: String, containerImage: String, containerFlags: String) -> String {
+    ///   Details that exist for a reason:
+    ///   - The guards create `~/.claude`/`~/.claude.json` so the mounts don't
+    ///     fail on machines that never ran claude on the host.
+    ///   - `--env`: the runtime forces TERM=xterm and strips COLORTERM/LANG,
+    ///     degrading Claude Code's renderer; slim images only ship C.UTF-8.
+    ///     DISABLE_AUTOUPDATER stops claude re-downloading updates into the
+    ///     ephemeral container layer on every session.
+    ///   - The sh wrapper waits (max 5s) for the container PTY to receive a
+    ///     real window size: it briefly reads 0x0 at startup, which made
+    ///     claude lay out for 80 columns and garble the terminal. Its `"$@"`
+    ///     forwards externally appended args (`--resume`) to claude; the
+    ///     trailing `claude` word is $0.
+    ///   - With an empty image the command still targets `container run` --
+    ///     it fails loudly rather than silently dropping isolation.
+    /// `extraMountPaths`: additional host paths mounted at themselves.
+    /// Used to mount the project's MAIN repository into worktree sessions --
+    /// a worktree's `.git` file points at the main repo, so without that
+    /// mount every git operation inside the container fails.
+    func claudeCommand(claudeFlags: String, sbxFlags: String, containerImage: String, containerFlags: String, extraMountPaths: [String] = []) -> String {
         var parts: [String]
+        let flags = claudeFlags.trimmingCharacters(in: .whitespaces)
         switch self {
         case .off:
             parts = ["claude"]
@@ -40,7 +58,17 @@ enum SandboxBackend: String, Codable {
             }
             parts.append("claude --")
         case .appleContainer:
-            parts = [#"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD""#]
+            var run = #"mkdir -p "$HOME/.claude"; [ -f "$HOME/.claude.json" ] || printf '{}' > "$HOME/.claude.json"; [ -f "$HOME/.gitconfig" ] || touch "$HOME/.gitconfig"; container run -it --rm --env TERM=xterm-256color --env COLORTERM=truecolor --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 --env DISABLE_AUTOUPDATER=1 --volume "$PWD":"$PWD""#
+            for path in extraMountPaths {
+                // Mount the path git recorded: macOS /tmp-style symlinks must
+                // resolve or the in-container path won't match .git contents.
+                let resolved = Self.realResolvedPath(path)
+                if !resolved.isEmpty {
+                    run += #" --volume "\#(resolved)":"\#(resolved)""#
+                }
+            }
+            run += #" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --volume "$HOME/.gitconfig":/root/.gitconfig --workdir "$PWD""#
+            parts = [run]
             let extra = containerFlags.trimmingCharacters(in: .whitespaces)
             if !extra.isEmpty {
                 parts.append(extra)
@@ -49,13 +77,35 @@ enum SandboxBackend: String, Codable {
             if !image.isEmpty {
                 parts.append(image)
             }
-            parts.append("claude")
+            let claudeInvocation = flags.isEmpty ? "claude" : "claude \(flags)"
+            parts.append(#"sh -c 'i=0; while [ "$(stty size 2>/dev/null)" = "0 0" ] && [ $i -lt 100 ]; do sleep 0.05; i=$((i+1)); done; exec \#(claudeInvocation) "$@"' claude"#)
+            return parts.joined(separator: " ")
         }
-        let flags = claudeFlags.trimmingCharacters(in: .whitespaces)
         if !flags.isEmpty {
             parts.append(flags)
         }
         return parts.joined(separator: " ")
+    }
+
+    /// Whether a sandboxed container session may run in this directory.
+    /// Mounting $HOME (or an ancestor of it) overlaps the ~/.claude state
+    /// mounts: observed to silently drop the workdir mount -- claude sees an
+    /// empty project -- or hang the VM unkillably.
+    static func isUnsafeContainerWorkingDirectory(_ path: String, home: String = NSHomeDirectory()) -> Bool {
+        let resolved = realResolvedPath(path)
+        let resolvedHome = realResolvedPath(home)
+        if resolved == "/" { return true }
+        return resolved == resolvedHome || resolvedHome.hasPrefix(resolved + "/")
+    }
+
+    /// realpath(3): resolves symlinks the way git records paths (e.g.
+    /// /tmp -> /private/tmp). NSString.resolvingSymlinksInPath is unsuitable
+    /// here -- it strips the /private prefix instead of adding it. Returns
+    /// the input unchanged when the path doesn't exist.
+    static func realResolvedPath(_ path: String) -> String {
+        guard let resolved = realpath(path, nil) else { return path }
+        defer { free(resolved) }
+        return String(cString: resolved)
     }
 }
 
@@ -155,8 +205,11 @@ struct CanopySettings: Codable {
         terminalPath = try container.decodeIfPresent(String.self, forKey: .terminalPath) ?? "/System/Applications/Utilities/Terminal.app"
         notifyOnFinish = try container.decodeIfPresent(Bool.self, forKey: .notifyOnFinish) ?? true
         checkForUpdatesOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .checkForUpdatesOnLaunch) ?? true
-        if let backend = try container.decodeIfPresent(SandboxBackend.self, forKey: .sandboxBackend) {
-            sandboxBackend = backend
+        if let raw = try container.decodeIfPresent(String.self, forKey: .sandboxBackend) {
+            // Tolerant of unknown rawValues (config written by a newer
+            // version): throwing here would fail the whole-file decode and
+            // load()'s fallback would silently factory-reset all settings.
+            sandboxBackend = SandboxBackend(rawValue: raw) ?? .off
         } else {
             let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
             let useSandbox = try legacy.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -75,7 +75,9 @@ enum SandboxBackend: String, Codable {
             }
             let image = containerImage.trimmingCharacters(in: .whitespaces)
             if !image.isEmpty {
-                parts.append(image)
+                // One shell token: spaces/metacharacters in the user-supplied
+                // image name must not split or inject.
+                parts.append(Self.shellSingleQuoted(image))
             }
             // The invocation lives inside the wrapper's single quotes: a
             // single quote in user flags would terminate the string early
@@ -110,6 +112,13 @@ enum SandboxBackend: String, Codable {
         guard let resolved = realpath(path, nil) else { return path }
         defer { free(resolved) }
         return String(cString: resolved)
+    }
+
+    /// Wraps a user-supplied value as ONE shell token, escaping embedded
+    /// single quotes (which would otherwise terminate the quoting and leak
+    /// the rest as shell tokens).
+    static func shellSingleQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
     }
 }
 
@@ -273,6 +282,13 @@ struct CanopySettings: Codable {
             NSLog("Canopy: failed to encode settings")
             return false
         }
-        return FileManager.default.createFile(atPath: path, contents: data)
+        do {
+            // Atomic: a crash mid-write must not leave a truncated file.
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            return true
+        } catch {
+            NSLog("Canopy: failed to write %@ (%@)", path, "\(error)")
+            return false
+        }
     }
 }

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -1,5 +1,64 @@
 import Foundation
 
+/// How Claude Code sessions are isolated from the host system.
+enum SandboxBackend: String, Codable {
+    /// No isolation -- claude runs directly on the host.
+    case off
+    /// Docker Sandboxes microVM (`sbx run`). Requires Docker Desktop.
+    case dockerSbx
+    /// Apple's `container` runtime -- one lightweight VM per container.
+    /// Requires macOS 26+ on Apple silicon.
+    case appleContainer
+
+    /// Whether `--resume` works for this backend. Session JSONLs must
+    /// persist on the host: sbx microVMs are ephemeral, while the Apple
+    /// container backend bind-mounts ~/.claude from the host.
+    var supportsResume: Bool { self != .dockerSbx }
+
+    /// Builds the full command sent to the terminal for this backend.
+    ///
+    /// - `.dockerSbx`: `sbx run [sbx-flags] claude -- [claude-flags]`.
+    ///   The `--` is always included so flags appended later (like `--resume`)
+    ///   are passed to claude, not to sbx.
+    /// - `.appleContainer`: `container run ... [container-flags] <image> claude [claude-flags]`.
+    ///   `"$PWD"` / `"$HOME"` are expanded by the shell the command is typed
+    ///   into, which already runs in the worktree. The worktree is mounted at
+    ///   its host path so session JSONLs land in the same
+    ///   `~/.claude/projects/<munged-cwd>` directory as unsandboxed runs.
+    ///   With an empty image the command still targets `container run` --
+    ///   it fails loudly rather than silently dropping isolation.
+    func claudeCommand(claudeFlags: String, sbxFlags: String, containerImage: String, containerFlags: String) -> String {
+        var parts: [String]
+        switch self {
+        case .off:
+            parts = ["claude"]
+        case .dockerSbx:
+            parts = ["sbx run"]
+            let sbx = sbxFlags.trimmingCharacters(in: .whitespaces)
+            if !sbx.isEmpty {
+                parts.append(sbx)
+            }
+            parts.append("claude --")
+        case .appleContainer:
+            parts = [#"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD""#]
+            let extra = containerFlags.trimmingCharacters(in: .whitespaces)
+            if !extra.isEmpty {
+                parts.append(extra)
+            }
+            let image = containerImage.trimmingCharacters(in: .whitespaces)
+            if !image.isEmpty {
+                parts.append(image)
+            }
+            parts.append("claude")
+        }
+        let flags = claudeFlags.trimmingCharacters(in: .whitespaces)
+        if !flags.isEmpty {
+            parts.append(flags)
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
 /// App-wide settings persisted to ~/.config/canopy/settings.json.
 struct CanopySettings: Codable {
     /// Automatically run `claude` when opening a new terminal session.
@@ -25,17 +84,27 @@ struct CanopySettings: Codable {
     /// Whether to check GitHub for a newer Canopy release on launch (rate-limited to once per day).
     var checkForUpdatesOnLaunch: Bool
 
-    /// Whether to run Claude Code inside a Docker Sandbox (sbx) microVM.
-    var useSandbox: Bool
+    /// Which sandbox backend (if any) Claude Code sessions run inside.
+    var sandboxBackend: SandboxBackend
 
     /// Additional flags passed to `sbx run` (e.g. "--memory 8g").
     var sbxFlags: String
+
+    /// OCI image used by the Apple container backend (e.g. "canopy-claude").
+    /// Must contain claude, node, and git -- see docs/guide.md for a recipe.
+    var containerImage: String
+
+    /// Additional flags passed to `container run` (e.g. "--memory 8g --cpus 8").
+    var containerFlags: String
 
     /// Path to the GitHub CLI (`gh`). Used for PR status in the status bar.
     var ghPath: String
 
     /// Path to the sandbox CLI (`sbx`). Used for sandboxed sessions.
     var sbxPath: String
+
+    /// Path to Apple's `container` CLI. Used by the Apple container backend.
+    var containerPath: String
 
     var ideName: String {
         ((idePath as NSString).lastPathComponent as NSString).deletingPathExtension
@@ -45,7 +114,7 @@ struct CanopySettings: Codable {
         ((terminalPath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 
-    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, useSandbox: Bool = false, sbxFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil) {
+    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, checkForUpdatesOnLaunch: Bool = true, sandboxBackend: SandboxBackend = .off, sbxFlags: String = "", containerImage: String = "", containerFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil, containerPath: String? = nil) {
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
         self.confirmBeforeClosing = confirmBeforeClosing
@@ -53,10 +122,13 @@ struct CanopySettings: Codable {
         self.terminalPath = terminalPath
         self.notifyOnFinish = notifyOnFinish
         self.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
-        self.useSandbox = useSandbox
+        self.sandboxBackend = sandboxBackend
         self.sbxFlags = sbxFlags
+        self.containerImage = containerImage
+        self.containerFlags = containerFlags
         self.ghPath = ghPath ?? Self.detectCLI("gh")
         self.sbxPath = sbxPath ?? Self.detectCLI("sbx")
+        self.containerPath = containerPath ?? Self.detectCLI("container")
     }
 
     /// Detects a CLI tool by checking common Homebrew and system paths.
@@ -69,6 +141,11 @@ struct CanopySettings: Codable {
         return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? ""
     }
 
+    /// Key used by versions before the backend enum existed. Decode-only.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case useSandbox
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         autoStartClaude = try container.decodeIfPresent(Bool.self, forKey: .autoStartClaude) ?? true
@@ -78,39 +155,30 @@ struct CanopySettings: Codable {
         terminalPath = try container.decodeIfPresent(String.self, forKey: .terminalPath) ?? "/System/Applications/Utilities/Terminal.app"
         notifyOnFinish = try container.decodeIfPresent(Bool.self, forKey: .notifyOnFinish) ?? true
         checkForUpdatesOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .checkForUpdatesOnLaunch) ?? true
-        useSandbox = try container.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false
+        if let backend = try container.decodeIfPresent(SandboxBackend.self, forKey: .sandboxBackend) {
+            sandboxBackend = backend
+        } else {
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            let useSandbox = try legacy.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false
+            sandboxBackend = useSandbox ? .dockerSbx : .off
+        }
         sbxFlags = try container.decodeIfPresent(String.self, forKey: .sbxFlags) ?? ""
+        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? ""
+        containerFlags = try container.decodeIfPresent(String.self, forKey: .containerFlags) ?? ""
         ghPath = try container.decodeIfPresent(String.self, forKey: .ghPath) ?? Self.detectCLI("gh")
         sbxPath = try container.decodeIfPresent(String.self, forKey: .sbxPath) ?? Self.detectCLI("sbx")
+        containerPath = try container.decodeIfPresent(String.self, forKey: .containerPath) ?? Self.detectCLI("container")
     }
 
     /// The full command sent to the terminal when auto-starting.
-    ///
-    /// When sandbox mode is enabled, `--` separates sbx flags from claude flags:
-    /// `sbx run [sbx-flags] claude -- [claude-flags]`
-    /// The `--` is always included in sandbox mode so that flags appended later
-    /// (like `--resume`) are correctly passed to claude, not to sbx.
+    /// See `SandboxBackend.claudeCommand` for the per-backend shapes.
     var claudeCommand: String {
-        var parts: [String] = []
-        if useSandbox {
-            parts.append("sbx run")
-            let trimmedSbx = sbxFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmedSbx.isEmpty {
-                parts.append(trimmedSbx)
-            }
-            parts.append("claude --")
-            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        } else {
-            parts.append("claude")
-            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        }
-        return parts.joined(separator: " ")
+        sandboxBackend.claudeCommand(
+            claudeFlags: claudeFlags,
+            sbxFlags: sbxFlags,
+            containerImage: containerImage,
+            containerFlags: containerFlags
+        )
     }
 
     // MARK: - Persistence

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -40,28 +40,79 @@ struct ContainerImageBuilder {
         }
         defer { try? FileManager.default.removeItem(atPath: contextDir) }
 
+        let result = await runCapturingOutput(
+            buildCommand(tag: tag, contextDir: contextDir),
+            timeoutSeconds: 1800
+        )
+        return result.exitCode == 0 ? .success : .failure(String(result.output.suffix(500)))
+    }
+
+    /// Output accumulator usable from pipe/termination handler threads.
+    private final class OutputBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+        private(set) var timedOut = false
+
+        func append(_ chunk: Data) {
+            lock.lock(); defer { lock.unlock() }
+            data.append(chunk)
+        }
+        func markTimedOut() {
+            lock.lock(); defer { lock.unlock() }
+            timedOut = true
+        }
+        var string: String {
+            lock.lock(); defer { lock.unlock() }
+            return String(data: data, encoding: .utf8) ?? ""
+        }
+    }
+
+    /// Runs a command in a login shell, draining output WHILE it runs.
+    /// Draining only after termination deadlocks: the 64KB pipe buffer
+    /// fills (real builds easily exceed it), the child blocks writing,
+    /// never exits, and the termination handler never fires.
+    static func runCapturingOutput(_ command: String, timeoutSeconds: Double) async -> (exitCode: Int32, output: String) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
-        process.arguments = ["-ilc", buildCommand(tag: tag, contextDir: contextDir)]
+        process.arguments = ["-ilc", command]
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe
 
+        let buffer = OutputBuffer()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+            } else {
+                buffer.append(chunk)
+            }
+        }
+
+        let timeoutWork = DispatchWorkItem {
+            if process.isRunning {
+                buffer.markTimedOut()
+                process.terminate()
+            }
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWork)
+
         return await withCheckedContinuation { continuation in
             process.terminationHandler = { process in
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                if process.terminationStatus == 0 {
-                    continuation.resume(returning: .success)
-                } else {
-                    let output = String(data: data, encoding: .utf8) ?? ""
-                    continuation.resume(returning: .failure(String(output.suffix(500))))
+                timeoutWork.cancel()
+                pipe.fileHandleForReading.readabilityHandler = nil
+                if let remaining = try? pipe.fileHandleForReading.readToEnd() {
+                    buffer.append(remaining)
                 }
+                let suffix = buffer.timedOut ? "\n(command timed out after \(Int(timeoutSeconds))s)" : ""
+                continuation.resume(returning: (process.terminationStatus, buffer.string + suffix))
             }
             do {
                 try process.run()
             } catch {
                 process.terminationHandler = nil
-                continuation.resume(returning: .failure(error.localizedDescription))
+                timeoutWork.cancel()
+                continuation.resume(returning: (127, error.localizedDescription))
             }
         }
     }

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -16,10 +16,11 @@ struct ContainerImageBuilder {
     ENV PATH="/root/.local/bin:$PATH" LANG=C.UTF-8 LC_ALL=C.UTF-8 DISABLE_AUTOUPDATER=1
     """
 
-    /// Single-quoted: the tag is user input interpolated into a login-shell
-    /// command -- unquoted, spaces or metacharacters would split or inject.
+    /// Single-quoted with embedded-quote escaping: the tag is user input
+    /// interpolated into a login-shell command -- unquoted (or with a raw `'`
+    /// inside), spaces or metacharacters would split or inject.
     static func buildCommand(tag: String, contextDir: String) -> String {
-        "container build --tag '\(tag)' --file '\(contextDir)/Dockerfile' '\(contextDir)'"
+        "container build --tag \(SandboxBackend.shellSingleQuoted(tag)) --file \(SandboxBackend.shellSingleQuoted(contextDir + "/Dockerfile")) \(SandboxBackend.shellSingleQuoted(contextDir))"
     }
 
     enum BuildResult: Equatable {
@@ -137,6 +138,6 @@ struct ContainerImageBuilder {
     static func imageExists(_ name: String) async -> Bool {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return false }
-        return await SandboxChecker.succeeds("container image inspect '\(trimmed)'")
+        return await SandboxChecker.succeeds("container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))")
     }
 }

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -47,11 +47,14 @@ struct ContainerImageBuilder {
         return result.exitCode == 0 ? .success : .failure(String(result.output.suffix(500)))
     }
 
-    /// Output accumulator usable from pipe/termination handler threads.
+    /// Output accumulator + completion state usable from pipe/termination
+    /// handler threads (Process and DispatchWorkItem aren't Sendable, so the
+    /// timeout coordinates through this box instead).
     private final class OutputBuffer: @unchecked Sendable {
         private let lock = NSLock()
         private var data = Data()
         private(set) var timedOut = false
+        private var finished = false
 
         func append(_ chunk: Data) {
             lock.lock(); defer { lock.unlock() }
@@ -61,10 +64,23 @@ struct ContainerImageBuilder {
             lock.lock(); defer { lock.unlock() }
             timedOut = true
         }
+        func markFinished() {
+            lock.lock(); defer { lock.unlock() }
+            finished = true
+        }
+        var isFinished: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return finished
+        }
         var string: String {
             lock.lock(); defer { lock.unlock() }
             return String(data: data, encoding: .utf8) ?? ""
         }
+    }
+
+    private final class ProcessBox: @unchecked Sendable {
+        let process: Process
+        init(_ process: Process) { self.process = process }
     }
 
     /// Runs a command in a login shell, draining output WHILE it runs.
@@ -89,17 +105,17 @@ struct ContainerImageBuilder {
             }
         }
 
-        let timeoutWork = DispatchWorkItem {
-            if process.isRunning {
+        let box = ProcessBox(process)
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
+            if !buffer.isFinished, box.process.isRunning {
                 buffer.markTimedOut()
-                process.terminate()
+                box.process.terminate()
             }
         }
-        DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWork)
 
         return await withCheckedContinuation { continuation in
             process.terminationHandler = { process in
-                timeoutWork.cancel()
+                buffer.markFinished()
                 pipe.fileHandleForReading.readabilityHandler = nil
                 if let remaining = try? pipe.fileHandleForReading.readToEnd() {
                     buffer.append(remaining)
@@ -111,7 +127,7 @@ struct ContainerImageBuilder {
                 try process.run()
             } catch {
                 process.terminationHandler = nil
-                timeoutWork.cancel()
+                buffer.markFinished()
                 continuation.resume(returning: (127, error.localizedDescription))
             }
         }

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -13,11 +13,13 @@ struct ContainerImageBuilder {
     FROM node:22-slim
     RUN apt-get update && apt-get install -y git ripgrep curl ca-certificates && rm -rf /var/lib/apt/lists/*
     RUN curl -fsSL https://claude.ai/install.sh | bash
-    ENV PATH="/root/.local/bin:$PATH"
+    ENV PATH="/root/.local/bin:$PATH" LANG=C.UTF-8 LC_ALL=C.UTF-8 DISABLE_AUTOUPDATER=1
     """
 
+    /// Single-quoted: the tag is user input interpolated into a login-shell
+    /// command -- unquoted, spaces or metacharacters would split or inject.
     static func buildCommand(tag: String, contextDir: String) -> String {
-        "container build --tag \(tag) --file \(contextDir)/Dockerfile \(contextDir)"
+        "container build --tag '\(tag)' --file '\(contextDir)/Dockerfile' '\(contextDir)'"
     }
 
     enum BuildResult: Equatable {
@@ -68,6 +70,6 @@ struct ContainerImageBuilder {
     static func imageExists(_ name: String) async -> Bool {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return false }
-        return await SandboxChecker.succeeds("container image inspect \(trimmed)")
+        return await SandboxChecker.succeeds("container image inspect '\(trimmed)'")
     }
 }

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Builds and inspects the OCI image used by the Apple container backend.
+struct ContainerImageBuilder {
+    /// Recipe for the default sandbox image.
+    ///
+    /// Claude Code is installed with the native installer (not npm): the
+    /// host's ~/.claude.json is mounted into the container and declares
+    /// `installMethod: native`, so the in-container claude expects a binary
+    /// at /root/.local/bin/claude and reports /doctor warnings otherwise.
+    /// The node base image stays so npx-launched MCP servers can run.
+    static let dockerfile = """
+    FROM node:22-slim
+    RUN apt-get update && apt-get install -y git ripgrep curl ca-certificates && rm -rf /var/lib/apt/lists/*
+    RUN curl -fsSL https://claude.ai/install.sh | bash
+    ENV PATH="/root/.local/bin:$PATH"
+    """
+
+    static func buildCommand(tag: String, contextDir: String) -> String {
+        "container build --tag \(tag) --file \(contextDir)/Dockerfile \(contextDir)"
+    }
+
+    enum BuildResult: Equatable {
+        case success
+        case failure(String)
+    }
+
+    /// Writes the embedded Dockerfile to a temporary directory and runs
+    /// `container build`. Returns the tail of the build output on failure.
+    static func build(tag: String) async -> BuildResult {
+        let contextDir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("canopy-image-\(UUID().uuidString)")
+        do {
+            try FileManager.default.createDirectory(atPath: contextDir, withIntermediateDirectories: true)
+            try dockerfile.write(toFile: contextDir + "/Dockerfile", atomically: true, encoding: .utf8)
+        } catch {
+            return .failure("Could not write Dockerfile: \(error.localizedDescription)")
+        }
+        defer { try? FileManager.default.removeItem(atPath: contextDir) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
+        process.arguments = ["-ilc", buildCommand(tag: tag, contextDir: contextDir)]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        return await withCheckedContinuation { continuation in
+            process.terminationHandler = { process in
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                if process.terminationStatus == 0 {
+                    continuation.resume(returning: .success)
+                } else {
+                    let output = String(data: data, encoding: .utf8) ?? ""
+                    continuation.resume(returning: .failure(String(output.suffix(500))))
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                continuation.resume(returning: .failure(error.localizedDescription))
+            }
+        }
+    }
+
+    /// Returns true if the image is present in the local store.
+    static func imageExists(_ name: String) async -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        return await SandboxChecker.succeeds("container image inspect \(trimmed)")
+    }
+}

--- a/Canopy/Services/GitService.swift
+++ b/Canopy/Services/GitService.swift
@@ -61,9 +61,22 @@ struct GitService {
     }
 
     /// Checks if a branch has commits not merged into the base branch.
-    func branchHasUnmergedCommits(repoPath: String, branch: String, baseBranch: String = "main") async -> Bool {
-        let count = (try? await run(["rev-list", "--count", "\(baseBranch)..\(branch)"], in: repoPath))
-            .flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+    /// With no explicit base, detects it (main/master/develop/dev) -- the old
+    /// hardcoded "main" default made the check silently pass (rev-list fails,
+    /// count 0) on master-default repos, so users deleted unmerged work with
+    /// no warning. Failures count as "has unmerged commits": warn-side.
+    func branchHasUnmergedCommits(repoPath: String, branch: String, baseBranch explicitBase: String? = nil) async -> Bool {
+        var resolvedBase = explicitBase
+        if resolvedBase == nil {
+            resolvedBase = await baseBranch(for: branch, repoPath: repoPath)
+        }
+        guard let base = resolvedBase else {
+            return true
+        }
+        guard let count = (try? await run(["rev-list", "--count", "\(base)..\(branch)"], in: repoPath))
+            .flatMap({ Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) }) else {
+            return true
+        }
         return count > 0
     }
 
@@ -143,6 +156,16 @@ struct GitService {
         let baseOutput = try await run(["merge-base", target, source], in: repoPath)
         let mergeBase = baseOutput.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        // The merge requires checking out target in the user's main repo;
+        // put their original branch back afterwards instead of silently
+        // leaving the checkout switched.
+        let originalBranch = (try? await currentBranch(repoPath: repoPath)) ?? ""
+        func restoreOriginalBranch() async {
+            if !originalBranch.isEmpty, originalBranch != "HEAD", originalBranch != target {
+                _ = try? await run(["checkout", originalBranch], in: repoPath)
+            }
+        }
+
         // Checkout target branch
         try await run(["checkout", target], in: repoPath)
 
@@ -159,15 +182,18 @@ struct GitService {
 
             if !files.isEmpty {
                 _ = try? await run(["merge", "--abort"], in: repoPath)
+                await restoreOriginalBranch()
                 return .conflict(files: files)
             }
             // Not a conflict — re-throw
+            await restoreOriginalBranch()
             throw error
         }
 
         // Count commits that were merged using merge-base
         let countOutput = try await run(["rev-list", "--count", "\(mergeBase)..\(target)"], in: repoPath)
         let count = Int(countOutput.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+        await restoreOriginalBranch()
         return .success(commitCount: count)
     }
 

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -60,7 +60,7 @@ struct SandboxChecker {
     }
 
     /// Returns true if the given shell command exits 0 in a login shell.
-    private static func succeeds(_ command: String) async -> Bool {
+    static func succeeds(_ command: String) async -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: loginShell())
         process.arguments = ["-ilc", command]

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Checks whether Docker and the `sbx` CLI are available on the system.
+/// Checks whether the CLI tools required by a sandbox backend are available.
 ///
 /// Uses a login shell to resolve PATH so that tools installed via Homebrew
 /// or Docker Desktop are found even when running from a GUI app.
@@ -9,6 +9,24 @@ struct SandboxChecker {
         case available
         case missingDocker
         case missingSbx
+        case missingContainer
+        case containerSystemStopped
+    }
+
+    /// Checks that the given backend's tools are installed and ready.
+    static func check(backend: SandboxBackend) async -> Status {
+        switch backend {
+        case .off:
+            return .available
+        case .dockerSbx:
+            return await check()
+        case .appleContainer:
+            guard await commandExists("container") else { return .missingContainer }
+            // The runtime daemon must be started once per boot
+            // (`container system start`) before containers can run.
+            guard await succeeds("container system status") else { return .containerSystemStopped }
+            return .available
+        }
     }
 
     /// Checks for both `docker` and `sbx` in PATH.
@@ -38,9 +56,14 @@ struct SandboxChecker {
     /// Uses `-ilc` (interactive login) so that both `.zprofile` and `.zshrc` are
     /// sourced -- Homebrew's PATH is often configured in `.zshrc` only.
     static func commandExists(_ name: String) async -> Bool {
+        await succeeds("which \(name)")
+    }
+
+    /// Returns true if the given shell command exits 0 in a login shell.
+    private static func succeeds(_ command: String) async -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: loginShell())
-        process.arguments = ["-ilc", "which \(name)"]
+        process.arguments = ["-ilc", command]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         do {

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -76,6 +76,9 @@ struct SandboxChecker {
             process.waitUntilExit()
             return process.terminationStatus == 0
         } catch {
+            // Spawn failure is not the same as "tool missing", but callers
+            // can only see false -- at least leave a trace for diagnosis.
+            NSLog("Canopy: SandboxChecker could not run %@ (%@)", command, "\(error)")
             return false
         }
     }

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -11,6 +11,7 @@ struct SandboxChecker {
         case missingSbx
         case missingContainer
         case containerSystemStopped
+        case missingKernel
     }
 
     /// Checks that the given backend's tools are installed and ready.
@@ -25,6 +26,10 @@ struct SandboxChecker {
             // The runtime daemon must be started once per boot
             // (`container system start`) before containers can run.
             guard await succeeds("container system status") else { return .containerSystemStopped }
+            // `system status` exits 0 even when no default Linux kernel is
+            // installed, but `container run` then fails. The kernel symlink
+            // lives in the runtime's app root.
+            guard await succeeds(#"test -e "$HOME/Library/Application Support/com.apple.container/kernels/default.kernel-arm64""#) else { return .missingKernel }
             return .available
         }
     }

--- a/Canopy/Services/TerminalSession.swift
+++ b/Canopy/Services/TerminalSession.swift
@@ -163,6 +163,10 @@ final class TerminalSession: ObservableObject {
     }
 
     func stop() {
+        // Kill the child (shell + claude) -- without this the process keeps
+        // running (and an agent keeps working/spending) invisibly until the
+        // app quits: the pty master stays retained by the pending read.
+        terminalView?.terminate()
         terminalView = nil
         isRunning = false
     }

--- a/Canopy/Utilities/ClaudeSessionFinder.swift
+++ b/Canopy/Utilities/ClaudeSessionFinder.swift
@@ -6,8 +6,9 @@ import Foundation
 /// Claude Code stores session transcripts as JSONL files in:
 ///   ~/.claude/projects/{encoded-path}/{session-uuid}.jsonl
 ///
-/// The path encoding replaces both "/" and "." with "-".
-/// e.g. /Users/julien/my.project → -Users-julien-my-project
+/// Claude Code 2.x encodes its resolved cwd with `[^a-zA-Z0-9]` → "-"
+/// (verified against the shipped binary), e.g.
+///   /Users/julien/my_proj.v2 → -Users-julien-my-proj-v2
 ///
 /// This is the single source of truth for the encoding — `SessionCostService`
 /// and `ClaudeTranscriptLoader` route through here. If Claude Code ever
@@ -18,10 +19,17 @@ enum ClaudeSessionFinder {
     /// logs for the given working directory.
     static func projectDirectory(for directory: String) -> String {
         let expanded = (directory as NSString).expandingTildeInPath
-        let resolved = (expanded as NSString).resolvingSymlinksInPath
-        let encoded = resolved
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
+        // realpath, not NSString.resolvingSymlinksInPath: Claude encodes
+        // process.cwd(), which is /private/tmp/... for /tmp paths.
+        let resolved = SandboxBackend.realResolvedPath(expanded)
+        let encoded = String(resolved.unicodeScalars.map { scalar -> Character in
+            switch scalar {
+            case "a"..."z", "A"..."Z", "0"..."9":
+                return Character(scalar)
+            default:
+                return "-"
+            }
+        })
         let home = NSHomeDirectory()
         return "\(home)/.claude/projects/\(encoded)"
     }

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -13,12 +13,22 @@ struct AddProjectSheet: View {
     @State private var symlinkPaths = ""
     @State private var setupCommands = ""
     @State private var overrideClaude = false
-    @State private var autoStartClaude = false
-    @State private var claudeFlags = ""
-    @State private var sandboxBackend = SandboxBackend.off
-    @State private var sbxFlags = ""
+    @State private var autoStartClaude: Bool
+    @State private var claudeFlags: String
+    @State private var sandboxBackend: SandboxBackend
+    @State private var sbxFlags: String
     @State private var containerImage = ""
     @State private var containerFlags = ""
+
+    init(settings: CanopySettings) {
+        // Seed from the global values so enabling the override changes
+        // nothing until the user actually changes a field.
+        let seeds = ClaudeOverrideDefaults(project: nil, settings: settings)
+        self._autoStartClaude = State(initialValue: seeds.autoStartClaude)
+        self._claudeFlags = State(initialValue: seeds.claudeFlags)
+        self._sandboxBackend = State(initialValue: seeds.sandboxBackend)
+        self._sbxFlags = State(initialValue: seeds.sbxFlags)
+    }
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var isValidRepo = false

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -20,9 +20,12 @@ struct AddProjectSheet: View {
     @State private var containerImage = ""
     @State private var containerFlags = ""
 
+    private let globalSettings: CanopySettings
+
     init(settings: CanopySettings) {
         // Seed from the global values so enabling the override changes
         // nothing until the user actually changes a field.
+        self.globalSettings = settings
         let seeds = ClaudeOverrideDefaults(project: nil, settings: settings)
         self._autoStartClaude = State(initialValue: seeds.autoStartClaude)
         self._claudeFlags = State(initialValue: seeds.claudeFlags)
@@ -213,7 +216,7 @@ struct AddProjectSheet: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Container image")
                                     .font(.subheadline)
-                                TextField("blank = use global image", text: $containerImage)
+                                TextField("blank = use global (\(globalSettings.containerImage))", text: $containerImage)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
                                 Text("Container flags")
@@ -221,6 +224,9 @@ struct AddProjectSheet: View {
                                 TextField("blank = use global flags", text: $containerFlags)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
+                                Text("Leave blank to inherit the global values.")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
                             }
                             .padding(.leading, 16)
                         }
@@ -238,7 +244,7 @@ struct AddProjectSheet: View {
                 Spacer()
                 Button("Add Project") { addProject() }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(!isValidRepo || projectName.isEmpty)
+                    .disabled(!isValidRepo || projectName.isEmpty || checkingSandbox)
             }
         }
         .padding(20)

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -15,8 +15,10 @@ struct AddProjectSheet: View {
     @State private var overrideClaude = false
     @State private var autoStartClaude = false
     @State private var claudeFlags = ""
-    @State private var useSandbox = false
+    @State private var sandboxBackend = SandboxBackend.off
     @State private var sbxFlags = ""
+    @State private var containerImage = ""
+    @State private var containerFlags = ""
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var isValidRepo = false
@@ -152,43 +154,61 @@ struct AddProjectSheet: View {
                         }
                         .padding(.leading, 16)
 
-                        Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
-                            get: { useSandbox },
+                        Picker("Sandbox", selection: Binding(
+                            get: { sandboxBackend },
                             set: { newValue in
-                                if newValue {
+                                if newValue == .off {
+                                    sandboxBackend = .off
+                                    sandboxStatus = nil
+                                } else {
                                     checkingSandbox = true
                                     Task.detached(priority: .utility) {
-                                        let status = await SandboxChecker.check()
+                                        let status = await SandboxChecker.check(backend: newValue)
                                         await MainActor.run {
                                             sandboxStatus = status
-                                            useSandbox = status == .available
+                                            sandboxBackend = status == .available ? newValue : .off
                                             checkingSandbox = false
                                         }
                                     }
-                                } else {
-                                    useSandbox = false
-                                    sandboxStatus = nil
                                 }
                             }
-                        ))
+                        )) {
+                            Text("Off").tag(SandboxBackend.off)
+                            Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                            Text("Apple container").tag(SandboxBackend.appleContainer)
+                        }
                             .font(.subheadline)
                             .padding(.leading, 16)
                             .disabled(checkingSandbox)
 
                         if let status = sandboxStatus, status != .available {
-                            Text(status == .missingDocker
-                                ? "Docker not found. Install Docker Desktop from docker.com."
-                                : "sbx not found. Install with: brew install docker/tap/sbx")
+                            Text(SandboxBackendUI.warning(for: status))
                                 .font(.caption)
                                 .foregroundStyle(.red)
                                 .padding(.leading, 16)
                         }
 
-                        if useSandbox {
+                        if sandboxBackend == .dockerSbx {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Sandbox flags")
                                     .font(.subheadline)
                                 TextField("e.g. --memory 8g", text: $sbxFlags)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                            }
+                            .padding(.leading, 16)
+                        }
+
+                        if sandboxBackend == .appleContainer {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Container image")
+                                    .font(.subheadline)
+                                TextField("blank = use global image", text: $containerImage)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                                Text("Container flags")
+                                    .font(.subheadline)
+                                TextField("blank = use global flags", text: $containerFlags)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
                             }
@@ -263,8 +283,12 @@ struct AddProjectSheet: View {
             setupCommands: parseCommaSeparated(setupCommands),
             autoStartClaude: overrideClaude ? autoStartClaude : nil,
             claudeFlags: overrideClaude ? claudeFlags : nil,
-            useSandbox: overrideClaude ? useSandbox : nil,
-            sbxFlags: overrideClaude ? sbxFlags : nil
+            sandboxBackend: overrideClaude ? sandboxBackend : nil,
+            sbxFlags: overrideClaude ? sbxFlags : nil,
+            // Blank image/flags mean "inherit global", so store nil rather than
+            // letting an empty string override a configured global value.
+            containerImage: overrideClaude ? nilIfBlank(containerImage) : nil,
+            containerFlags: overrideClaude ? nilIfBlank(containerFlags) : nil
         )
         project.colorIndex = selectedColorIndex
         appState.addProject(project)
@@ -275,5 +299,10 @@ struct AddProjectSheet: View {
         text.split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    private func nilIfBlank(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -6,6 +6,7 @@ struct EditProjectSheet: View {
     @Environment(\.dismiss) var dismiss
 
     let project: Project
+    private let globalSettings: CanopySettings
 
     @State private var projectName: String
     @State private var filesToCopy: String
@@ -24,6 +25,7 @@ struct EditProjectSheet: View {
 
     init(project: Project, settings: CanopySettings) {
         self.project = project
+        self.globalSettings = settings
         self._projectName = State(initialValue: project.name)
         self._filesToCopy = State(initialValue: project.filesToCopy.joined(separator: ", "))
         self._symlinkPaths = State(initialValue: project.symlinkPaths.joined(separator: ", "))
@@ -192,14 +194,17 @@ struct EditProjectSheet: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Container image")
                                     .font(.subheadline)
-                                TextField("blank = use global image", text: $containerImage)
+                                TextField("blank = use global (\(globalSettings.containerImage))", text: $containerImage)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
                                 Text("Container flags")
                                     .font(.subheadline)
-                                TextField("blank = use global flags", text: $containerFlags)
+                                TextField(containerFlagsPlaceholder, text: $containerFlags)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
+                                Text("Leave blank to inherit the global values.")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
                             }
                             .padding(.leading, 16)
                         }
@@ -216,7 +221,7 @@ struct EditProjectSheet: View {
                 Spacer()
                 Button("Save") { save() }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(projectName.isEmpty)
+                    .disabled(projectName.isEmpty || checkingSandbox)
             }
         }
         .padding(20)
@@ -253,6 +258,11 @@ struct EditProjectSheet: View {
         let trimmed = text.trimmingCharacters(in: .whitespaces)
         return trimmed.isEmpty ? nil : trimmed
     }
+
+    private var containerFlagsPlaceholder: String {
+        let global = globalSettings.containerFlags.trimmingCharacters(in: .whitespaces)
+        return global.isEmpty ? "blank = use global flags" : "blank = use global (\(global))"
+    }
 }
 
 /// Shared user-facing strings for sandbox backend validation.
@@ -264,9 +274,11 @@ enum SandboxBackendUI {
         case .missingSbx:
             return "sbx not found. Install with: brew install docker/tap/sbx"
         case .missingContainer:
-            return "container not found. Requires macOS 26+ on Apple silicon -- install from github.com/apple/container."
+            return "container not found. Requires macOS 26+ on Apple silicon -- install with: brew install container"
         case .containerSystemStopped:
             return "container runtime is not running. Start it with: container system start"
+        case .missingKernel:
+            return "container runtime has no Linux kernel installed. Run: container system kernel set --recommended"
         case .available:
             return ""
         }

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -14,8 +14,10 @@ struct EditProjectSheet: View {
     @State private var overrideClaude: Bool
     @State private var autoStartClaude: Bool
     @State private var claudeFlags: String
-    @State private var useSandbox: Bool
+    @State private var sandboxBackend: SandboxBackend
     @State private var sbxFlags: String
+    @State private var containerImage: String
+    @State private var containerFlags: String
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var selectedColorIndex: Int
@@ -28,11 +30,14 @@ struct EditProjectSheet: View {
         self._setupCommands = State(initialValue: project.setupCommands.joined(separator: ", "))
         self._overrideClaude = State(initialValue:
             project.autoStartClaude != nil || project.claudeFlags != nil
-            || project.useSandbox != nil || project.sbxFlags != nil)
+            || project.sandboxBackend != nil || project.sbxFlags != nil
+            || project.containerImage != nil || project.containerFlags != nil)
         self._autoStartClaude = State(initialValue: project.autoStartClaude ?? false)
         self._claudeFlags = State(initialValue: project.claudeFlags ?? "")
-        self._useSandbox = State(initialValue: project.useSandbox ?? false)
+        self._sandboxBackend = State(initialValue: project.sandboxBackend ?? .off)
         self._sbxFlags = State(initialValue: project.sbxFlags ?? "")
+        self._containerImage = State(initialValue: project.containerImage ?? "")
+        self._containerFlags = State(initialValue: project.containerFlags ?? "")
         self._selectedColorIndex = State(initialValue: project.colorIndex ?? 0)
     }
 
@@ -135,43 +140,61 @@ struct EditProjectSheet: View {
                         }
                         .padding(.leading, 16)
 
-                        Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
-                            get: { useSandbox },
+                        Picker("Sandbox", selection: Binding(
+                            get: { sandboxBackend },
                             set: { newValue in
-                                if newValue {
+                                if newValue == .off {
+                                    sandboxBackend = .off
+                                    sandboxStatus = nil
+                                } else {
                                     checkingSandbox = true
                                     Task.detached(priority: .utility) {
-                                        let status = await SandboxChecker.check()
+                                        let status = await SandboxChecker.check(backend: newValue)
                                         await MainActor.run {
                                             sandboxStatus = status
-                                            useSandbox = status == .available
+                                            sandboxBackend = status == .available ? newValue : .off
                                             checkingSandbox = false
                                         }
                                     }
-                                } else {
-                                    useSandbox = false
-                                    sandboxStatus = nil
                                 }
                             }
-                        ))
+                        )) {
+                            Text("Off").tag(SandboxBackend.off)
+                            Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                            Text("Apple container").tag(SandboxBackend.appleContainer)
+                        }
                             .font(.subheadline)
                             .padding(.leading, 16)
                             .disabled(checkingSandbox)
 
                         if let status = sandboxStatus, status != .available {
-                            Text(status == .missingDocker
-                                ? "Docker not found. Install Docker Desktop from docker.com."
-                                : "sbx not found. Install with: brew install docker/tap/sbx")
+                            Text(SandboxBackendUI.warning(for: status))
                                 .font(.caption)
                                 .foregroundStyle(.red)
                                 .padding(.leading, 16)
                         }
 
-                        if useSandbox {
+                        if sandboxBackend == .dockerSbx {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Sandbox flags")
                                     .font(.subheadline)
                                 TextField("e.g. --memory 8g", text: $sbxFlags)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                            }
+                            .padding(.leading, 16)
+                        }
+
+                        if sandboxBackend == .appleContainer {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Container image")
+                                    .font(.subheadline)
+                                TextField("blank = use global image", text: $containerImage)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 12, design: .monospaced))
+                                Text("Container flags")
+                                    .font(.subheadline)
+                                TextField("blank = use global flags", text: $containerFlags)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.system(size: 12, design: .monospaced))
                             }
@@ -206,8 +229,12 @@ struct EditProjectSheet: View {
         updated.setupCommands = parseCSV(setupCommands)
         updated.autoStartClaude = overrideClaude ? autoStartClaude : nil
         updated.claudeFlags = overrideClaude ? claudeFlags : nil
-        updated.useSandbox = overrideClaude ? useSandbox : nil
+        updated.sandboxBackend = overrideClaude ? sandboxBackend : nil
         updated.sbxFlags = overrideClaude ? sbxFlags : nil
+        // Blank image/flags mean "inherit global", so store nil rather than
+        // letting an empty string override a configured global value.
+        updated.containerImage = overrideClaude ? nilIfBlank(containerImage) : nil
+        updated.containerFlags = overrideClaude ? nilIfBlank(containerFlags) : nil
         updated.colorIndex = selectedColorIndex
         appState.updateProject(updated)
         dismiss()
@@ -217,5 +244,28 @@ struct EditProjectSheet: View {
         text.split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    private func nilIfBlank(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// Shared user-facing strings for sandbox backend validation.
+enum SandboxBackendUI {
+    static func warning(for status: SandboxChecker.Status) -> String {
+        switch status {
+        case .missingDocker:
+            return "Docker not found. Install Docker Desktop from docker.com."
+        case .missingSbx:
+            return "sbx not found. Install with: brew install docker/tap/sbx"
+        case .missingContainer:
+            return "container not found. Requires macOS 26+ on Apple silicon -- install from github.com/apple/container."
+        case .containerSystemStopped:
+            return "container runtime is not running. Start it with: container system start"
+        case .available:
+            return ""
+        }
     }
 }

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -22,7 +22,7 @@ struct EditProjectSheet: View {
     @State private var checkingSandbox = false
     @State private var selectedColorIndex: Int
 
-    init(project: Project) {
+    init(project: Project, settings: CanopySettings) {
         self.project = project
         self._projectName = State(initialValue: project.name)
         self._filesToCopy = State(initialValue: project.filesToCopy.joined(separator: ", "))
@@ -32,10 +32,13 @@ struct EditProjectSheet: View {
             project.autoStartClaude != nil || project.claudeFlags != nil
             || project.sandboxBackend != nil || project.sbxFlags != nil
             || project.containerImage != nil || project.containerFlags != nil)
-        self._autoStartClaude = State(initialValue: project.autoStartClaude ?? false)
-        self._claudeFlags = State(initialValue: project.claudeFlags ?? "")
-        self._sandboxBackend = State(initialValue: project.sandboxBackend ?? .off)
-        self._sbxFlags = State(initialValue: project.sbxFlags ?? "")
+        // Seed from effective values so enabling the override changes
+        // nothing until the user actually changes a field.
+        let seeds = ClaudeOverrideDefaults(project: project, settings: settings)
+        self._autoStartClaude = State(initialValue: seeds.autoStartClaude)
+        self._claudeFlags = State(initialValue: seeds.claudeFlags)
+        self._sandboxBackend = State(initialValue: seeds.sandboxBackend)
+        self._sbxFlags = State(initialValue: seeds.sbxFlags)
         self._containerImage = State(initialValue: project.containerImage ?? "")
         self._containerFlags = State(initialValue: project.containerFlags ?? "")
         self._selectedColorIndex = State(initialValue: project.colorIndex ?? 0)

--- a/Canopy/Views/HelpView.swift
+++ b/Canopy/Views/HelpView.swift
@@ -93,6 +93,10 @@ struct HelpView: View {
                             "When enabled in Settings, new sessions automatically run `claude` with your configured flags. Per-project overrides available.")
                     concept("Session Resume",
                             "When opening an existing worktree, Canopy finds the last Claude session ID and passes --resume so you continue where you left off.")
+                    concept("Sandbox Backends",
+                            "Optional isolation for Claude sessions, set globally (Settings), per project, or per session (New Worktree Session sheet). Docker Sandbox runs Claude in an sbx microVM (requires Docker Desktop; no session resume). Apple container runs it in a lightweight VM via Apple's container runtime (macOS 26+, Apple silicon; resume works). Sandboxed sessions show a shield icon in the sidebar — hover it to see which backend.")
+                    concept("Sandbox Login (Apple container)",
+                            "macOS keeps Claude's credentials in the Keychain, which the Linux VM can't read. Run /login once inside your first sandboxed session — credentials persist in the mounted ~/.claude for all later sessions.")
                 }
 
                 // Config

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -184,10 +184,8 @@ struct SessionView: View {
                 let shouldStart = project?.shouldAutoStartClaude(globalSettings: appState.settings)
                     ?? appState.settings.autoStartClaude
                 if shouldStart {
-                    let backend = project?.resolvedSandboxBackend(globalSettings: appState.settings)
-                        ?? appState.settings.sandboxBackend
-                    var command = project?.resolvedClaudeCommand(globalSettings: appState.settings)
-                        ?? appState.settings.claudeCommand
+                    let backend = appState.sandboxBackend(for: session)
+                    var command = appState.claudeCommand(for: session)
                     // Resume a specific Claude session if we have its ID.
                     // Skipped for sbx -- its session files live inside the
                     // ephemeral microVM. The Apple container backend mounts

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -191,6 +191,7 @@ struct SessionView: View {
                        SandboxBackend.isUnsafeContainerWorkingDirectory(session.workingDirectory) {
                         Task { @MainActor in
                             try? await Task.sleep(for: .milliseconds(500))
+                            guard !Task.isCancelled else { return }
                             terminalSession.sendCommand(
                                 "echo '⚠️  Canopy: Apple container sessions cannot run in your home directory (or above it) -- the ~/.claude mounts would overlap. Use a project directory, or turn the sandbox off for this session.'"
                             )

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -185,6 +185,18 @@ struct SessionView: View {
                     ?? appState.settings.autoStartClaude
                 if shouldStart {
                     let backend = appState.sandboxBackend(for: session)
+                    // Mounting $HOME overlaps the ~/.claude mounts and breaks
+                    // the VM (silently empty workdir, or an unkillable hang).
+                    if backend == .appleContainer,
+                       SandboxBackend.isUnsafeContainerWorkingDirectory(session.workingDirectory) {
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(500))
+                            terminalSession.sendCommand(
+                                "echo '⚠️  Canopy: Apple container sessions cannot run in your home directory (or above it) -- the ~/.claude mounts would overlap. Use a project directory, or turn the sandbox off for this session.'"
+                            )
+                        }
+                        return
+                    }
                     var command = appState.claudeCommand(for: session)
                     // Resume a specific Claude session if we have its ID.
                     // Skipped for sbx -- its session files live inside the

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -184,12 +184,15 @@ struct SessionView: View {
                 let shouldStart = project?.shouldAutoStartClaude(globalSettings: appState.settings)
                     ?? appState.settings.autoStartClaude
                 if shouldStart {
-                    let isSandboxed = project?.useSandbox ?? appState.settings.useSandbox
+                    let backend = project?.resolvedSandboxBackend(globalSettings: appState.settings)
+                        ?? appState.settings.sandboxBackend
                     var command = project?.resolvedClaudeCommand(globalSettings: appState.settings)
                         ?? appState.settings.claudeCommand
                     // Resume a specific Claude session if we have its ID.
-                    // Skip in sandbox mode -- session files live inside the ephemeral microVM.
-                    if !isSandboxed, let sessionId = session.claudeSessionId {
+                    // Skipped for sbx -- its session files live inside the
+                    // ephemeral microVM. The Apple container backend mounts
+                    // ~/.claude from the host, so resume works there.
+                    if backend.supportsResume, let sessionId = session.claudeSessionId {
                         command += " --resume \(sessionId)"
                     }
                     Task { @MainActor in

--- a/Canopy/Views/MergeWorktreeSheet.swift
+++ b/Canopy/Views/MergeWorktreeSheet.swift
@@ -228,6 +228,16 @@ struct MergeWorktreeSheet: View {
                     return
                 }
 
+                // The merge checks out the target branch in the MAIN repo:
+                // uncommitted changes there would be dragged onto the target
+                // branch (or collide) with no warning.
+                let mainDirty = try await git.hasUncommittedChanges(repoPath: project.repositoryPath)
+                if mainDirty {
+                    errorMessage = "The main repository has uncommitted changes. Commit or stash them there first -- merging switches its checked-out branch."
+                    isMerging = false
+                    return
+                }
+
                 // Check if branch is already merged (0 commits ahead of target)
                 let ahead = try await git.commitCount(
                     from: branchName,
@@ -265,13 +275,6 @@ struct MergeWorktreeSheet: View {
         errorMessage = nil
 
         Task {
-            // Close session if active
-            if let sid = sessionId {
-                appState.performCloseSession(id: sid)
-            } else if let session = appState.sessions.first(where: { $0.worktreePath == worktreePath }) {
-                appState.performCloseSession(id: session.id)
-            }
-
             do {
                 if deleteWorktree {
                     try await git.removeWorktree(
@@ -282,6 +285,15 @@ struct MergeWorktreeSheet: View {
 
                 if deleteBranch {
                     try await git.deleteBranch(name: branchName, repoPath: project.repositoryPath)
+                }
+
+                // Close the session only after cleanup succeeded -- on a git
+                // failure the user keeps their tab instead of losing it and
+                // then seeing an error.
+                if let sid = sessionId {
+                    appState.performCloseSession(id: sid)
+                } else if let session = appState.sessions.first(where: { $0.worktreePath == worktreePath }) {
+                    appState.performCloseSession(id: session.id)
                 }
 
                 dismiss()

--- a/Canopy/Views/ProjectDetailView.swift
+++ b/Canopy/Views/ProjectDetailView.swift
@@ -430,18 +430,7 @@ struct ProjectDetailView: View {
 
     /// Creates a session in an existing worktree directory (no git worktree add).
     private func resumeWorktree(_ wt: WorktreeInfo) {
-        // Look up the most recent Claude session for this worktree
-        let sessionId = ClaudeSessionFinder.findLatestSessionId(for: wt.path)
-
-        let session = SessionInfo(
-            name: wt.branch ?? "session",
-            workingDirectory: wt.path,
-            projectId: project.id,
-            branchName: wt.branch,
-            worktreePath: wt.path,
-            claudeSessionId: sessionId
-        )
-        appState.sessions.append(session)
+        appState.openWorktreeSession(project: project, worktreePath: wt.path, branch: wt.branch)
     }
 
     // MARK: - Helpers

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -12,12 +12,15 @@ struct SettingsView: View {
     @State private var terminalPath: String
     @State private var notifyOnFinish: Bool
     @State private var checkForUpdatesOnLaunch: Bool
-    @State private var useSandbox: Bool
+    @State private var sandboxBackend: SandboxBackend
     @State private var sbxFlags: String
+    @State private var containerImage: String
+    @State private var containerFlags: String
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var ghPath: String
     @State private var sbxPath: String
+    @State private var containerPath: String
 
     init(settings: CanopySettings) {
         self._autoStartClaude = State(initialValue: settings.autoStartClaude)
@@ -27,10 +30,13 @@ struct SettingsView: View {
         self._terminalPath = State(initialValue: settings.terminalPath)
         self._notifyOnFinish = State(initialValue: settings.notifyOnFinish)
         self._checkForUpdatesOnLaunch = State(initialValue: settings.checkForUpdatesOnLaunch)
-        self._useSandbox = State(initialValue: settings.useSandbox)
+        self._sandboxBackend = State(initialValue: settings.sandboxBackend)
         self._sbxFlags = State(initialValue: settings.sbxFlags)
+        self._containerImage = State(initialValue: settings.containerImage)
+        self._containerFlags = State(initialValue: settings.containerFlags)
         self._ghPath = State(initialValue: settings.ghPath)
         self._sbxPath = State(initialValue: settings.sbxPath)
+        self._containerPath = State(initialValue: settings.containerPath)
     }
 
     var body: some View {
@@ -79,15 +85,21 @@ struct SettingsView: View {
 
                                 Divider()
 
-                                Toggle("Run in Docker Sandbox (sbx)", isOn: Binding(
-                                    get: { useSandbox },
+                                Picker("Sandbox", selection: Binding(
+                                    get: { sandboxBackend },
                                     set: { newValue in
-                                        if newValue { verifySandbox() } else {
-                                            useSandbox = false
+                                        if newValue == .off {
+                                            sandboxBackend = .off
                                             sandboxStatus = nil
+                                        } else {
+                                            verifySandbox(newValue)
                                         }
                                     }
-                                ))
+                                )) {
+                                    Text("Off").tag(SandboxBackend.off)
+                                    Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                                    Text("Apple container").tag(SandboxBackend.appleContainer)
+                                }
                                 .disabled(checkingSandbox)
 
                                 if let status = sandboxStatus, status != .available {
@@ -96,7 +108,7 @@ struct SettingsView: View {
                                         .foregroundStyle(.red)
                                 }
 
-                                if useSandbox {
+                                if sandboxBackend == .dockerSbx {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text("Sandbox flags")
                                             .font(.subheadline)
@@ -105,6 +117,36 @@ struct SettingsView: View {
                                             .textFieldStyle(.roundedBorder)
                                             .font(.system(size: 12, design: .monospaced))
                                         Text("Additional flags passed to `sbx run`.")
+                                            .font(.caption)
+                                            .foregroundStyle(.tertiary)
+                                    }
+                                }
+
+                                if sandboxBackend == .appleContainer {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Container image")
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                        TextField("e.g. canopy-claude", text: $containerImage)
+                                            .textFieldStyle(.roundedBorder)
+                                            .font(.system(size: 12, design: .monospaced))
+                                        Text("OCI image with claude, node, and git installed. See the user guide for a Dockerfile recipe.")
+                                            .font(.caption)
+                                            .foregroundStyle(.tertiary)
+                                        if containerImage.trimmingCharacters(in: .whitespaces).isEmpty {
+                                            Text("An image is required to start sandboxed sessions.")
+                                                .font(.caption)
+                                                .foregroundStyle(.red)
+                                        }
+                                    }
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Container flags")
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                        TextField("e.g. --memory 8g --cpus 8", text: $containerFlags)
+                                            .textFieldStyle(.roundedBorder)
+                                            .font(.system(size: 12, design: .monospaced))
+                                        Text("Additional flags passed to `container run`.")
                                             .font(.caption)
                                             .foregroundStyle(.tertiary)
                                     }
@@ -228,6 +270,21 @@ struct SettingsView: View {
                                     .font(.caption)
                                     .foregroundStyle(.tertiary)
                             }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Apple container CLI")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                HStack {
+                                    TextField("/usr/local/bin/container", text: $containerPath)
+                                        .textFieldStyle(.roundedBorder)
+                                        .font(.system(size: 12, design: .monospaced))
+                                    cliStatusDot(containerPath)
+                                }
+                                Text("Used by the Apple container sandbox backend.")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
                         .padding(4)
                     } label: {
@@ -267,50 +324,29 @@ struct SettingsView: View {
     }
 
     private var previewCommand: String {
-        var parts: [String] = []
-        if useSandbox {
-            parts.append("sbx run")
-            let trimmedSbx = sbxFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmedSbx.isEmpty {
-                parts.append(trimmedSbx)
-            }
-            parts.append("claude --")
-            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        } else {
-            parts.append("claude")
-            let trimmed = claudeFlags.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty {
-                parts.append(trimmed)
-            }
-        }
-        return parts.joined(separator: " ")
+        sandboxBackend.claudeCommand(
+            claudeFlags: claudeFlags,
+            sbxFlags: sbxFlags,
+            containerImage: containerImage,
+            containerFlags: containerFlags
+        )
     }
 
-    private func verifySandbox() {
+    private func verifySandbox(_ backend: SandboxBackend) {
         checkingSandbox = true
         sandboxStatus = nil
         Task.detached(priority: .utility) {
-            let status = await SandboxChecker.check()
+            let status = await SandboxChecker.check(backend: backend)
             await MainActor.run {
                 sandboxStatus = status
-                useSandbox = status == .available
+                sandboxBackend = status == .available ? backend : .off
                 checkingSandbox = false
             }
         }
     }
 
     private func sandboxWarning(for status: SandboxChecker.Status) -> String {
-        switch status {
-        case .missingDocker:
-            return "Docker not found. Install Docker Desktop from docker.com."
-        case .missingSbx:
-            return "sbx not found. Install with: brew install docker/tap/sbx"
-        case .available:
-            return ""
-        }
+        SandboxBackendUI.warning(for: status)
     }
 
     private func cliStatusDot(_ path: String) -> some View {
@@ -332,10 +368,13 @@ struct SettingsView: View {
         settings.terminalPath = terminalPath
         settings.notifyOnFinish = notifyOnFinish
         settings.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
-        settings.useSandbox = useSandbox
+        settings.sandboxBackend = sandboxBackend
         settings.sbxFlags = sbxFlags
+        settings.containerImage = containerImage
+        settings.containerFlags = containerFlags
         settings.ghPath = ghPath
         settings.sbxPath = sbxPath
+        settings.containerPath = containerPath
         settings.save()
         appState.settings = settings
         dismiss()

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @State private var imageExists: Bool?
     @State private var buildingImage = false
     @State private var buildError: String?
+    @State private var saveError: String?
     @State private var ghPath: String
     @State private var sbxPath: String
     @State private var containerPath: String
@@ -169,7 +170,11 @@ struct SettingsView: View {
                                                 .foregroundStyle(.green)
                                         }
                                     }
-                                    .task(id: sandboxBackend) { await refreshImageStatus() }
+                                    // Re-check when the image NAME changes too,
+                                    // not just the backend -- otherwise the
+                                    // found/not-found status goes blank after
+                                    // editing the field.
+                                    .task(id: "\(sandboxBackend.rawValue)|\(containerImage)") { await refreshImageStatus() }
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text("Container flags")
                                             .font(.subheadline)
@@ -347,12 +352,21 @@ struct SettingsView: View {
             HStack {
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
+                if let saveError {
+                    Text(saveError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
                 Spacer()
                 Button("Save") { save() }
                     .keyboardShortcut(.defaultAction)
                     // While a backend check is in flight the picker state is
-                    // stale; saving then would persist the old backend.
-                    .disabled(checkingSandbox)
+                    // stale; saving then would persist the old backend. An
+                    // empty image would generate a baffling `container run`
+                    // failure ("failed to pull image sh").
+                    .disabled(checkingSandbox
+                        || (sandboxBackend == .appleContainer
+                            && containerImage.trimmingCharacters(in: .whitespaces).isEmpty))
             }
         }
     }
@@ -367,6 +381,9 @@ struct SettingsView: View {
     }
 
     private func refreshImageStatus() async {
+        // Debounce keystrokes; .task(id:) cancels the previous check.
+        try? await Task.sleep(for: .milliseconds(300))
+        guard !Task.isCancelled else { return }
         let image = containerImage
         let exists = await ContainerImageBuilder.imageExists(image)
         if containerImage == image {
@@ -436,7 +453,12 @@ struct SettingsView: View {
         settings.ghPath = ghPath
         settings.sbxPath = sbxPath
         settings.containerPath = containerPath
-        settings.save()
+        // A failed write must keep the sheet open: dismissing would let the
+        // user believe their (possibly security-relevant) choice persisted.
+        guard settings.save() else {
+            saveError = "Could not write ~/.config/canopy/settings.json"
+            return
+        }
         appState.settings = settings
         dismiss()
     }

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -350,6 +350,9 @@ struct SettingsView: View {
                 Spacer()
                 Button("Save") { save() }
                     .keyboardShortcut(.defaultAction)
+                    // While a backend check is in flight the picker state is
+                    // stale; saving then would persist the old backend.
+                    .disabled(checkingSandbox)
             }
         }
     }

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
     @State private var containerFlags: String
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
+    @State private var imageExists: Bool?
+    @State private var buildingImage = false
+    @State private var buildError: String?
     @State private var ghPath: String
     @State private var sbxPath: String
     @State private var containerPath: String
@@ -127,18 +130,46 @@ struct SettingsView: View {
                                         Text("Container image")
                                             .font(.subheadline)
                                             .fontWeight(.medium)
-                                        TextField("e.g. canopy-claude", text: $containerImage)
-                                            .textFieldStyle(.roundedBorder)
-                                            .font(.system(size: 12, design: .monospaced))
-                                        Text("OCI image with claude, node, and git installed. See the user guide for a Dockerfile recipe.")
+                                        HStack {
+                                            TextField("canopy-claude", text: $containerImage)
+                                                .textFieldStyle(.roundedBorder)
+                                                .font(.system(size: 12, design: .monospaced))
+                                                .onChange(of: containerImage) { _, _ in
+                                                    imageExists = nil
+                                                    buildError = nil
+                                                }
+                                            Button(buildingImage ? "Building…" : "Build Image") {
+                                                buildImage()
+                                            }
+                                            .disabled(buildingImage || containerImage.trimmingCharacters(in: .whitespaces).isEmpty)
+                                        }
+                                        Text("OCI image with claude, node, and git installed. Build Image creates it from Canopy's built-in recipe (a few minutes on first build).")
                                             .font(.caption)
                                             .foregroundStyle(.tertiary)
                                         if containerImage.trimmingCharacters(in: .whitespaces).isEmpty {
                                             Text("An image is required to start sandboxed sessions.")
                                                 .font(.caption)
                                                 .foregroundStyle(.red)
+                                        } else if buildingImage {
+                                            Text("Building image -- this can take a few minutes…")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        } else if let error = buildError {
+                                            Text("Build failed: \(error)")
+                                                .font(.caption)
+                                                .foregroundStyle(.red)
+                                                .lineLimit(6)
+                                        } else if imageExists == false {
+                                            Text("Image not found locally. Click Build Image to create it.")
+                                                .font(.caption)
+                                                .foregroundStyle(.orange)
+                                        } else if imageExists == true {
+                                            Text("Image found locally.")
+                                                .font(.caption)
+                                                .foregroundStyle(.green)
                                         }
                                     }
+                                    .task(id: sandboxBackend) { await refreshImageStatus() }
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text("Container flags")
                                             .font(.subheadline)
@@ -330,6 +361,33 @@ struct SettingsView: View {
             containerImage: containerImage,
             containerFlags: containerFlags
         )
+    }
+
+    private func refreshImageStatus() async {
+        let image = containerImage
+        let exists = await ContainerImageBuilder.imageExists(image)
+        if containerImage == image {
+            imageExists = exists
+        }
+    }
+
+    private func buildImage() {
+        buildingImage = true
+        buildError = nil
+        let tag = containerImage.trimmingCharacters(in: .whitespaces)
+        Task.detached(priority: .utility) {
+            let result = await ContainerImageBuilder.build(tag: tag)
+            await MainActor.run {
+                buildingImage = false
+                switch result {
+                case .success:
+                    imageExists = true
+                case .failure(let output):
+                    buildError = output
+                    imageExists = false
+                }
+            }
+        }
     }
 
     private func verifySandbox(_ backend: SandboxBackend) {

--- a/Canopy/Views/Sidebar.swift
+++ b/Canopy/Views/Sidebar.swift
@@ -55,7 +55,7 @@ struct Sidebar: View {
                                 sessionRow(session)
                             }
                             .onMove { source, destination in
-                                appState.moveSession(from: source, to: destination)
+                                appState.movePlainSessions(from: source, to: destination)
                             }
                         }
                     }
@@ -231,6 +231,9 @@ struct Sidebar: View {
             }
             Button("Browse All…") { promptPickerSession = session }
         }
+        // Prompts go to the live terminal; a session that was never
+        // displayed has none, and the send would silently no-op.
+        .disabled(appState.terminalSessions[session.id] == nil)
 
         Divider()
 

--- a/Canopy/Views/Sidebar.swift
+++ b/Canopy/Views/Sidebar.swift
@@ -77,7 +77,7 @@ struct Sidebar: View {
         }
         .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
         .sheet(isPresented: $appState.showAddProjectSheet) {
-            AddProjectSheet()
+            AddProjectSheet(settings: appState.settings)
         }
         .sheet(isPresented: $appState.showNewWorktreeSheet, onDismiss: {
             appState.worktreeSheetProjectId = nil
@@ -85,7 +85,7 @@ struct Sidebar: View {
             WorktreeSheet(preselectedProjectId: appState.worktreeSheetProjectId)
         }
         .sheet(item: $editingProject) { project in
-            EditProjectSheet(project: project)
+            EditProjectSheet(project: project, settings: appState.settings)
         }
         .sheet(item: $infoSession) { session in
             SessionInfoSheet(

--- a/Canopy/Views/Sidebar.swift
+++ b/Canopy/Views/Sidebar.swift
@@ -389,11 +389,7 @@ struct Sidebar: View {
     // MARK: - Helpers
 
     private func sandboxBackend(_ session: SessionInfo) -> SandboxBackend {
-        if let projectId = session.projectId,
-           let project = appState.projects.first(where: { $0.id == projectId }) {
-            return project.resolvedSandboxBackend(globalSettings: appState.settings)
-        }
-        return appState.settings.sandboxBackend
+        appState.sandboxBackend(for: session)
     }
 
     private func projectColorFor(_ session: SessionInfo) -> Color {

--- a/Canopy/Views/Sidebar.swift
+++ b/Canopy/Views/Sidebar.swift
@@ -157,11 +157,11 @@ struct Sidebar: View {
             let diff = appState.sessionDiffStats[session.id]
             let ahead = appState.sessionCommitsAhead[session.id]
             let prs = appState.sessionPRCount[session.id]
-            let sandboxed = isSandboxed(session)
+            let backend = sandboxBackend(session)
             if let ts = appState.terminalSessions[session.id] {
-                LiveSessionRow(session: session, terminalSession: ts, projectColor: color, diffStat: diff, commitsAhead: ahead, prCount: prs, isSandboxed: sandboxed)
+                LiveSessionRow(session: session, terminalSession: ts, projectColor: color, diffStat: diff, commitsAhead: ahead, prCount: prs, sandboxBackend: backend)
             } else {
-                SidebarSessionRow(session: session, projectColor: color, diffStat: diff, commitsAhead: ahead, prCount: prs, isSandboxed: sandboxed)
+                SidebarSessionRow(session: session, projectColor: color, diffStat: diff, commitsAhead: ahead, prCount: prs, sandboxBackend: backend)
             }
 
             Spacer()
@@ -388,12 +388,12 @@ struct Sidebar: View {
 
     // MARK: - Helpers
 
-    private func isSandboxed(_ session: SessionInfo) -> Bool {
+    private func sandboxBackend(_ session: SessionInfo) -> SandboxBackend {
         if let projectId = session.projectId,
            let project = appState.projects.first(where: { $0.id == projectId }) {
-            return project.useSandbox ?? appState.settings.useSandbox
+            return project.resolvedSandboxBackend(globalSettings: appState.settings)
         }
-        return appState.settings.useSandbox
+        return appState.settings.sandboxBackend
     }
 
     private func projectColorFor(_ session: SessionInfo) -> Color {
@@ -497,7 +497,7 @@ struct LiveSessionRow: View {
     var diffStat: GitDiffStat?
     var commitsAhead: Int?
     var prCount: Int?
-    var isSandboxed: Bool = false
+    var sandboxBackend: SandboxBackend = .off
 
     var body: some View {
         SidebarSessionRow(
@@ -507,7 +507,7 @@ struct LiveSessionRow: View {
             diffStat: diffStat,
             commitsAhead: commitsAhead,
             prCount: prCount,
-            isSandboxed: isSandboxed
+            sandboxBackend: sandboxBackend
         )
     }
 }
@@ -521,7 +521,7 @@ struct SidebarSessionRow: View {
     var diffStat: GitDiffStat?
     var commitsAhead: Int?
     var prCount: Int?
-    var isSandboxed: Bool = false
+    var sandboxBackend: SandboxBackend = .off
 
     var body: some View {
         HStack(spacing: 8) {
@@ -533,11 +533,13 @@ struct SidebarSessionRow: View {
                     Text(session.name)
                         .font(.system(size: 12, weight: .medium))
                         .lineLimit(1)
-                    if isSandboxed {
+                    if sandboxBackend != .off {
                         Image(systemName: "shield.lefthalf.filled")
                             .font(.system(size: 9))
                             .foregroundStyle(.secondary)
-                            .tooltip("Running in Docker Sandbox")
+                            .tooltip(sandboxBackend == .dockerSbx
+                                ? "Running in Docker Sandbox"
+                                : "Running in Apple container")
                     }
                 }
 

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -14,6 +14,9 @@ struct WorktreeSheet: View {
     @State private var branchName = ""
     @State private var baseBranch = ""
     @State private var branches: [BranchInfo] = []
+    @State private var sandboxOverride: SandboxBackend?
+    @State private var sandboxStatus: SandboxChecker.Status?
+    @State private var checkingSandbox = false
     @State private var errorMessage: String?
     @State private var isCreating = false
 
@@ -42,7 +45,7 @@ struct WorktreeSheet: View {
             }
         }
         .padding(20)
-        .frame(width: 450, height: 380)
+        .frame(width: 450, height: 460)
         .onAppear {
             if let preId = preselectedProjectId {
                 selectedProjectId = preId
@@ -125,6 +128,44 @@ struct WorktreeSheet: View {
                     .fontWeight(.medium)
                 TextField("feat/my-feature", text: $branchName)
                     .textFieldStyle(.roundedBorder)
+            }
+
+            // Per-session sandbox override
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Sandbox")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Picker("", selection: Binding(
+                    get: { sandboxOverride },
+                    set: { newValue in
+                        guard let backend = newValue, backend != .off else {
+                            sandboxOverride = newValue
+                            sandboxStatus = nil
+                            return
+                        }
+                        checkingSandbox = true
+                        Task.detached(priority: .utility) {
+                            let status = await SandboxChecker.check(backend: backend)
+                            await MainActor.run {
+                                sandboxStatus = status
+                                sandboxOverride = status == .available ? backend : nil
+                                checkingSandbox = false
+                            }
+                        }
+                    }
+                )) {
+                    Text("Use project default").tag(SandboxBackend?.none)
+                    Text("Off").tag(SandboxBackend?.some(.off))
+                    Text("Docker Sandbox (sbx)").tag(SandboxBackend?.some(.dockerSbx))
+                    Text("Apple container").tag(SandboxBackend?.some(.appleContainer))
+                }
+                .labelsHidden()
+                .disabled(checkingSandbox)
+                if let status = sandboxStatus, status != .available {
+                    Text(SandboxBackendUI.warning(for: status))
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             }
 
             // Config summary
@@ -215,7 +256,8 @@ struct WorktreeSheet: View {
                 try await appState.createWorktreeSession(
                     project: project,
                     branchName: branchName,
-                    baseBranch: baseBranch
+                    baseBranch: baseBranch,
+                    sandboxBackend: sandboxOverride
                 )
                 await MainActor.run { dismiss() }
             } catch {

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -218,7 +218,7 @@ struct WorktreeSheet: View {
                 Spacer()
                 Button("Create Session") { createWorktree() }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(selectedProject == nil || branchName.isEmpty || baseBranch.isEmpty || isCreating)
+                    .disabled(selectedProject == nil || branchName.isEmpty || baseBranch.isEmpty || isCreating || checkingSandbox)
             }
         }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
             name: "Canopy",
             dependencies: ["SwiftTerm"],
             path: "Canopy",
-            exclude: ["App/Canopy.entitlements"],
+            // CLAUDE.md files are claude-mem plugin markers (git-ignored,
+            // also excluded in project.yml for the Xcode build).
+            // Assets.xcassets is consumed by the Xcode app build, not SPM.
+            exclude: ["App/Canopy.entitlements", "Assets.xcassets", "Models/CLAUDE.md", "Views/CLAUDE.md", "Services/CLAUDE.md"],
             swiftSettings: [
                 .swiftLanguageMode(.v5),
             ]
@@ -23,7 +26,8 @@ let package = Package(
         .testTarget(
             name: "CanopyTests",
             dependencies: ["Canopy"],
-            path: "Tests"
+            path: "Tests",
+            exclude: ["CLAUDE.md"]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -158,18 +158,15 @@ This is the feature I was most skeptical I'd use, and now I can't imagine workin
 
 ---
 
-### 🛡 Docker Sandbox — run Claude in isolation
+### 🛡 Sandboxes — run Claude in isolation
 
-Enable **Run in Docker Sandbox** in Settings or per-project to launch Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM via `sbx run`. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system — network, Docker socket, home directory, and tools are all isolated.
+Pick a sandbox backend in Settings (globally, per project, or per session in the New Worktree Session sheet) to launch Claude inside a VM. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system. A shield icon marks sandboxed sessions in the sidebar, and the split terminal still opens a host shell for inspecting the real filesystem. Canopy validates the required tools before enabling a backend.
 
-Canopy checks that both Docker Desktop and `sbx` are installed before enabling the toggle. When sandbox mode is active:
+**Docker Sandbox (sbx)** — a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM via `sbx run`. Session resume is disabled (session files live inside the ephemeral microVM).
+*Requirements:* [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
 
-- The command becomes `sbx run [sbx-flags] claude -- [claude-flags]`
-- Session resume is disabled (session files live inside the ephemeral microVM)
-- A shield icon appears next to the session name in the sidebar
-- The split terminal still opens a host shell (useful for inspecting the real filesystem)
-
-**Requirements:** [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
+**Apple container** — a lightweight VM via Apple's open-source [container](https://github.com/apple/container) runtime, no Docker Desktop needed. Canopy mounts the worktree, the project's main repo, and your `~/.claude` state at their host paths — so git works inside the sandbox and **session resume works**, unlike sbx. The default `canopy-claude` image is built in one click (**Settings → Build Image**); a one-time `/login` inside the first sandboxed session sets up credentials.
+*Requirements:* macOS 26+ on Apple silicon, `brew install container`, `container system start` once per boot. Full setup steps in the [user guide](docs/guide.md#sandbox-modes).
 
 ---
 
@@ -276,8 +273,9 @@ Every project can be configured independently from the **Add Project** sheet:
 | Worktree base directory | `~/worktrees/myproject` | Where new worktrees live (default: `../canopy-worktrees/<project>`) |
 | Auto-start Claude | on/off | Per-project override of the global default |
 | Claude flags | `--permission-mode auto` | Per-project override of the global flags |
-| Docker Sandbox | on/off | Run Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM |
+| Sandbox backend | Off / Docker Sandbox / Apple container | Run Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM or an [Apple container](https://github.com/apple/container) VM |
 | Sandbox flags | `--memory 8g` | Additional flags passed to `sbx run` |
+| Container image / flags | `canopy-claude` / `--memory 8g` | Image and extra flags for the Apple container backend |
 
 All configuration lives in `~/.config/canopy/`:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Every Canopy feature exists because I was tired of doing something manually. Eac
 | `git checkout main && git pull && git merge feat/… && git worktree remove … && git branch -d …` | Right-click → **Merge & Finish** — two panels, one button |
 | Squint at `ls ~/.claude/projects/` trying to guess how many tokens you've burned this week | Open **Activity** — token counts, session history, 12-week heatmap |
 | Type out the same "write tests", "review security", "update docs" prompt for the tenth time | Save it once in the **Prompt Library** — one right-click to fire it at any session |
+| Scroll a flickering terminal trying to re-read what Claude said ten minutes ago | Right-click → **Show Transcript** — the conversation as clean markdown, live-updating |
+| Worry about what an autonomous agent might touch outside the repo | Pick a **sandbox** — per session, per project, or globally — and Claude runs in a VM with just your worktree mounted |
 
 None of these are big problems on their own. All of them are papercuts. Canopy is a tool for people who notice papercuts.
 
@@ -145,6 +147,12 @@ If you have more than four or five sessions open, this is the fastest way to nav
 `Cmd+F` inside any session opens an incremental search over the terminal output. Matches highlight as you type. Return jumps to the next match. Shift-return jumps to the previous one. Escape closes the search.
 
 This is a small feature that turns out to matter a lot: when Claude produces a 400-line plan and you need to jump to the part about "database migration," you used to scroll. Now you don't.
+
+---
+
+### 📜 Show Transcript — read the conversation, not the terminal
+
+Right-click any session → **Show Transcript…** for a clean, scrollable, read-only view of the whole conversation. When Claude Code is running, Canopy reads its structured JSONL session log and renders user/assistant turns with markdown formatting — tool calls compacted to one-line summaries instead of walls of raw output. It live-updates as Claude streams, with an auto-tail toggle so you can read history without being yanked back down. The Copy button (`Cmd+Shift+C`) puts the formatted markdown on your clipboard — handy for PR descriptions and notes.
 
 ---
 
@@ -283,6 +291,7 @@ All configuration lives in `~/.config/canopy/`:
 - `projects.json` — project list and per-project config
 - `projects.backup.json` — automatic backup created on every launch
 - `sessions.json` — persisted sessions, restored on app restart
+- `sessions.backup.json` — automatic backup created on every launch
 - `prompts.json` — saved prompt library
 
 ---

--- a/Tests/AppStatePersistenceTests.swift
+++ b/Tests/AppStatePersistenceTests.swift
@@ -43,6 +43,39 @@ struct AppStatePersistenceTests {
         #expect(state.expandedProjects.contains(project.id))
     }
 
+    // MARK: - Reopen Existing Worktree
+
+    @Test @MainActor func openWorktreeSessionPersistsToDisk() {
+        // Reopening a worktree from the project detail view must survive an
+        // app restart -- this path used to append the session without saving.
+        let tmpDir = NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let state1 = AppState(configDir: tmpDir)
+        let project = Project(name: "test", repositoryPath: "/tmp/repo")
+        state1.projects = [project]
+        state1.openWorktreeSession(project: project, worktreePath: "/tmp/wt-x", branch: "feat/x")
+
+        #expect(state1.sessions.count == 1)
+        #expect(state1.sessions.first?.projectId == project.id)
+
+        let state2 = AppState(configDir: tmpDir)
+        state2.loadSessions()
+        #expect(state2.sessions.first?.worktreePath == "/tmp/wt-x")
+        #expect(state2.sessions.first?.branchName == "feat/x")
+    }
+
+    @Test @MainActor func openWorktreeSessionDefaultsNameWithoutBranch() {
+        let tmpDir = NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let state = AppState(configDir: tmpDir)
+        let project = Project(name: "test", repositoryPath: "/tmp/repo")
+        state.openWorktreeSession(project: project, worktreePath: "/tmp/wt-y", branch: nil)
+
+        #expect(state.sessions.first?.name == "session")
+    }
+
     // MARK: - Persistence Round-Trip
 
     @Test @MainActor func saveAndLoadProjects() {

--- a/Tests/AppStateTests.swift
+++ b/Tests/AppStateTests.swift
@@ -204,26 +204,44 @@ struct AppStateTests {
         #expect(state.sessions[2].name == "A")
     }
 
-    @Test @MainActor func moveSession() {
+    @Test @MainActor func movePlainSessions() {
         let state = AppState()
         state.createSession(name: "A", directory: "/tmp/a")
         state.createSession(name: "B", directory: "/tmp/b")
         state.createSession(name: "C", directory: "/tmp/c")
 
-        state.moveSession(from: IndexSet(integer: 2), to: 0)
+        state.movePlainSessions(from: IndexSet(integer: 2), to: 0)
 
         #expect(state.sessions.map(\.name) == ["C", "A", "B"])
     }
 
-    @Test @MainActor func moveSessionRevertsSortMode() {
+    @Test @MainActor func movePlainSessionsRevertsSortMode() {
         let state = AppState()
         state.createSession(name: "A", directory: "/tmp/a")
         state.createSession(name: "B", directory: "/tmp/b")
         state.tabSortMode = .name
 
-        state.moveSession(from: IndexSet(integer: 1), to: 0)
+        state.movePlainSessions(from: IndexSet(integer: 1), to: 0)
 
         #expect(state.tabSortMode == .manual)
+    }
+
+    @Test @MainActor func movePlainSessionsLeavesProjectSessionsInPlace() {
+        // The sidebar passes offsets into the FILTERED plain list; applying
+        // them to the full array used to move arbitrary project sessions.
+        let state = AppState()
+        let project = Project(name: "p", repositoryPath: "/tmp/p")
+        state.projects = [project]
+        var worktree = SessionInfo(name: "WT", workingDirectory: "/tmp/wt", projectId: project.id)
+        worktree.worktreePath = "/tmp/wt"
+        state.sessions = [worktree]
+        state.createSession(name: "P1", directory: "/tmp/p1")
+        state.createSession(name: "P2", directory: "/tmp/p2")
+
+        // Move plain index 1 (P2) above plain index 0 (P1)
+        state.movePlainSessions(from: IndexSet(integer: 1), to: 0)
+
+        #expect(state.sessions.map(\.name) == ["WT", "P2", "P1"])
     }
 
     @Test @MainActor func swapSessions() {

--- a/Tests/ClaudeSessionFinderTests.swift
+++ b/Tests/ClaudeSessionFinderTests.swift
@@ -14,13 +14,7 @@ struct ClaudeSessionFinderTests {
         body: () throws -> Void
     ) throws {
         let fm = FileManager.default
-        // Claude encodes paths: "/" → "-", "." → "-"
-        let expanded = (directory as NSString).expandingTildeInPath
-        let resolved = (expanded as NSString).resolvingSymlinksInPath
-        let encoded = resolved
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
-        let projectDir = "\(NSHomeDirectory())/.claude/projects/\(encoded)"
+        let projectDir = ClaudeSessionFinder.projectDirectory(for: directory)
 
         try fm.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(atPath: projectDir) }
@@ -34,6 +28,28 @@ struct ClaudeSessionFinderTests {
         }
 
         try body()
+    }
+
+    // MARK: - Encoding contract with Claude Code
+
+    @Test func encodesEveryNonAlphanumericLikeClaudeCode() {
+        // Claude Code 2.x encodes cwd with replace(/[^a-zA-Z0-9]/g, "-").
+        // Only handling "/" and "." (the old behavior) made Canopy look in a
+        // directory Claude never writes for paths containing _, spaces, etc.
+        // -- silently breaking resume, transcripts, and cost tracking.
+        let dir = ClaudeSessionFinder.projectDirectory(for: "/Users/x/my_proj.v2 (beta)")
+        #expect(dir.hasSuffix("/.claude/projects/-Users-x-my-proj-v2--beta-"))
+    }
+
+    @Test func resolvesTmpLikeClaudeCwd() throws {
+        // Claude's process.cwd() yields /private/tmp/... for /tmp paths;
+        // the encoding must match or the lookup misses.
+        let dir = "/tmp/canopy-enc-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let projectDir = ClaudeSessionFinder.projectDirectory(for: dir)
+        #expect(projectDir.contains("/.claude/projects/-private-tmp-canopy-enc-"))
     }
 
     // MARK: - Tests

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+@Suite("ContainerImageBuilder")
+struct ContainerImageBuilderTests {
+
+    @Test func dockerfileUsesNativeInstaller() {
+        // The mounted host ~/.claude.json declares installMethod "native",
+        // so the in-container claude looks for /root/.local/bin/claude.
+        // An npm-only image triggers /doctor "missing or broken" warnings.
+        #expect(ContainerImageBuilder.dockerfile.contains("https://claude.ai/install.sh"))
+        #expect(ContainerImageBuilder.dockerfile.contains(#"PATH="/root/.local/bin:$PATH""#))
+    }
+
+    @Test func dockerfileIncludesAgentEssentials() {
+        // git for commits, node base for npx-launched MCP servers.
+        #expect(ContainerImageBuilder.dockerfile.contains("FROM node:"))
+        #expect(ContainerImageBuilder.dockerfile.contains("git"))
+    }
+
+    @Test func buildCommandTargetsTagAndContext() {
+        let command = ContainerImageBuilder.buildCommand(tag: "canopy-claude", contextDir: "/tmp/ctx")
+        #expect(command == "container build --tag canopy-claude --file /tmp/ctx/Dockerfile /tmp/ctx")
+    }
+
+    @Test func imageExistsFalseForBogusImage() async {
+        // Stable on any machine: false whether the container CLI is
+        // missing or the image is simply not present.
+        let exists = await ContainerImageBuilder.imageExists("definitely-not-an-image-xyz-123")
+        #expect(exists == false)
+    }
+}

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -27,6 +27,13 @@ struct ContainerImageBuilderTests {
         #expect(command == "container build --tag 'canopy-claude' --file '/tmp/my ctx/Dockerfile' '/tmp/my ctx'")
     }
 
+    @Test func buildCommandEscapesEmbeddedSingleQuotes() {
+        // A raw ' inside the tag would terminate the quoting and leak the
+        // rest of the value as shell tokens.
+        let command = ContainerImageBuilder.buildCommand(tag: "a'b", contextDir: "/tmp/ctx")
+        #expect(command.contains(#"--tag 'a'\''b'"#))
+    }
+
     @Test func dockerfileSetsRenderingEnvironment() {
         // Sessions inherit the image env when --env flags are absent (custom
         // commands, future paths). Bake sane terminal defaults into the image

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -19,9 +19,19 @@ struct ContainerImageBuilderTests {
         #expect(ContainerImageBuilder.dockerfile.contains("git"))
     }
 
-    @Test func buildCommandTargetsTagAndContext() {
-        let command = ContainerImageBuilder.buildCommand(tag: "canopy-claude", contextDir: "/tmp/ctx")
-        #expect(command == "container build --tag canopy-claude --file /tmp/ctx/Dockerfile /tmp/ctx")
+    @Test func buildCommandQuotesTagAndContext() {
+        // The tag is user input interpolated into a login-shell command:
+        // unquoted, a space or shell metacharacter would split arguments
+        // or inject commands.
+        let command = ContainerImageBuilder.buildCommand(tag: "canopy-claude", contextDir: "/tmp/my ctx")
+        #expect(command == "container build --tag 'canopy-claude' --file '/tmp/my ctx/Dockerfile' '/tmp/my ctx'")
+    }
+
+    @Test func dockerfileSetsRenderingEnvironment() {
+        // Sessions inherit the image env when --env flags are absent (custom
+        // commands, future paths). Bake sane terminal defaults into the image
+        // too: UTF-8 locale and no self-updates into the ephemeral layer.
+        #expect(ContainerImageBuilder.dockerfile.contains("DISABLE_AUTOUPDATER=1"))
     }
 
     @Test func imageExistsFalseForBogusImage() async {

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -34,6 +34,26 @@ struct ContainerImageBuilderTests {
         #expect(ContainerImageBuilder.dockerfile.contains("DISABLE_AUTOUPDATER=1"))
     }
 
+    @Test func runCapturingOutputSurvivesLargeOutput() async {
+        // A 64KB pipe buffer blocks the child if nobody drains it while the
+        // process runs -- the old implementation read only after termination,
+        // so any real `container build` (apt-get logs alone exceed 64KB)
+        // deadlocked with the Building… spinner stuck forever.
+        let result = await ContainerImageBuilder.runCapturingOutput(
+            "i=0; while [ $i -lt 5000 ]; do echo 0123456789012345678901234567890123456789; i=$((i+1)); done; echo TAIL-MARKER",
+            timeoutSeconds: 60
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.output.count > 100_000)
+        #expect(result.output.contains("TAIL-MARKER"))
+    }
+
+    @Test func runCapturingOutputTimesOut() async {
+        let result = await ContainerImageBuilder.runCapturingOutput("sleep 60", timeoutSeconds: 2)
+        #expect(result.exitCode != 0)
+        #expect(result.output.contains("timed out"))
+    }
+
     @Test func imageExistsFalseForBogusImage() async {
         // Stable on any machine: false whether the container CLI is
         // missing or the image is simply not present.

--- a/Tests/ContainerSandboxE2ETests.swift
+++ b/Tests/ContainerSandboxE2ETests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Deep end-to-end tests: run the REAL commands Canopy generates against the
+/// real Apple container runtime and image. Gated -- they skip (visibly, as
+/// "skipped") on machines without the runtime, the daemon, or the image.
+///
+/// `-it` is stripped before running: swift test has no TTY, and
+/// `container run -it` without one fails with "Operation not supported by
+/// device". Everything else (guards, env, mounts, workdir, wrapper, image,
+/// arg forwarding) runs exactly as in the app.
+@Suite("Apple Container E2E", .serialized, .enabled(if: ContainerE2E.available))
+struct ContainerSandboxE2ETests {
+
+    @Test(.timeLimit(.minutes(3)))
+    func generatedCommandRunsClaudeInsideContainer() throws {
+        // Worktree-shaped scenario incl. a path with spaces: claude must
+        // start inside the VM with the worktree mounted at its host path.
+        let dir = try ContainerE2E.makeTempDir(name: "canopy e2e wt")
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude"
+        settings.claudeFlags = "--version"
+
+        // Appended --resume must reach claude (forwarded via "$@") without
+        // breaking the invocation.
+        let command = ContainerE2E.stripTTY(settings.claudeCommand) + " --resume bogus-e2e-id"
+        let result = ContainerE2E.run(command, in: dir)
+
+        #expect(result.exitCode == 0, "output: \(result.output.suffix(400))")
+        #expect(result.output.contains("(Claude Code)"))
+    }
+
+    @Test(.timeLimit(.minutes(3)))
+    func gitWorksInsideSandboxedWorktree() throws {
+        // A worktree's .git file points at the MAIN repo. Without the extra
+        // repo mount, every git command inside the container dies with
+        // "fatal: not a git repository". This runs the real mount layout.
+        let base = try ContainerE2E.makeTempDir(name: "canopy-e2e-git")
+        defer { try? FileManager.default.removeItem(atPath: base) }
+        let repo = base + "/main-repo"
+        let worktree = base + "/trees/feat"
+        let setup = ContainerE2E.run("""
+            mkdir -p '\(repo)' && cd '\(repo)' && git init -q -b main && \
+            git -c user.name=t -c user.email=t@t commit -q --allow-empty -m init && \
+            git worktree add -q '\(worktree)' -b feat
+            """, in: base)
+        try #require(setup.exitCode == 0, "setup failed: \(setup.output)")
+
+        let backend = SandboxBackend.appleContainer
+        let full = backend.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "canopy-claude",
+            containerFlags: "", extraMountPaths: [repo]
+        )
+        // Surgically swap the claude exec for a git probe; guards, env,
+        // mounts, workdir, image, and wrapper all stay exactly as generated.
+        let probe = ContainerE2E.stripTTY(full).replacingOccurrences(
+            of: #"exec claude "$@""#,
+            with: #"git status --porcelain >/dev/null 2>&1 && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m sandboxed && echo GIT_OK || echo GIT_FAIL"#
+        )
+        let result = ContainerE2E.run(probe, in: worktree)
+
+        #expect(result.exitCode == 0, "output: \(result.output.suffix(400))")
+        #expect(result.output.contains("GIT_OK"), "output: \(result.output.suffix(400))")
+    }
+}
+
+enum ContainerE2E {
+    /// Runtime + daemon + image all present, computed once per run.
+    static let available: Bool = {
+        run("container system status && container image inspect 'canopy-claude' >/dev/null", in: NSTemporaryDirectory()).exitCode == 0
+    }()
+
+    static func stripTTY(_ command: String) -> String {
+        command.replacingOccurrences(of: "container run -it ", with: "container run ")
+    }
+
+    static func makeTempDir(name: String) throws -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Runs a command through a login zsh in the given directory, mirroring
+    /// how Canopy's terminal sessions execute what it sends them.
+    static func run(_ command: String, in directory: String) -> (exitCode: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", command]
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+        } catch {
+            return (127, "failed to launch zsh: \(error)")
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+    }
+}

--- a/Tests/GitServiceBranchTests.swift
+++ b/Tests/GitServiceBranchTests.swift
@@ -21,6 +21,62 @@ struct GitServiceBranchTests {
         try await body(repoPath)
     }
 
+    private func withTempRepo(defaultBranch: String, _ body: (String) async throws -> Void) async throws {
+        let repoPath = NSTemporaryDirectory() + "canopy-branch-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: repoPath) }
+
+        try shell("git init -b \(defaultBranch) && git config user.email 'test@test.com' && git config user.name 'Test'", in: repoPath)
+        try "hello".write(toFile: "\(repoPath)/file.txt", atomically: true, encoding: .utf8)
+        try shell("git add -A && git commit -m 'initial'", in: repoPath)
+
+        try await body(repoPath)
+    }
+
+    // MARK: - Unmerged detection on master-default repos
+
+    @Test func unmergedCommitsDetectedOnMasterDefaultRepo() async throws {
+        // The old hardcoded baseBranch: "main" default made rev-list fail on
+        // master-default repos, count as 0, and let users delete branches
+        // with unmerged work without any warning.
+        try await withTempRepo(defaultBranch: "master") { repo in
+            try shell("git checkout -b feature && echo x > f2.txt && git add -A && git commit -m 'work'", in: repo)
+            try shell("git checkout master", in: repo)
+
+            let unmerged = await git.branchHasUnmergedCommits(repoPath: repo, branch: "feature")
+            #expect(unmerged == true)
+        }
+    }
+
+    @Test func mergedBranchReportsNoUnmergedCommits() async throws {
+        try await withTempRepo(defaultBranch: "master") { repo in
+            try shell("git checkout -b feature && echo x > f2.txt && git add -A && git commit -m 'work'", in: repo)
+            try shell("git checkout master && git merge feature", in: repo)
+
+            let unmerged = await git.branchHasUnmergedCommits(repoPath: repo, branch: "feature")
+            #expect(unmerged == false)
+        }
+    }
+
+    // MARK: - mergeInto restores the original checkout
+
+    @Test func mergeIntoRestoresOriginalBranch() async throws {
+        // The merge checks out the target in the user's MAIN repo; leaving
+        // it switched silently changed what the user had checked out.
+        try await withTempRepo { repo in
+            try shell("git checkout -b feature && echo x > f2.txt && git add -A && git commit -m 'work'", in: repo)
+            try shell("git checkout -b elsewhere main", in: repo)
+
+            let result = try await git.mergeInto(target: "main", source: "feature", repoPath: repo)
+
+            if case .success = result {} else {
+                Issue.record("expected merge success, got \(result)")
+            }
+            let current = try await git.currentBranch(repoPath: repo)
+            #expect(current == "elsewhere")
+        }
+    }
+
     // MARK: - worktreeHasChanges
 
     @Test func cleanWorktreeHasNoChanges() async throws {
@@ -84,9 +140,10 @@ struct GitServiceBranchTests {
 
     @Test func unmergedWithNonexistentBase() async throws {
         try await withTempRepo { repo in
-            // If base doesn't exist, should return false (0 from error)
+            // A failed check must warn (true), not silently clear the way
+            // for deleting a branch whose merge state is unknown.
             let hasUnmerged = await git.branchHasUnmergedCommits(repoPath: repo, branch: "main", baseBranch: "nonexistent")
-            #expect(hasUnmerged == false)
+            #expect(hasUnmerged == true)
         }
     }
 

--- a/Tests/MergeWorktreeTests.swift
+++ b/Tests/MergeWorktreeTests.swift
@@ -539,8 +539,10 @@ struct MergeWorktreeTests {
             switch result {
             case .success(let count):
                 #expect(count == 1)
+                // The repo was on feat/from-develop before the merge; the
+                // user's checkout must be restored, not left on the target.
                 let branch = try await git.currentBranch(repoPath: repo)
-                #expect(branch == "develop")
+                #expect(branch == "feat/from-develop")
             case .conflict:
                 Issue.record("Expected success")
             }

--- a/Tests/ProjectResolutionTests.swift
+++ b/Tests/ProjectResolutionTests.swift
@@ -116,7 +116,7 @@ struct ProjectResolutionTests {
 
         let command = project.resolvedClaudeCommand(globalSettings: settings)
         #expect(command.contains("container run"))
-        #expect(command.contains(#"--workdir "$PWD" project-image sh -c"#))
+        #expect(command.contains(#"--workdir "$PWD" 'project-image' sh -c"#))
         #expect(command.contains(#"exec claude --permission-mode auto "$@""#))
     }
 
@@ -131,7 +131,7 @@ struct ProjectResolutionTests {
         settings.containerFlags = "--memory 8g"
 
         let command = project.resolvedClaudeCommand(globalSettings: settings)
-        #expect(command.contains(" --memory 8g global-image sh -c"))
+        #expect(command.contains(" --memory 8g 'global-image' sh -c"))
     }
 
     @Test func claudeCommandSandboxWithResume() {

--- a/Tests/ProjectResolutionTests.swift
+++ b/Tests/ProjectResolutionTests.swift
@@ -228,6 +228,54 @@ struct ProjectResolutionTests {
         #expect(settings.claudeCommand == "sbx run claude --")
     }
 
+    // MARK: - Override Sheet Seeding
+
+    @Test func overrideDefaultsSeedFromGlobalsWhenProjectHasNoOverrides() {
+        // Enabling "Override global Claude settings" must start from the
+        // EFFECTIVE values. Seeding autoStart=false / flags="" used to write
+        // unintended overrides that silently disabled claude auto-start when
+        // the user only wanted to change the sandbox backend.
+        var settings = CanopySettings()
+        settings.autoStartClaude = true
+        settings.claudeFlags = "--permission-mode auto"
+        settings.sandboxBackend = .dockerSbx
+        settings.sbxFlags = "--memory 8g"
+        let project = Project(name: "p", repositoryPath: "/tmp")
+
+        let seeds = ClaudeOverrideDefaults(project: project, settings: settings)
+        #expect(seeds.autoStartClaude == true)
+        #expect(seeds.claudeFlags == "--permission-mode auto")
+        #expect(seeds.sandboxBackend == .dockerSbx)
+        #expect(seeds.sbxFlags == "--memory 8g")
+    }
+
+    @Test func overrideDefaultsKeepExistingProjectOverrides() {
+        var settings = CanopySettings()
+        settings.autoStartClaude = true
+        let project = Project(
+            name: "p", repositoryPath: "/tmp",
+            autoStartClaude: false,
+            claudeFlags: "--model haiku",
+            sandboxBackend: .appleContainer
+        )
+
+        let seeds = ClaudeOverrideDefaults(project: project, settings: settings)
+        #expect(seeds.autoStartClaude == false)
+        #expect(seeds.claudeFlags == "--model haiku")
+        #expect(seeds.sandboxBackend == .appleContainer)
+    }
+
+    @Test func overrideDefaultsForNewProjectUseGlobals() {
+        var settings = CanopySettings()
+        settings.autoStartClaude = false
+        settings.claudeFlags = "--verbose"
+
+        let seeds = ClaudeOverrideDefaults(project: nil, settings: settings)
+        #expect(seeds.autoStartClaude == false)
+        #expect(seeds.claudeFlags == "--verbose")
+        #expect(seeds.sandboxBackend == .off)
+    }
+
     // MARK: - Forward-Compatible Decoding
 
     @Test func decodesWithMissingOptionalFields() throws {

--- a/Tests/ProjectResolutionTests.swift
+++ b/Tests/ProjectResolutionTests.swift
@@ -114,7 +114,10 @@ struct ProjectResolutionTests {
         )
         let settings = CanopySettings()
 
-        #expect(project.resolvedClaudeCommand(globalSettings: settings) == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" project-image claude --permission-mode auto"#)
+        let command = project.resolvedClaudeCommand(globalSettings: settings)
+        #expect(command.contains("container run"))
+        #expect(command.contains(#"--workdir "$PWD" project-image sh -c"#))
+        #expect(command.contains(#"exec claude --permission-mode auto "$@""#))
     }
 
     @Test func appleContainerImageFallsBackToGlobal() {
@@ -128,7 +131,7 @@ struct ProjectResolutionTests {
         settings.containerFlags = "--memory 8g"
 
         let command = project.resolvedClaudeCommand(globalSettings: settings)
-        #expect(command.contains(" --memory 8g global-image claude "))
+        #expect(command.contains(" --memory 8g global-image sh -c"))
     }
 
     @Test func claudeCommandSandboxWithResume() {
@@ -177,7 +180,8 @@ struct ProjectResolutionTests {
             command += " --resume \(sessionId)"
         }
 
-        #expect(command.hasSuffix("claude --permission-mode auto --resume \(sessionId)"))
+        // Appended args become "$@" positionals forwarded to claude.
+        #expect(command.hasSuffix("' claude --resume \(sessionId)"))
     }
 
     @Test func sandboxResumeAppendedWhenNotSandboxed() {
@@ -317,6 +321,22 @@ struct ProjectResolutionTests {
         let project = try JSONDecoder().decode(Project.self, from: json.data(using: .utf8)!)
         #expect(project.sandboxBackend == .dockerSbx)
         #expect(project.sbxFlags == "--memory 8g")
+    }
+
+    @Test func unknownBackendRawValueDecodesAsNilWithoutLosingProject() throws {
+        // A projects.json written by a NEWER Canopy must not throw: the
+        // loader's try? fallback would silently drop ALL projects.
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "future",
+            "repositoryPath": "/repo",
+            "sandboxBackend": "futureBackend"
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: json.data(using: .utf8)!)
+        #expect(project.sandboxBackend == nil)
+        #expect(project.name == "future")
     }
 
     @Test func legacyProjectUseSandboxFalseMigratesToExplicitOff() throws {

--- a/Tests/ProjectResolutionTests.swift
+++ b/Tests/ProjectResolutionTests.swift
@@ -79,7 +79,7 @@ struct ProjectResolutionTests {
     @Test func claudeCommandSandboxFallsBackToGlobal() {
         let project = Project(name: "test", repositoryPath: "/tmp")
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
 
         #expect(project.resolvedClaudeCommand(globalSettings: settings) == "sbx run claude -- --permission-mode auto")
     }
@@ -87,10 +87,10 @@ struct ProjectResolutionTests {
     @Test func claudeCommandProjectOverridesSandbox() {
         let project = Project(
             name: "test", repositoryPath: "/tmp",
-            useSandbox: false
+            sandboxBackend: .off
         )
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
 
         #expect(project.resolvedClaudeCommand(globalSettings: settings) == "claude --permission-mode auto")
     }
@@ -98,7 +98,7 @@ struct ProjectResolutionTests {
     @Test func claudeCommandProjectEnablesSandbox() {
         let project = Project(
             name: "test", repositoryPath: "/tmp",
-            useSandbox: true,
+            sandboxBackend: .dockerSbx,
             sbxFlags: "--memory 16g"
         )
         let settings = CanopySettings()
@@ -106,9 +106,34 @@ struct ProjectResolutionTests {
         #expect(project.resolvedClaudeCommand(globalSettings: settings) == "sbx run --memory 16g claude -- --permission-mode auto")
     }
 
+    @Test func claudeCommandProjectSelectsAppleContainer() {
+        let project = Project(
+            name: "test", repositoryPath: "/tmp",
+            sandboxBackend: .appleContainer,
+            containerImage: "project-image"
+        )
+        let settings = CanopySettings()
+
+        #expect(project.resolvedClaudeCommand(globalSettings: settings) == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" project-image claude --permission-mode auto"#)
+    }
+
+    @Test func appleContainerImageFallsBackToGlobal() {
+        // Project opts into the container backend but inherits the global image.
+        let project = Project(
+            name: "test", repositoryPath: "/tmp",
+            sandboxBackend: .appleContainer
+        )
+        var settings = CanopySettings()
+        settings.containerImage = "global-image"
+        settings.containerFlags = "--memory 8g"
+
+        let command = project.resolvedClaudeCommand(globalSettings: settings)
+        #expect(command.contains(" --memory 8g global-image claude "))
+    }
+
     @Test func claudeCommandSandboxWithResume() {
         // When sandbox is on, --resume still lands after -- (passed to claude, not sbx)
-        let project = Project(name: "test", repositoryPath: "/tmp", useSandbox: true)
+        let project = Project(name: "test", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
         let settings = CanopySettings()
 
         var command = project.resolvedClaudeCommand(globalSettings: settings)
@@ -117,16 +142,16 @@ struct ProjectResolutionTests {
         #expect(command == "sbx run claude -- --permission-mode auto --resume abc-123")
     }
 
-    @Test func sandboxResumeSkippedWhenSandboxed() {
-        // Simulates MainWindow logic: --resume is not appended in sandbox mode
-        // because session files are ephemeral inside the microVM.
-        let project = Project(name: "test", repositoryPath: "/tmp", useSandbox: true)
+    @Test func sandboxResumeSkippedWhenDockerSbx() {
+        // Simulates MainWindow logic: --resume is not appended for the sbx
+        // backend because session files are ephemeral inside its microVM.
+        let project = Project(name: "test", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
         let settings = CanopySettings()
 
-        let isSandboxed = project.useSandbox ?? settings.useSandbox
+        let backend = project.resolvedSandboxBackend(globalSettings: settings)
         var command = project.resolvedClaudeCommand(globalSettings: settings)
         let sessionId = "277f18de-ba7a-440e-aaf4-66987b38f08d"
-        if !isSandboxed {
+        if backend.supportsResume {
             command += " --resume \(sessionId)"
         }
 
@@ -135,15 +160,35 @@ struct ProjectResolutionTests {
         #expect(command == "sbx run claude -- --permission-mode auto")
     }
 
+    @Test func sandboxResumeAppendedWhenAppleContainer() {
+        // Apple container sessions ARE resumable: ~/.claude is bind-mounted
+        // from the host, so session JSONLs persist across container runs.
+        let project = Project(
+            name: "test", repositoryPath: "/tmp",
+            sandboxBackend: .appleContainer,
+            containerImage: "canopy-claude"
+        )
+        let settings = CanopySettings()
+
+        let backend = project.resolvedSandboxBackend(globalSettings: settings)
+        var command = project.resolvedClaudeCommand(globalSettings: settings)
+        let sessionId = "277f18de-ba7a-440e-aaf4-66987b38f08d"
+        if backend.supportsResume {
+            command += " --resume \(sessionId)"
+        }
+
+        #expect(command.hasSuffix("claude --permission-mode auto --resume \(sessionId)"))
+    }
+
     @Test func sandboxResumeAppendedWhenNotSandboxed() {
         // Simulates MainWindow logic: --resume IS appended when not sandboxed
         let project = Project(name: "test", repositoryPath: "/tmp")
         let settings = CanopySettings()
 
-        let isSandboxed = project.useSandbox ?? settings.useSandbox
+        let backend = project.resolvedSandboxBackend(globalSettings: settings)
         var command = project.resolvedClaudeCommand(globalSettings: settings)
         let sessionId = "277f18de-ba7a-440e-aaf4-66987b38f08d"
-        if !isSandboxed {
+        if backend.supportsResume {
             command += " --resume \(sessionId)"
         }
 
@@ -152,32 +197,32 @@ struct ProjectResolutionTests {
     }
 
     @Test func sandboxResolutionProjectNilFallsToGlobal() {
-        // useSandbox == nil on project means use global setting
+        // sandboxBackend == nil on project means use global setting
         let project = Project(name: "test", repositoryPath: "/tmp")
         var settings = CanopySettings()
 
-        settings.useSandbox = false
-        #expect((project.useSandbox ?? settings.useSandbox) == false)
+        settings.sandboxBackend = .off
+        #expect(project.resolvedSandboxBackend(globalSettings: settings) == .off)
 
-        settings.useSandbox = true
-        #expect((project.useSandbox ?? settings.useSandbox) == true)
+        settings.sandboxBackend = .appleContainer
+        #expect(project.resolvedSandboxBackend(globalSettings: settings) == .appleContainer)
     }
 
     @Test func sandboxResolutionProjectOverridesGlobal() {
-        let projectOn = Project(name: "on", repositoryPath: "/tmp", useSandbox: true)
-        let projectOff = Project(name: "off", repositoryPath: "/tmp", useSandbox: false)
+        let projectOn = Project(name: "on", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
+        let projectOff = Project(name: "off", repositoryPath: "/tmp", sandboxBackend: .off)
         var settings = CanopySettings()
-        settings.useSandbox = false
+        settings.sandboxBackend = .off
 
-        #expect((projectOn.useSandbox ?? settings.useSandbox) == true)
-        #expect((projectOff.useSandbox ?? settings.useSandbox) == false)
+        #expect(projectOn.resolvedSandboxBackend(globalSettings: settings) == .dockerSbx)
+        #expect(projectOff.resolvedSandboxBackend(globalSettings: settings) == .off)
     }
 
     @Test func sandboxEmptyClaudeFlagsStillHasSeparator() {
         // Even with no claude flags, -- must be present so appended flags
         // (like --resume from MainWindow) are passed to claude, not sbx.
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
         settings.claudeFlags = ""
 
         #expect(settings.claudeCommand == "sbx run claude --")
@@ -204,8 +249,41 @@ struct ProjectResolutionTests {
         #expect(project.worktreeBaseDir == nil)
         #expect(project.autoStartClaude == nil)
         #expect(project.claudeFlags == nil)
-        #expect(project.useSandbox == nil)
+        #expect(project.sandboxBackend == nil)
         #expect(project.sbxFlags == nil)
+        #expect(project.containerImage == nil)
+        #expect(project.containerFlags == nil)
+    }
+
+    @Test func legacyProjectUseSandboxMigratesToDockerSbx() throws {
+        // Projects saved before the backend enum used a useSandbox boolean.
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "legacy",
+            "repositoryPath": "/repo",
+            "useSandbox": true,
+            "sbxFlags": "--memory 8g"
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: json.data(using: .utf8)!)
+        #expect(project.sandboxBackend == .dockerSbx)
+        #expect(project.sbxFlags == "--memory 8g")
+    }
+
+    @Test func legacyProjectUseSandboxFalseMigratesToExplicitOff() throws {
+        // useSandbox: false was an explicit per-project override (not nil),
+        // so it must stay an override after migration.
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "legacy",
+            "repositoryPath": "/repo",
+            "useSandbox": false
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: json.data(using: .utf8)!)
+        #expect(project.sandboxBackend == .off)
     }
 
     @Test func decodesWithPartialFields() throws {
@@ -236,8 +314,10 @@ struct ProjectResolutionTests {
             setupCommands: ["npm i"],
             autoStartClaude: true,
             claudeFlags: "--verbose",
-            useSandbox: true,
-            sbxFlags: "--memory 8g"
+            sandboxBackend: .dockerSbx,
+            sbxFlags: "--memory 8g",
+            containerImage: "img",
+            containerFlags: "--cpus 4"
         )
 
         let data = try JSONEncoder().encode(project)
@@ -246,7 +326,9 @@ struct ProjectResolutionTests {
         #expect(json["autoStartClaude"] as? Bool == true)
         #expect(json["claudeFlags"] as? String == "--verbose")
         #expect(json["setupCommands"] as? [String] == ["npm i"])
-        #expect(json["useSandbox"] as? Bool == true)
+        #expect(json["sandboxBackend"] as? String == "dockerSbx")
         #expect(json["sbxFlags"] as? String == "--memory 8g")
+        #expect(json["containerImage"] as? String == "img")
+        #expect(json["containerFlags"] as? String == "--cpus 4")
     }
 }

--- a/Tests/SandboxCheckerTests.swift
+++ b/Tests/SandboxCheckerTests.swift
@@ -21,5 +21,20 @@ struct SandboxCheckerTests {
         #expect(SandboxChecker.Status.missingDocker == SandboxChecker.Status.missingDocker)
         #expect(SandboxChecker.Status.missingSbx == SandboxChecker.Status.missingSbx)
         #expect(SandboxChecker.Status.missingDocker != SandboxChecker.Status.missingSbx)
+        #expect(SandboxChecker.Status.missingContainer != SandboxChecker.Status.containerSystemStopped)
+    }
+
+    @Test func checkOffNeedsNoTools() async {
+        // No backend means nothing to validate -- must not probe for CLIs.
+        let status = await SandboxChecker.check(backend: .off)
+        #expect(status == .available)
+    }
+
+    @Test func legacyCheckMatchesDockerSbxBackend() async {
+        // The original check() validated docker + sbx; the backend-aware
+        // overload must report the same thing for .dockerSbx.
+        let legacy = await SandboxChecker.check()
+        let backend = await SandboxChecker.check(backend: .dockerSbx)
+        #expect(legacy == backend)
     }
 }

--- a/Tests/SandboxCheckerTests.swift
+++ b/Tests/SandboxCheckerTests.swift
@@ -22,6 +22,7 @@ struct SandboxCheckerTests {
         #expect(SandboxChecker.Status.missingSbx == SandboxChecker.Status.missingSbx)
         #expect(SandboxChecker.Status.missingDocker != SandboxChecker.Status.missingSbx)
         #expect(SandboxChecker.Status.missingContainer != SandboxChecker.Status.containerSystemStopped)
+        #expect(SandboxChecker.Status.missingKernel != SandboxChecker.Status.containerSystemStopped)
     }
 
     @Test func checkOffNeedsNoTools() async {

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Per-session sandbox override: session → project → global resolution.
+@Suite("Per-Session Sandbox")
+@MainActor
+struct SessionSandboxTests {
+
+    @Test func sessionOverrideWinsOverProjectAndGlobal() {
+        let state = AppState()
+        state.settings.sandboxBackend = .off
+        let project = Project(name: "p", repositoryPath: "/tmp", sandboxBackend: .off)
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp",
+            projectId: project.id,
+            sandboxBackend: .appleContainer
+        )
+
+        #expect(state.sandboxBackend(for: session) == .appleContainer)
+    }
+
+    @Test func sessionWithoutOverrideFallsBackToProject() {
+        let state = AppState()
+        state.settings.sandboxBackend = .off
+        let project = Project(name: "p", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
+        state.projects = [project]
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp", projectId: project.id)
+
+        #expect(state.sandboxBackend(for: session) == .dockerSbx)
+    }
+
+    @Test func plainSessionFallsBackToGlobal() {
+        let state = AppState()
+        state.settings.sandboxBackend = .appleContainer
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp")
+
+        #expect(state.sandboxBackend(for: session) == .appleContainer)
+    }
+
+    @Test func claudeCommandUsesSessionBackendWithProjectFlags() {
+        // The override changes only the backend; flags and image still
+        // resolve through the normal project → global chain.
+        let state = AppState()
+        state.settings.sandboxBackend = .off
+        state.settings.containerImage = "global-image"
+        let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--model haiku")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp",
+            projectId: project.id,
+            sandboxBackend: .appleContainer
+        )
+
+        let command = state.claudeCommand(for: session)
+        #expect(command.hasPrefix("container run"))
+        #expect(command.hasSuffix("global-image claude --model haiku"))
+    }
+
+    @Test func claudeCommandWithoutOverrideMatchesProjectResolution() {
+        let state = AppState()
+        state.settings.sandboxBackend = .dockerSbx
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp", projectId: project.id)
+
+        #expect(state.claudeCommand(for: session)
+            == project.resolvedClaudeCommand(globalSettings: state.settings))
+    }
+
+    @Test func legacySessionDecodesWithNilBackend() throws {
+        // sessions.json entries saved before the field existed.
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "old",
+            "workingDirectory": "/tmp",
+            "createdAt": 0
+        }
+        """
+        let session = try JSONDecoder().decode(SessionInfo.self, from: json.data(using: .utf8)!)
+        #expect(session.sandboxBackend == nil)
+    }
+}

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -7,8 +7,13 @@ import Foundation
 @MainActor
 struct SessionSandboxTests {
 
+    /// Temp config dir so no test can touch the real ~/.config/canopy.
+    private func makeState() -> AppState {
+        AppState(configDir: NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)")
+    }
+
     @Test func sessionOverrideWinsOverProjectAndGlobal() {
-        let state = AppState()
+        let state = makeState()
         state.settings.sandboxBackend = .off
         let project = Project(name: "p", repositoryPath: "/tmp", sandboxBackend: .off)
         state.projects = [project]
@@ -22,7 +27,7 @@ struct SessionSandboxTests {
     }
 
     @Test func sessionWithoutOverrideFallsBackToProject() {
-        let state = AppState()
+        let state = makeState()
         state.settings.sandboxBackend = .off
         let project = Project(name: "p", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
         state.projects = [project]
@@ -32,7 +37,7 @@ struct SessionSandboxTests {
     }
 
     @Test func plainSessionFallsBackToGlobal() {
-        let state = AppState()
+        let state = makeState()
         state.settings.sandboxBackend = .appleContainer
         let session = SessionInfo(name: "s", workingDirectory: "/tmp")
 
@@ -42,7 +47,7 @@ struct SessionSandboxTests {
     @Test func claudeCommandUsesSessionBackendWithProjectFlags() {
         // The override changes only the backend; flags and image still
         // resolve through the normal project → global chain.
-        let state = AppState()
+        let state = makeState()
         state.settings.sandboxBackend = .off
         state.settings.containerImage = "global-image"
         let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--model haiku")
@@ -59,7 +64,7 @@ struct SessionSandboxTests {
     }
 
     @Test func claudeCommandWithoutOverrideMatchesProjectResolution() {
-        let state = AppState()
+        let state = makeState()
         state.settings.sandboxBackend = .dockerSbx
         let project = Project(name: "p", repositoryPath: "/tmp")
         state.projects = [project]

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -60,7 +60,7 @@ struct SessionSandboxTests {
 
         let command = state.claudeCommand(for: session)
         #expect(command.contains("container run"))
-        #expect(command.contains(" global-image sh -c"))
+        #expect(command.contains(" 'global-image' sh -c"))
         #expect(command.contains(#"exec claude --model haiku "$@""#))
     }
 

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -59,8 +59,9 @@ struct SessionSandboxTests {
         )
 
         let command = state.claudeCommand(for: session)
-        #expect(command.hasPrefix("container run"))
-        #expect(command.hasSuffix("global-image claude --model haiku"))
+        #expect(command.contains("container run"))
+        #expect(command.contains(" global-image sh -c"))
+        #expect(command.contains(#"exec claude --model haiku "$@""#))
     }
 
     @Test func claudeCommandWithoutOverrideMatchesProjectResolution() {
@@ -72,6 +73,50 @@ struct SessionSandboxTests {
 
         #expect(state.claudeCommand(for: session)
             == project.resolvedClaudeCommand(globalSettings: state.settings))
+    }
+
+    @Test func worktreeSessionMountsMainRepository() {
+        // A worktree's .git file points at the main repo: without this
+        // mount, every git command inside the container fails.
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/canopy-worktrees/repo/feat",
+            projectId: project.id,
+            worktreePath: "/Users/x/dev/canopy-worktrees/repo/feat",
+            sandboxBackend: .appleContainer
+        )
+
+        #expect(state.claudeCommand(for: session).contains(#"--volume "/Users/x/dev/repo":"/Users/x/dev/repo""#))
+    }
+
+    @Test func mainRepoSessionDoesNotDoubleMount() {
+        // When the session runs IN the main repo, $PWD already mounts it;
+        // a second identical mount risks the overlapping-mount failure.
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/repo",
+            projectId: project.id,
+            sandboxBackend: .appleContainer
+        )
+
+        #expect(!state.claudeCommand(for: session).contains(#"--volume "/Users/x/dev/repo""#))
+    }
+
+    @Test func openWorktreeSessionStoresOverride() {
+        // Reopening a worktree must be able to carry a sandbox override,
+        // like createWorktreeSession -- otherwise the override is silently
+        // dropped and claude runs with weaker isolation than chosen.
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        state.openWorktreeSession(project: project, worktreePath: "/tmp/wt", branch: "b", sandboxBackend: .appleContainer)
+
+        #expect(state.sessions.first?.sandboxBackend == .appleContainer)
+        #expect(state.sandboxBackend(for: state.sessions.first!) == .appleContainer)
     }
 
     @Test func legacySessionDecodesWithNilBackend() throws {

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -91,15 +91,32 @@ struct SessionSandboxTests {
         #expect(state.claudeCommand(for: session).contains(#"--volume "/Users/x/dev/repo":"/Users/x/dev/repo""#))
     }
 
-    @Test func mainRepoSessionDoesNotDoubleMount() {
-        // When the session runs IN the main repo, $PWD already mounts it;
-        // a second identical mount risks the overlapping-mount failure.
+    @Test func nonWorktreeSessionGetsNoRepoMount() {
+        // Plain/main-repo sessions don't need the extra mount: their .git is
+        // self-contained, and overlapping mounts break the VM.
         let state = makeState()
         let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
         state.projects = [project]
         let session = SessionInfo(
             name: "s", workingDirectory: "/Users/x/dev/repo",
             projectId: project.id,
+            sandboxBackend: .appleContainer
+        )
+
+        #expect(!state.claudeCommand(for: session).contains(#"--volume "/Users/x/dev/repo""#))
+    }
+
+    @Test func worktreeSessionAtRepoPathDoesNotDoubleMount() {
+        // Exercises the equality guard itself: worktreePath set AND equal to
+        // the repo path. $PWD already mounts it; a second identical mount
+        // risks the overlapping-mount failure.
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/repo",
+            projectId: project.id,
+            worktreePath: "/Users/x/dev/repo",
             sandboxBackend: .appleContainer
         )
 

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -186,11 +186,48 @@ struct SettingsTests {
 
     // MARK: - Sandbox (Apple container backend)
 
+    /// The full golden command. Structure, in order:
+    /// 1. Host-side guards so fresh machines (no ~/.claude yet) can mount.
+    /// 2. `container run` with env propagated: the runtime forces TERM=xterm
+    ///    and strips COLORTERM/LANG, which degrades Claude Code's renderer;
+    ///    slim images only ship the C.UTF-8 locale. DISABLE_AUTOUPDATER stops
+    ///    claude self-updating into the ephemeral container layer every run.
+    /// 3. Worktree mounted at its host path + ~/.claude state mounts.
+    /// 4. A sh wrapper that waits for the container PTY to receive its real
+    ///    window size before exec'ing claude (it briefly reads 0x0 at start,
+    ///    making claude lay out for 80 columns and garble the terminal), and
+    ///    forwards externally appended args (--resume) to claude via "$@".
     @Test func claudeCommandWithAppleContainer() {
         var settings = CanopySettings()
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "canopy-claude"
-        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" canopy-claude claude --permission-mode auto"#)
+        #expect(settings.claudeCommand == #"mkdir -p "$HOME/.claude"; [ -f "$HOME/.claude.json" ] || printf '{}' > "$HOME/.claude.json"; [ -f "$HOME/.gitconfig" ] || touch "$HOME/.gitconfig"; container run -it --rm --env TERM=xterm-256color --env COLORTERM=truecolor --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 --env DISABLE_AUTOUPDATER=1 --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --volume "$HOME/.gitconfig":/root/.gitconfig --workdir "$PWD" canopy-claude sh -c 'i=0; while [ "$(stty size 2>/dev/null)" = "0 0" ] && [ $i -lt 100 ]; do sleep 0.05; i=$((i+1)); done; exec claude --permission-mode auto "$@"' claude"#)
+    }
+
+    @Test func claudeCommandAppleContainerExtraMountsResolveSymlinks() throws {
+        // The extra mount is the worktree's MAIN repo (its .git file points
+        // there). git records the RESOLVED path, so /tmp must mount as
+        // /private/tmp or the in-container lookup fails.
+        let dir = "/tmp/canopy-mount-test-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let backend = SandboxBackend.appleContainer
+        let command = backend.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "img", containerFlags: "",
+            extraMountPaths: [dir]
+        )
+        #expect(command.contains(#"--volume "/private\#(dir)":"/private\#(dir)""#))
+    }
+
+    @Test func unsafeContainerWorkingDirectories() {
+        // $HOME (or an ancestor) overlaps the ~/.claude mounts: the workdir
+        // mount is silently dropped or the VM hangs.
+        #expect(SandboxBackend.isUnsafeContainerWorkingDirectory("/Users/x", home: "/Users/x"))
+        #expect(SandboxBackend.isUnsafeContainerWorkingDirectory("/Users", home: "/Users/x"))
+        #expect(SandboxBackend.isUnsafeContainerWorkingDirectory("/", home: "/Users/x"))
+        #expect(!SandboxBackend.isUnsafeContainerWorkingDirectory("/Users/x/dev/proj", home: "/Users/x"))
+        #expect(!SandboxBackend.isUnsafeContainerWorkingDirectory("/Users/xyz", home: "/Users/x"))
     }
 
     @Test func claudeCommandAppleContainerWithFlags() {
@@ -198,7 +235,9 @@ struct SettingsTests {
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "canopy-claude:latest"
         settings.containerFlags = "--memory 8g --cpus 8"
-        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" --memory 8g --cpus 8 canopy-claude:latest claude --permission-mode auto"#)
+        let command = settings.claudeCommand
+        // Container flags go before the image; image before the wrapper.
+        #expect(command.contains(#"--workdir "$PWD" --memory 8g --cpus 8 canopy-claude:latest sh -c"#))
     }
 
     @Test func claudeCommandAppleContainerEmptyClaudeFlags() {
@@ -206,7 +245,7 @@ struct SettingsTests {
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "canopy-claude"
         settings.claudeFlags = "   "
-        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" canopy-claude claude"#)
+        #expect(settings.claudeCommand.contains(#"exec claude "$@""#))
     }
 
     @Test func claudeCommandAppleContainerTrimsImageAndFlags() {
@@ -214,7 +253,19 @@ struct SettingsTests {
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "  canopy-claude  "
         settings.containerFlags = "  --memory 8g  "
-        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" --memory 8g canopy-claude claude --permission-mode auto"#)
+        #expect(settings.claudeCommand.contains(#"--workdir "$PWD" --memory 8g canopy-claude sh -c"#))
+    }
+
+    @Test func claudeCommandAppleContainerResumeAppendReachesClaude() {
+        // MainWindow appends " --resume <id>" to the command. The wrapper's
+        // trailing $0 word is `claude`, so appended text becomes positional
+        // args forwarded to claude via "$@" inside the container.
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude"
+        let command = settings.claudeCommand + " --resume abc-123"
+        #expect(command.hasSuffix(#"' claude --resume abc-123"#))
+        #expect(command.contains(#"exec claude --permission-mode auto "$@""#))
     }
 
     @Test func claudeCommandAppleContainerEmptyImageNeverRunsOnHost() {
@@ -224,7 +275,18 @@ struct SettingsTests {
         var settings = CanopySettings()
         settings.sandboxBackend = .appleContainer
         settings.containerImage = ""
-        #expect(settings.claudeCommand.hasPrefix("container run"))
+        #expect(settings.claudeCommand.contains("container run"))
+        #expect(!settings.claudeCommand.hasPrefix("claude"))
+    }
+
+    @Test func unknownBackendRawValueDecodesAsOffWithoutLosingOtherSettings() throws {
+        // A config written by a NEWER Canopy (with a backend this build
+        // doesn't know) must not throw: load()'s try? fallback would
+        // silently factory-reset the user's entire settings file.
+        let json = #"{"sandboxBackend": "futureBackend", "claudeFlags": "--model opus"}"#
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: json.data(using: .utf8)!)
+        #expect(decoded.sandboxBackend == .off)
+        #expect(decoded.claudeFlags == "--model opus")
     }
 
     @Test func appleContainerCodableRoundTrip() throws {

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -14,8 +14,10 @@ struct SettingsTests {
         #expect(settings.confirmBeforeClosing == true)
         #expect(settings.idePath == "/Applications/Cursor.app")
         #expect(settings.terminalPath == "/System/Applications/Utilities/Terminal.app")
-        #expect(settings.useSandbox == false)
+        #expect(settings.sandboxBackend == .off)
         #expect(settings.sbxFlags == "")
+        #expect(settings.containerImage == "")
+        #expect(settings.containerFlags == "")
     }
 
     // MARK: - Claude Command
@@ -71,7 +73,7 @@ struct SettingsTests {
         #expect(decoded.claudeFlags == "--permission-mode auto")
         #expect(decoded.confirmBeforeClosing == true)
         #expect(decoded.terminalPath == "/System/Applications/Utilities/Terminal.app")
-        #expect(decoded.useSandbox == false)
+        #expect(decoded.sandboxBackend == .off)
         #expect(decoded.sbxFlags == "")
     }
 
@@ -126,53 +128,132 @@ struct SettingsTests {
         #expect(decoded.notifyOnFinish == true)
     }
 
-    // MARK: - Sandbox
+    // MARK: - Sandbox (Docker sbx backend)
 
     @Test func claudeCommandWithSandbox() {
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
         #expect(settings.claudeCommand == "sbx run claude -- --permission-mode auto")
     }
 
     @Test func claudeCommandWithSandboxFlags() {
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
         settings.sbxFlags = "--memory 8g"
         #expect(settings.claudeCommand == "sbx run --memory 8g claude -- --permission-mode auto")
     }
 
     @Test func claudeCommandSandboxOffIgnoresSbxFlags() {
         var settings = CanopySettings()
-        settings.useSandbox = false
+        settings.sandboxBackend = .off
         settings.sbxFlags = "--memory 8g"
         #expect(settings.claudeCommand == "claude --permission-mode auto")
     }
 
     @Test func sandboxCodableRoundTrip() throws {
         var original = CanopySettings()
-        original.useSandbox = true
+        original.sandboxBackend = .dockerSbx
         original.sbxFlags = "--memory 8g"
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(CanopySettings.self, from: data)
 
-        #expect(decoded.useSandbox == true)
+        #expect(decoded.sandboxBackend == .dockerSbx)
         #expect(decoded.sbxFlags == "--memory 8g")
     }
 
     @Test func claudeCommandSandboxTrimsWhitespace() {
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
         settings.sbxFlags = "  --memory 8g  "
         #expect(settings.claudeCommand == "sbx run --memory 8g claude -- --permission-mode auto")
     }
 
     @Test func claudeCommandSandboxEmptyFlags() {
         var settings = CanopySettings()
-        settings.useSandbox = true
+        settings.sandboxBackend = .dockerSbx
         settings.sbxFlags = "   "
         settings.claudeFlags = ""
         #expect(settings.claudeCommand == "sbx run claude --")
+    }
+
+    // MARK: - Sandbox (Apple container backend)
+
+    @Test func claudeCommandWithAppleContainer() {
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude"
+        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" canopy-claude claude --permission-mode auto"#)
+    }
+
+    @Test func claudeCommandAppleContainerWithFlags() {
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude:latest"
+        settings.containerFlags = "--memory 8g --cpus 8"
+        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" --memory 8g --cpus 8 canopy-claude:latest claude --permission-mode auto"#)
+    }
+
+    @Test func claudeCommandAppleContainerEmptyClaudeFlags() {
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude"
+        settings.claudeFlags = "   "
+        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" canopy-claude claude"#)
+    }
+
+    @Test func claudeCommandAppleContainerTrimsImageAndFlags() {
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "  canopy-claude  "
+        settings.containerFlags = "  --memory 8g  "
+        #expect(settings.claudeCommand == #"container run -it --rm --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --workdir "$PWD" --memory 8g canopy-claude claude --permission-mode auto"#)
+    }
+
+    @Test func claudeCommandAppleContainerEmptyImageNeverRunsOnHost() {
+        // An empty image is a misconfiguration (the UI prevents it), but the
+        // command must still target the container runtime: silently falling
+        // back to an unsandboxed `claude` would drop isolation the user asked for.
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = ""
+        #expect(settings.claudeCommand.hasPrefix("container run"))
+    }
+
+    @Test func appleContainerCodableRoundTrip() throws {
+        var original = CanopySettings()
+        original.sandboxBackend = .appleContainer
+        original.containerImage = "canopy-claude"
+        original.containerFlags = "--memory 8g"
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: data)
+
+        #expect(decoded.sandboxBackend == .appleContainer)
+        #expect(decoded.containerImage == "canopy-claude")
+        #expect(decoded.containerFlags == "--memory 8g")
+    }
+
+    // MARK: - Legacy useSandbox Migration
+
+    @Test func legacyUseSandboxTrueMigratesToDockerSbx() throws {
+        // Settings saved before the backend enum existed used a boolean.
+        let json = #"{"useSandbox": true, "sbxFlags": "--memory 8g"}"#
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: json.data(using: .utf8)!)
+        #expect(decoded.sandboxBackend == .dockerSbx)
+        #expect(decoded.sbxFlags == "--memory 8g")
+    }
+
+    @Test func legacyUseSandboxFalseMigratesToOff() throws {
+        let json = #"{"useSandbox": false}"#
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: json.data(using: .utf8)!)
+        #expect(decoded.sandboxBackend == .off)
+    }
+
+    @Test func explicitBackendWinsOverLegacyKey() throws {
+        let json = #"{"useSandbox": true, "sandboxBackend": "appleContainer"}"#
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: json.data(using: .utf8)!)
+        #expect(decoded.sandboxBackend == .appleContainer)
     }
 
     // MARK: - Persistence

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -201,7 +201,16 @@ struct SettingsTests {
         var settings = CanopySettings()
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "canopy-claude"
-        #expect(settings.claudeCommand == #"mkdir -p "$HOME/.claude"; [ -f "$HOME/.claude.json" ] || printf '{}' > "$HOME/.claude.json"; [ -f "$HOME/.gitconfig" ] || touch "$HOME/.gitconfig"; container run -it --rm --env TERM=xterm-256color --env COLORTERM=truecolor --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 --env DISABLE_AUTOUPDATER=1 --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --volume "$HOME/.gitconfig":/root/.gitconfig --workdir "$PWD" canopy-claude sh -c 'i=0; while [ "$(stty size 2>/dev/null)" = "0 0" ] && [ $i -lt 100 ]; do sleep 0.05; i=$((i+1)); done; exec claude --permission-mode auto "$@"' claude"#)
+        #expect(settings.claudeCommand == #"mkdir -p "$HOME/.claude"; [ -f "$HOME/.claude.json" ] || printf '{}' > "$HOME/.claude.json"; [ -f "$HOME/.gitconfig" ] || touch "$HOME/.gitconfig"; container run -it --rm --env TERM=xterm-256color --env COLORTERM=truecolor --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 --env DISABLE_AUTOUPDATER=1 --volume "$PWD":"$PWD" --volume "$HOME/.claude":/root/.claude --volume "$HOME/.claude.json":/root/.claude.json --volume "$HOME/.gitconfig":/root/.gitconfig --workdir "$PWD" 'canopy-claude' sh -c 'i=0; while [ "$(stty size 2>/dev/null)" = "0 0" ] && [ $i -lt 100 ]; do sleep 0.05; i=$((i+1)); done; exec claude --permission-mode auto "$@"' claude"#)
+    }
+
+    @Test func claudeCommandQuotesImageAsSingleToken() {
+        // The image is user input appended into the shell command: spaces or
+        // metacharacters would split it into multiple tokens.
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "registry.example.com/team/image:v1"
+        #expect(settings.claudeCommand.contains(#" 'registry.example.com/team/image:v1' sh -c"#))
     }
 
     @Test func claudeCommandAppleContainerExtraMountsResolveSymlinks() throws {
@@ -237,7 +246,7 @@ struct SettingsTests {
         settings.containerFlags = "--memory 8g --cpus 8"
         let command = settings.claudeCommand
         // Container flags go before the image; image before the wrapper.
-        #expect(command.contains(#"--workdir "$PWD" --memory 8g --cpus 8 canopy-claude:latest sh -c"#))
+        #expect(command.contains(#"--workdir "$PWD" --memory 8g --cpus 8 'canopy-claude:latest' sh -c"#))
     }
 
     @Test func claudeCommandAppleContainerEmptyClaudeFlags() {
@@ -253,7 +262,7 @@ struct SettingsTests {
         settings.sandboxBackend = .appleContainer
         settings.containerImage = "  canopy-claude  "
         settings.containerFlags = "  --memory 8g  "
-        #expect(settings.claudeCommand.contains(#"--workdir "$PWD" --memory 8g canopy-claude sh -c"#))
+        #expect(settings.claudeCommand.contains(#"--workdir "$PWD" --memory 8g 'canopy-claude' sh -c"#))
     }
 
     @Test func claudeCommandAppleContainerEscapesSingleQuotesInFlags() {

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -256,6 +256,17 @@ struct SettingsTests {
         #expect(settings.claudeCommand.contains(#"--workdir "$PWD" --memory 8g canopy-claude sh -c"#))
     }
 
+    @Test func claudeCommandAppleContainerEscapesSingleQuotesInFlags() {
+        // The claude invocation lives inside the wrapper's single-quoted
+        // sh -c string: an unescaped quote in user flags would terminate it
+        // early and leak the rest as shell tokens (injection).
+        var settings = CanopySettings()
+        settings.sandboxBackend = .appleContainer
+        settings.containerImage = "canopy-claude"
+        settings.claudeFlags = "--append-system-prompt 'be nice'"
+        #expect(settings.claudeCommand.contains(#"exec claude --append-system-prompt '\''be nice'\'' "$@""#))
+    }
+
     @Test func claudeCommandAppleContainerResumeAppendReachesClaude() {
         // MainWindow appends " --resume <id>" to the command. The wrapper's
         // trailing $0 word is `claude`, so appended text becomes positional
@@ -351,5 +362,32 @@ struct SettingsTests {
         let loaded = CanopySettings.load(from: "/nonexistent/canopy/settings.json")
         #expect(loaded.claudeFlags == "--permission-mode auto")
         #expect(loaded.sandboxBackend == .off)
+    }
+
+    @Test func loadFromCorruptFileBacksItUpBeforeResetting() throws {
+        // A corrupt file must not silently flatten the user's config (which
+        // would also silently turn sandboxing OFF) -- keep the evidence.
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("canopy-settings-corrupt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = (dir as NSString).appendingPathComponent("settings.json")
+        try "{not json".write(toFile: path, atomically: true, encoding: .utf8)
+
+        let loaded = CanopySettings.load(from: path)
+
+        #expect(loaded.sandboxBackend == .off) // defaults
+        #expect(FileManager.default.fileExists(atPath: path + ".corrupt"))
+    }
+
+    @Test func saveReportsFailure() {
+        let settings = CanopySettings()
+        #expect(settings.save(to: "/nonexistent-dir-xyz/settings.json") == false)
+
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("canopy-save-ok-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        #expect(settings.save(to: (dir as NSString).appendingPathComponent("settings.json")) == true)
     }
 }

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -16,8 +16,15 @@ struct SettingsTests {
         #expect(settings.terminalPath == "/System/Applications/Utilities/Terminal.app")
         #expect(settings.sandboxBackend == .off)
         #expect(settings.sbxFlags == "")
-        #expect(settings.containerImage == "")
+        #expect(settings.containerImage == "canopy-claude")
         #expect(settings.containerFlags == "")
+    }
+
+    @Test func containerImageDefaultsWhenMissingFromJSON() throws {
+        // Users who saved settings before the field existed get the default
+        // image, so the Apple container backend works without configuration.
+        let decoded = try JSONDecoder().decode(CanopySettings.self, from: "{}".data(using: .utf8)!)
+        #expect(decoded.containerImage == "canopy-claude")
     }
 
     // MARK: - Claude Command
@@ -258,18 +265,29 @@ struct SettingsTests {
 
     // MARK: - Persistence
 
-    @Test func saveAndLoad() {
+    // Persists to a temp path: tests must never touch the user's real
+    // ~/.config/canopy/settings.json (this test used to reset it to
+    // defaults on every run).
+    @Test func saveAndLoad() throws {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("canopy-settings-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = (dir as NSString).appendingPathComponent("settings.json")
+
         var settings = CanopySettings()
         settings.autoStartClaude = true
         settings.claudeFlags = "--model haiku"
-        settings.save()
+        settings.save(to: path)
 
-        let loaded = CanopySettings.load()
+        let loaded = CanopySettings.load(from: path)
         #expect(loaded.autoStartClaude == true)
         #expect(loaded.claudeFlags == "--model haiku")
+    }
 
-        // Reset to defaults
-        var reset = CanopySettings()
-        reset.save()
+    @Test func loadFromMissingPathReturnsDefaults() {
+        let loaded = CanopySettings.load(from: "/nonexistent/canopy/settings.json")
+        #expect(loaded.claudeFlags == "--permission-mode auto")
+        #expect(loaded.sandboxBackend == .off)
     }
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -64,18 +64,20 @@ Canopy can optionally run Claude Code inside a sandbox for hard process isolatio
 
 **Apple container** runs Claude inside a lightweight VM using Apple's open-source [container](https://github.com/apple/container) runtime -- no Docker Desktop needed. Requires macOS 26+ on Apple silicon, and the runtime must be started once per boot with `container system start`.
 
-Unlike sbx, `container` is a generic runtime, so you supply the image. Build one once with `container build --tag canopy-claude --file Dockerfile .` from a Dockerfile like:
+Unlike sbx, `container` is a generic runtime, so an image is needed. The image name defaults to `canopy-claude`; click **Build Image** in Settings to create it from Canopy's built-in recipe (takes a few minutes on first build):
 
 ```dockerfile
 FROM node:22-slim
 RUN apt-get update && apt-get install -y git ripgrep curl ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN npm install -g @anthropic-ai/claude-code
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:$PATH"
 ```
 
-then enter `canopy-claude` as the container image in Settings. Canopy launches sessions with the worktree mounted at its host path and `~/.claude` mounted from the host:
+Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image with claude, node, and git installed. Canopy launches sessions with the worktree mounted at its host path and `~/.claude` mounted from the host:
 
 - **Session resume works** -- session files persist on the host via the `~/.claude` mount
 - **One-time login**: macOS stores Claude OAuth credentials in the Keychain, which the Linux container can't read. Run `/login` inside the first sandboxed session; the credentials land in the mounted `~/.claude` and persist for all later sessions
+- **MCP servers**: because your host config is mounted, MCP servers launched via `npx` work (the image includes node), but servers pointing at macOS binaries or apps won't resolve inside the Linux VM
 - Add resource flags like `--memory 8g --cpus 8` in the "Container flags" setting (defaults are 1 GB / 4 CPUs)
 
 In both modes:
@@ -251,7 +253,7 @@ Prompts are stored globally in `~/.config/canopy/prompts.json` and shared across
 | Claude flags | `--permission-mode auto` | Flags passed to the `claude` command |
 | Sandbox | Off | Backend for isolated sessions: Docker Sandbox (`sbx`, requires Docker Desktop) or Apple container (requires macOS 26+, Apple silicon) |
 | Sandbox flags | *(empty)* | Additional flags passed to `sbx run` (e.g., `--memory 8g`) |
-| Container image | *(empty)* | OCI image used by the Apple container backend (see [Sandbox modes](#sandbox-modes)) |
+| Container image | `canopy-claude` | OCI image used by the Apple container backend; **Build Image** creates it from the built-in recipe (see [Sandbox modes](#sandbox-modes)) |
 | Container flags | *(empty)* | Additional flags passed to `container run` (e.g., `--memory 8g --cpus 8`) |
 | Confirm before closing | On | Ask before closing a session |
 | IDE path | `/Applications/Cursor.app` | App used for "Open in IDE" |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -329,6 +329,7 @@ All configuration lives in `~/.config/canopy/`:
 | `projects.json` | Project list and per-project config |
 | `projects.backup.json` | Automatic backup (created on every launch) |
 | `sessions.json` | Persisted sessions, restored on app restart |
+| `sessions.backup.json` | Automatic backup (created on every launch) |
 | `prompts.json` | Saved prompt library |
 
 ## Tips

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -56,35 +56,72 @@ Session IDs are found automatically by scanning `~/.claude/projects/`.
 
 ### Sandbox modes
 
-Canopy can optionally run Claude Code inside a sandbox for hard process isolation. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system. Two backends are available in Settings:
+Canopy can optionally run Claude Code inside a sandbox for hard process isolation. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system. Two backends are available.
 
-**Docker Sandbox (sbx)** runs Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM. The command becomes `sbx run claude -- [flags]`. Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
+The backend can be set at three levels -- resolution order is **session → project → global**:
+
+| Level | Where | Notes |
+|---|---|---|
+| Global | Settings (`Cmd+,`) → Claude Code → Sandbox picker | Default for everything |
+| Per project | Edit Project → Override global Claude settings → Sandbox picker | Overrides global |
+| Per session | New Worktree Session sheet (`Cmd+Shift+T`) → Sandbox picker | Overrides both, for that session only; "Use project default" inherits |
+
+Canopy validates the required tools before enabling a backend and shows a specific fix (install command, `container system start`, kernel install) when something is missing.
+
+#### Prerequisites
+
+**Docker Sandbox (sbx)**
+- macOS with [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+- `sbx` CLI: `brew install docker/tap/sbx`
+
+**Apple container**
+- **macOS 26+ on Apple silicon only**
+- `container` CLI: `brew install container` (or the `.pkg` from [github.com/apple/container](https://github.com/apple/container/releases))
+- Start the runtime once per boot: `container system start` (or `brew services start container` to keep it running)
+- First run only: install the Linux kernel with `container system kernel set --recommended` (~16 MB download)
+- Build the sandbox image once: **Settings → Build Image** (a few minutes; creates the default `canopy-claude` image)
+- First sandboxed session only: run `/login` inside it (see below)
+
+#### Docker Sandbox (sbx)
+
+Runs Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM. The command becomes `sbx run [sbx-flags] claude -- [claude-flags]`.
 
 - **Session resume is disabled** -- session files (`~/.claude/projects/`) live inside the ephemeral microVM and don't persist across runs
 
-**Apple container** runs Claude inside a lightweight VM using Apple's open-source [container](https://github.com/apple/container) runtime -- no Docker Desktop needed. Requires macOS 26+ on Apple silicon, and the runtime must be started once per boot with `container system start`.
+#### Apple container
 
-Unlike sbx, `container` is a generic runtime, so an image is needed. The image name defaults to `canopy-claude`; click **Build Image** in Settings to create it from Canopy's built-in recipe (takes a few minutes on first build):
+Runs Claude inside a lightweight VM using Apple's open-source [container](https://github.com/apple/container) runtime -- no Docker Desktop needed.
+
+Unlike sbx, `container` is a generic runtime, so an image is needed. The image name defaults to `canopy-claude`; click **Build Image** in Settings to create it (one-time) from Canopy's built-in recipe:
 
 ```dockerfile
 FROM node:22-slim
 RUN apt-get update && apt-get install -y git ripgrep curl ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://claude.ai/install.sh | bash
-ENV PATH="/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH" LANG=C.UTF-8 LC_ALL=C.UTF-8 DISABLE_AUTOUPDATER=1
 ```
 
-Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image with claude, node, and git installed. Canopy launches sessions with the worktree mounted at its host path and `~/.claude` mounted from the host:
+Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image that has claude, node, and git installed. After a Claude Code update, click **Build Image** again to refresh the image.
 
-- **Session resume works** -- session files persist on the host via the `~/.claude` mount
-- **One-time login**: macOS stores Claude OAuth credentials in the Keychain, which the Linux container can't read. Run `/login` inside the first sandboxed session; the credentials land in the mounted `~/.claude` and persist for all later sessions
+What Canopy mounts into the VM (all at their host paths, so everything lines up):
+
+- **Your worktree** (`$PWD`) -- file edits land directly in the worktree
+- **The project's main repository** (worktree sessions only) -- a worktree's `.git` file points at the main repo, so git inside the sandbox would be broken without it
+- **`~/.claude/` and `~/.claude.json`** -- Claude state lives on the host, which is why **session resume, Show Transcript, and `--resume` all work** (unlike sbx)
+- **`~/.gitconfig`** -- so commits inside the sandbox have your git identity
+
+Things to know:
+
+- **One-time login**: macOS stores Claude OAuth credentials in the Keychain, which the Linux VM can't read. Run `/login` inside the first sandboxed session; the credentials land in the mounted `~/.claude` and persist for all later sessions
+- **Resources**: the VM defaults to 1 GB RAM / 4 CPUs, which is tight for real builds. Put `--memory 8g --cpus 8` in the "Container flags" setting
 - **MCP servers**: because your host config is mounted, MCP servers launched via `npx` work (the image includes node), but servers pointing at macOS binaries or apps won't resolve inside the Linux VM
-- Add resource flags like `--memory 8g --cpus 8` in the "Container flags" setting (defaults are 1 GB / 4 CPUs)
+- **Home-directory sessions are blocked**: a sandboxed session can't run in `~` (or above it) -- that mount would overlap the `~/.claude` mounts, which the runtime can't handle. Use a project directory, or turn the sandbox off for that session
+- **Terminal rendering**: Canopy passes `TERM`, `COLORTERM`, and a UTF-8 locale into the VM and waits for the VM's terminal to pick up the real window size before starting claude -- without this, output renders garbled
 
-In both modes:
+#### In both modes
+
 - **A shield icon** appears next to the session name in the sidebar (hover to see which backend)
 - **The split terminal** still opens a host shell (not sandboxed), which is useful for inspecting the real filesystem
-
-The backend can be set globally (Settings), per project (project edit sheet), or per session: the New Worktree Session sheet has a Sandbox picker that overrides both for that session only. Canopy validates the required tools are installed before enabling a backend.
 
 ## Workflows
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -54,16 +54,35 @@ When Canopy creates or opens a session, it can auto-start Claude Code with your 
 
 Session IDs are found automatically by scanning `~/.claude/projects/`.
 
-### Docker Sandbox mode
+### Sandbox modes
 
-Canopy can optionally run Claude Code inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM for hard process isolation. When enabled, the command becomes `sbx run claude -- [flags]` instead of `claude [flags]`. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system.
+Canopy can optionally run Claude Code inside a sandbox for hard process isolation. Your working directory is bind-mounted into the sandbox, so file edits work normally, but the agent can't touch the rest of your system. Two backends are available in Settings:
 
-Key behaviors in sandbox mode:
+**Docker Sandbox (sbx)** runs Claude inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM. The command becomes `sbx run claude -- [flags]`. Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
+
 - **Session resume is disabled** -- session files (`~/.claude/projects/`) live inside the ephemeral microVM and don't persist across runs
-- **A shield icon** appears next to the session name in the sidebar
+
+**Apple container** runs Claude inside a lightweight VM using Apple's open-source [container](https://github.com/apple/container) runtime -- no Docker Desktop needed. Requires macOS 26+ on Apple silicon, and the runtime must be started once per boot with `container system start`.
+
+Unlike sbx, `container` is a generic runtime, so you supply the image. Build one once with `container build --tag canopy-claude --file Dockerfile .` from a Dockerfile like:
+
+```dockerfile
+FROM node:22-slim
+RUN apt-get update && apt-get install -y git ripgrep curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @anthropic-ai/claude-code
+```
+
+then enter `canopy-claude` as the container image in Settings. Canopy launches sessions with the worktree mounted at its host path and `~/.claude` mounted from the host:
+
+- **Session resume works** -- session files persist on the host via the `~/.claude` mount
+- **One-time login**: macOS stores Claude OAuth credentials in the Keychain, which the Linux container can't read. Run `/login` inside the first sandboxed session; the credentials land in the mounted `~/.claude` and persist for all later sessions
+- Add resource flags like `--memory 8g --cpus 8` in the "Container flags" setting (defaults are 1 GB / 4 CPUs)
+
+In both modes:
+- **A shield icon** appears next to the session name in the sidebar (hover to see which backend)
 - **The split terminal** still opens a host shell (not sandboxed), which is useful for inspecting the real filesystem
 
-Sandbox mode requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`). Canopy validates both are installed before enabling the toggle.
+Canopy validates the required tools are installed before enabling a backend.
 
 ## Workflows
 
@@ -230,12 +249,15 @@ Prompts are stored globally in `~/.config/canopy/prompts.json` and shared across
 |---------|---------|---------|
 | Auto-start Claude | On | Launch Claude Code when opening a session |
 | Claude flags | `--permission-mode auto` | Flags passed to the `claude` command |
-| Docker Sandbox | Off | Run Claude inside a `sbx` microVM (requires Docker Desktop + `sbx`) |
+| Sandbox | Off | Backend for isolated sessions: Docker Sandbox (`sbx`, requires Docker Desktop) or Apple container (requires macOS 26+, Apple silicon) |
 | Sandbox flags | *(empty)* | Additional flags passed to `sbx run` (e.g., `--memory 8g`) |
+| Container image | *(empty)* | OCI image used by the Apple container backend (see [Sandbox modes](#sandbox-modes)) |
+| Container flags | *(empty)* | Additional flags passed to `container run` (e.g., `--memory 8g --cpus 8`) |
 | Confirm before closing | On | Ask before closing a session |
 | IDE path | `/Applications/Cursor.app` | App used for "Open in IDE" |
 | `gh` CLI path | *auto-detected* | Used for open PR data. Leave blank to use `PATH` lookup; override if Homebrew is in a non-standard location. |
-| `sbx` CLI path | *auto-detected* | Used when Docker Sandbox is enabled. Same auto-detect/override behavior as `gh`. |
+| `sbx` CLI path | *auto-detected* | Used when the Docker Sandbox backend is enabled. Same auto-detect/override behavior as `gh`. |
+| `container` CLI path | *auto-detected* | Used when the Apple container backend is enabled. Same auto-detect/override behavior as `gh`. |
 
 Per-project overrides for auto-start, Claude flags, and sandbox mode are available in the project edit sheet.
 
@@ -274,7 +296,7 @@ All configuration lives in `~/.config/canopy/`:
 - **Text selection in the terminal**: Hold `Option` while dragging. Claude Code enables mouse reporting which captures normal clicks -- `Option` bypasses it.
 - **Show Transcript**: Right-click a session > Show Transcript… for a clean scrollable view of the conversation. When Claude Code is running, Canopy reads the structured JSONL session log (`~/.claude/projects/...`) and renders user/assistant turns with markdown formatting. The Copy button (⌘⇧C) puts the formatted markdown on the clipboard -- handy for pasting into PR descriptions or notes.
 - **Scrolling with `CLAUDE_CODE_NO_FLICKER=1`**: That flag puts Claude Code into the alternate screen buffer (DECSET 1049), which has no scrollback by terminal protocol design. The live viewport intentionally can't scroll back in that mode -- use Show Transcript to read history, or `Cmd+F` to search.
-- **Session resume**: When you reopen an existing worktree, Canopy finds the last Claude session ID automatically. You continue exactly where you left off. Note: sandbox sessions are not resumable -- the session data lives inside the ephemeral microVM and is discarded when the sandbox stops.
+- **Session resume**: When you reopen an existing worktree, Canopy finds the last Claude session ID automatically. You continue exactly where you left off. Note: Docker Sandbox (sbx) sessions are not resumable -- their session data lives inside the ephemeral microVM and is discarded when the sandbox stops. Apple container sessions resume normally, since `~/.claude` is mounted from the host.
 - **Worktree base directory**: By default, worktrees are created at `../canopy-worktrees/<project>/` (as siblings of your repo). Override this per-project if you prefer a different location.
 - **Quick rebuild**: Run `bash scripts/bundle.sh` then `open /Applications/Canopy.app`.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -84,7 +84,7 @@ In both modes:
 - **A shield icon** appears next to the session name in the sidebar (hover to see which backend)
 - **The split terminal** still opens a host shell (not sandboxed), which is useful for inspecting the real filesystem
 
-Canopy validates the required tools are installed before enabling a backend.
+The backend can be set globally (Settings), per project (project edit sheet), or per session: the New Worktree Session sheet has a Sandbox picker that overrides both for that session only. Canopy validates the required tools are installed before enabling a backend.
 
 ## Workflows
 
@@ -99,6 +99,7 @@ Canopy validates the required tools are installed before enabling a backend.
    - Pick your project
    - Select a base branch (Canopy auto-detects `main`, `master`, `develop`, or `dev`)
    - Name your feature branch (e.g., `feat/user-auth`)
+   - Optionally pick a sandbox just for this session (defaults to the project/global setting -- see [Sandbox modes](#sandbox-modes))
 
 3. Canopy will:
    - Run `git worktree add` with your branch


### PR DESCRIPTION
## Summary

Adds **Apple container** (apple/container) as a second sandbox backend alongside Docker Sandbox (sbx), makes sandboxing selectable **per session**, and hardens the whole app through three rounds of adversarial review, empirical failure-mode probing against the real runtime, and an app-wide audit ahead of 1.0.

### Apple container backend
- Sandbox setting becomes a picker — Off / Docker Sandbox (sbx) / Apple container — at three levels: global, per-project, **per-session** (New Worktree Session sheet). Resolution: session → project → global.
- Runs Claude Code in a lightweight VM via Apple's open-source `container` runtime (macOS 26+, Apple silicon). No Docker Desktop.
- Worktree mounted at its host path, **plus the project's main repo** (a worktree's `.git` points there — git is broken inside the VM without it) and `~/.claude` / `~/.claude.json` / `~/.gitconfig` — so **session resume, Show Transcript, cost tracking, and git commits all work inside the sandbox** (unlike sbx).
- Default image `canopy-claude`, built in-app (Settings → **Build Image**) from an embedded recipe using the native Claude Code installer (clean `/doctor` against the mounted host config).
- Terminal-rendering fixes verified empirically: TERM/COLORTERM/UTF-8 locale passed into the VM, claude starts behind a winsize-settle wrapper (the container PTY briefly reports 0×0), `--resume` forwarded via `"$@"`.
- Guard rails: validation detects missing CLI / stopped daemon / missing kernel with exact fix commands; home-directory sessions are blocked (overlapping virtiofs mounts silently drop the workdir or hang the VM — observed); legacy `useSandbox` configs migrate automatically; unknown future backend values can't factory-reset config files.

### Pre-release audit fixes (closed issues)
Closes #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28 — highlights: closing a session now actually terminates its shell/claude (#20); session resume/transcripts/cost fixed for paths with `_`, spaces, etc. by matching Claude Code's real path encoding (#21); Merge & Finish no longer switches the main repo's branch with uncommitted changes in tow (#22); `swift test` no longer resets the user's real settings (#18); image builds can't deadlock the UI on >64 KB output.

### Tests & docs
- Suite grows from 466 → **528 tests**, including a deep e2e suite that runs the *real* generated commands against the real runtime (claude boots in a mounted worktree with spaces in the path; git commits inside a sandboxed worktree) and skips on machines without apple/container.
- Zero compiler warnings, zero semgrep findings.
- guide.md gains consolidated per-backend prerequisites and the full mount/limitation story; README covers both backends; in-app Help gains sandbox concepts.

## Test plan
- [x] `swift test` — 528 tests, 34 suites, green
- [x] E2E against real runtime: command boots claude in worktree (spaces in path, appended `--resume`), git commit inside sandboxed worktree
- [x] Manual: sandboxed session renders cleanly, resumes, `/doctor` clean; per-project and per-session overrides launch correctly
- [x] `scripts/bundle.sh` archive build (Swift 6 strict concurrency) clean
- [ ] Manual spot-check: process terminates on session close (`ps aux | grep claude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)