### PR TITLE
refactor: single source of truth for Claude JSONL timestamp parsing

### DIFF
--- a/Canopy/Services/ActivityDataService.swift
+++ b/Canopy/Services/ActivityDataService.swift
@@ -6,16 +6,10 @@ enum ActivityDataService {
     // MARK: - Shared formatters (created once per loadData call, passed around)
 
     struct Formatters {
-        let iso8601: ISO8601DateFormatter
-        let iso8601NoFrac: ISO8601DateFormatter
         let dayFmt: DateFormatter
         let hourFmt: DateFormatter
 
         init() {
-            iso8601 = ISO8601DateFormatter()
-            iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            iso8601NoFrac = ISO8601DateFormatter()
-            iso8601NoFrac.formatOptions = [.withInternetDateTime]
             dayFmt = DateFormatter()
             dayFmt.dateFormat = "yyyy-MM-dd"
             dayFmt.timeZone = .current
@@ -143,8 +137,7 @@ enum ActivityDataService {
                 let model = message["model"] as? String ?? "unknown"
                 guard model != "<synthetic>" else { continue }
 
-                guard let date = formatters.iso8601.date(from: timestamp)
-                        ?? formatters.iso8601NoFrac.date(from: timestamp) else {
+                guard let date = ClaudeSessionFinder.parseTimestamp(timestamp) else {
                     continue
                 }
                 let dayKey = formatters.dayFmt.string(from: date)

--- a/Canopy/Services/SessionCostService.swift
+++ b/Canopy/Services/SessionCostService.swift
@@ -8,33 +8,12 @@ struct TokenUsage {
 
     var totalTokens: Int { inputTokens + outputTokens }
 
-    var formattedInput: String { formatCount(inputTokens) }
-    var formattedOutput: String { formatCount(outputTokens) }
-
-    private func formatCount(_ count: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
-    }
+    var formattedInput: String { inputTokens.formatted() }
+    var formattedOutput: String { outputTokens.formatted() }
 }
 
 /// Parses Claude Code JSONL session files for token usage data.
 enum SessionCostService {
-
-    private nonisolated(unsafe) static let iso8601: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-
-    /// Fallback for JSONL timestamps without fractional seconds (they occur in
-    /// real Claude Code logs); mirrors ActivityDataService. Without it, the
-    /// `.withFractionalSeconds` formatter returns nil for such timestamps.
-    private nonisolated(unsafe) static let iso8601NoFrac: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
 
     /// Parse token usage from JSONL content string, only counting entries after `since`.
     static func parseTokenUsage(from jsonlContent: String, since: Date? = nil) -> TokenUsage {
@@ -55,7 +34,7 @@ enum SessionCostService {
             // rather than over-report recent usage.
             if let since {
                 guard let timestamp = obj["timestamp"] as? String,
-                      let entryDate = iso8601.date(from: timestamp) ?? iso8601NoFrac.date(from: timestamp),
+                      let entryDate = ClaudeSessionFinder.parseTimestamp(timestamp),
                       entryDate >= since else {
                     continue
                 }

--- a/Canopy/Utilities/ClaudeSessionFinder.swift
+++ b/Canopy/Utilities/ClaudeSessionFinder.swift
@@ -34,6 +34,26 @@ enum ClaudeSessionFinder {
         return "\(home)/.claude/projects/\(encoded)"
     }
 
+    // ISO8601DateFormatter is thread-safe for parsing, so a shared instance is
+    // fine across the off-main parsing in ActivityDataService and SessionCostService.
+    private nonisolated(unsafe) static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private nonisolated(unsafe) static let iso8601NoFrac: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    /// Parses a Claude Code JSONL timestamp. Real logs appear both with and
+    /// without fractional seconds, so try the fractional formatter first and
+    /// fall back. Single source of truth for both forms.
+    static func parseTimestamp(_ timestamp: String) -> Date? {
+        iso8601.date(from: timestamp) ?? iso8601NoFrac.date(from: timestamp)
+    }
+
     /// Returns the most recent Claude session ID for the given working directory.
     static func findLatestSessionId(for directory: String) -> String? {
         let projectDir = projectDirectory(for: directory)


### PR DESCRIPTION
Two `/ponytail-audit` cleanups, both behavior-preserving (no functional change).

## What

- **Dedup ISO8601 timestamp parsing.** The with/without-fractional-seconds fallback was copy-pasted in `SessionCostService` and `ActivityDataService` — the latter literally commented *"mirrors ActivityDataService"*, i.e. a known keep-in-sync hazard. Both now route through `ClaudeSessionFinder.parseTimestamp(_:)`, the existing single-source-of-truth for Claude Code's on-disk format (both services already call into it).
  - `ActivityDataService.Formatters` keeps its per-call `dayFmt`/`hourFmt` — `DateFormatter` isn't thread-safe, so those stay per-`loadData` instances on purpose.
- **Drop hand-rolled `NumberFormatter`.** `TokenUsage.formattedInput/Output` now use `Int.formatted()`, matching the `.formatted()` already used in `TranscriptSheet` and `SessionInfoSheet`.

## Why

Removes a duplicated parser (one place to fix if Claude's timestamp format ever changes) and an inconsistency with the codebase's own formatting convention.

## Verification

- `swift test` — **564 tests / 43 suites green**.
- `scripts/bundle.sh` — **ARCHIVE SUCCEEDED**, installed to `/Applications`.
- Timestamp behavior is already covered by `ActivityDataTests`: `timestampWithoutFractionalSeconds`, `timestampWithTimezoneOffset`, and many fractional cases — these exercise the shared parser.
- Net **-8 lines**, no new files (so no `xcodegen` regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)