### PR TITLE
Fix main worktree misclassification on symlinked repo paths

### DIFF
--- a/Canopy/Services/GitService.swift
+++ b/Canopy/Services/GitService.swift
@@ -229,6 +229,15 @@ struct GitService {
         return (path as NSString).appendingPathComponent(raw)
     }
 
+    /// True if two filesystem paths refer to the same location, resolving
+    /// symlinks. `git worktree list` reports symlink-resolved paths (e.g.
+    /// /private/tmp/…) while a stored repo path may keep the unresolved form
+    /// (/tmp/…); a raw string compare would wrongly treat them as different.
+    static func samePath(_ a: String, _ b: String) -> Bool {
+        URL(fileURLWithPath: a).resolvingSymlinksInPath().path
+            == URL(fileURLWithPath: b).resolvingSymlinksInPath().path
+    }
+
     // MARK: - Diff & Push Status
 
     /// Returns a summary of uncommitted changes (staged + unstaged) vs HEAD.

--- a/Canopy/Services/GitService.swift
+++ b/Canopy/Services/GitService.swift
@@ -229,13 +229,15 @@ struct GitService {
         return (path as NSString).appendingPathComponent(raw)
     }
 
-    /// True if two filesystem paths refer to the same location, resolving
-    /// symlinks. `git worktree list` reports symlink-resolved paths (e.g.
-    /// /private/tmp/…) while a stored repo path may keep the unresolved form
-    /// (/tmp/…); a raw string compare would wrongly treat them as different.
+    /// True if two filesystem paths refer to the same location. Resolves with
+    /// realpath(3) via `SandboxBackend.realResolvedPath` — the same helper the
+    /// rest of the codebase uses to match how git records paths (/tmp →
+    /// /private/tmp). `git worktree list` reports the resolved form while a
+    /// stored repo path may keep the unresolved one, so a raw string compare
+    /// wrongly treats them as different. (Foundation's resolvingSymlinksInPath
+    /// is unsuitable here — it strips /private instead of adding it.)
     static func samePath(_ a: String, _ b: String) -> Bool {
-        URL(fileURLWithPath: a).resolvingSymlinksInPath().path
-            == URL(fileURLWithPath: b).resolvingSymlinksInPath().path
+        SandboxBackend.realResolvedPath(a) == SandboxBackend.realResolvedPath(b)
     }
 
     // MARK: - Diff & Push Status

--- a/Canopy/Views/ProjectDetailView.swift
+++ b/Canopy/Views/ProjectDetailView.swift
@@ -288,7 +288,8 @@ struct ProjectDetailView: View {
         appState.sessions.first { $0.worktreePath == wt.path }
     }
 
-    /// Returns true if a session exists for this worktree's branch (matched by path).
+    /// True if this worktree is the project's main checkout — its path matches
+    /// the repository path, resolving symlinks.
     private func isMainWorktree(_ wt: WorktreeInfo) -> Bool {
         GitService.samePath(wt.path, project.repositoryPath)
     }

--- a/Canopy/Views/ProjectDetailView.swift
+++ b/Canopy/Views/ProjectDetailView.swift
@@ -290,7 +290,7 @@ struct ProjectDetailView: View {
 
     /// Returns true if a session exists for this worktree's branch (matched by path).
     private func isMainWorktree(_ wt: WorktreeInfo) -> Bool {
-        wt.path == project.repositoryPath
+        GitService.samePath(wt.path, project.repositoryPath)
     }
 
     @ViewBuilder

--- a/Tests/GitServiceTests.swift
+++ b/Tests/GitServiceTests.swift
@@ -350,6 +350,18 @@ struct GitServiceTests {
         #expect(!GitService.samePath(target, target + "-other"))
     }
 
+    /// The exact reported scenario: `/tmp` is a system symlink to `/private/tmp`,
+    /// so `git worktree list` records `/private/tmp/…` while a stored repo path
+    /// may keep the `/tmp/…` spelling. The two must compare equal.
+    @Test func samePathMatchesTmpAndPrivateTmpSpellings() throws {
+        let resolved = "/private/tmp/canopy-sp-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: resolved, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: resolved) }
+        let viaTmp = resolved.replacingOccurrences(of: "/private/tmp", with: "/tmp")
+
+        #expect(GitService.samePath(resolved, viaTmp))
+    }
+
     @discardableResult
     private func shell(_ command: String, in dir: String) throws -> String {
         let process = Process()

--- a/Tests/GitServiceTests.swift
+++ b/Tests/GitServiceTests.swift
@@ -328,6 +328,28 @@ struct GitServiceTests {
 
     // MARK: - Helpers
 
+    // MARK: - Path comparison (main worktree detection)
+
+    /// `git worktree list` reports symlink-resolved paths (e.g. /private/tmp/…)
+    /// while a stored repositoryPath may be the unresolved (/tmp/…) form. They
+    /// must compare equal — otherwise the main worktree is misclassified as a
+    /// feature worktree and wrongly offered Merge & Delete. Regression test.
+    @Test func samePathTreatsSymlinkAndTargetAsEqual() throws {
+        let target = NSTemporaryDirectory() + "canopy-target-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: target, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: target) }
+
+        let link = NSTemporaryDirectory() + "canopy-link-\(UUID().uuidString)"
+        try fm.createSymbolicLink(atPath: link, withDestinationPath: target)
+        defer { try? fm.removeItem(atPath: link) }
+
+        // The symlink and its target are the same directory.
+        #expect(GitService.samePath(link, target))
+        #expect(GitService.samePath(target, target))
+        // Genuinely different paths stay unequal.
+        #expect(!GitService.samePath(target, target + "-other"))
+    }
+
     @discardableResult
     private func shell(_ command: String, in dir: String) throws -> String {
         let process = Process()


### PR DESCRIPTION
Closes #31.

## Problem
`ProjectDetailView.isMainWorktree` compared `wt.path == project.repositoryPath` with raw string equality. `git worktree list` reports symlink-resolved paths (e.g. `/private/tmp/repo`) while the stored repo path may keep the unresolved form (`/tmp/repo`, or any project added via a symlinked directory). The mismatch made the **main worktree get misclassified as a feature worktree** — shown with the branch icon and wrongly offered **Merge & Finish** and **Delete**.

## Fix
- Add `GitService.samePath(_:_:)`, a symlink-resolving path comparison.
- Use it in `isMainWorktree`.

## Test
- `GitServiceTests.samePathTreatsSymlinkAndTargetAsEqual` pins the behaviour: a symlink and its target compare equal, genuinely different paths do not. Fails on the old `==`, passes with the fix.
- Full `swift test`: 531 tests pass.

Scope: just this bug — 3 files, +32/−1.