### PR TITLE
Update sandbox image to pull latest Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Update the Apple container sandbox image**: a new **Update** button (Settings
+  → Apple container, next to Build Image) rebuilds the image with `--no-cache`
+  to pull the latest Claude Code. Claude Code is baked into an image layer with
+  its auto-updater disabled, so the version was previously frozen at first build
+  — and a plain rebuild reused the cached install layer and reinstalled the same
+  version. (#38)
+
 ## [1.1.0] - 2026-06-22
 
 ### Added

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -19,8 +19,13 @@ struct ContainerImageBuilder {
     /// Single-quoted with embedded-quote escaping: the tag is user input
     /// interpolated into a login-shell command -- unquoted (or with a raw `'`
     /// inside), spaces or metacharacters would split or inject.
-    static func buildCommand(tag: String, contextDir: String) -> String {
-        "container build --tag \(SandboxBackend.shellSingleQuoted(tag)) --file \(SandboxBackend.shellSingleQuoted(contextDir + "/Dockerfile")) \(SandboxBackend.shellSingleQuoted(contextDir))"
+    ///
+    /// `noCache` bypasses the layer cache so the `RUN curl install.sh` layer
+    /// re-runs and pulls the latest Claude Code -- a plain rebuild would reuse
+    /// the cached layer and reinstall the same pinned version.
+    static func buildCommand(tag: String, contextDir: String, noCache: Bool = false) -> String {
+        let cacheFlag = noCache ? "--no-cache " : ""
+        return "container build \(cacheFlag)--tag \(SandboxBackend.shellSingleQuoted(tag)) --file \(SandboxBackend.shellSingleQuoted(contextDir + "/Dockerfile")) \(SandboxBackend.shellSingleQuoted(contextDir))"
     }
 
     enum BuildResult: Equatable {
@@ -30,7 +35,10 @@ struct ContainerImageBuilder {
 
     /// Writes the embedded Dockerfile to a temporary directory and runs
     /// `container build`. Returns the tail of the build output on failure.
-    static func build(tag: String) async -> BuildResult {
+    ///
+    /// Pass `noCache: true` to update an existing image to the latest Claude
+    /// Code (the recipe is fixed, so the cache must be busted to re-fetch it).
+    static func build(tag: String, noCache: Bool = false) async -> BuildResult {
         let contextDir = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("canopy-image-\(UUID().uuidString)")
         do {
@@ -42,7 +50,7 @@ struct ContainerImageBuilder {
         defer { try? FileManager.default.removeItem(atPath: contextDir) }
 
         let result = await runCapturingOutput(
-            buildCommand(tag: tag, contextDir: contextDir),
+            buildCommand(tag: tag, contextDir: contextDir, noCache: noCache),
             timeoutSeconds: 1800
         )
         return result.exitCode == 0 ? .success : .failure(String(result.output.suffix(500)))

--- a/Canopy/Views/HelpView.swift
+++ b/Canopy/Views/HelpView.swift
@@ -97,6 +97,8 @@ struct HelpView: View {
                             "Optional isolation for Claude sessions, set globally (Settings), per project, or per session (New Worktree Session sheet). Docker Sandbox runs Claude in an sbx microVM (requires Docker Desktop; no session resume). Apple container runs it in a lightweight VM via Apple's container runtime (macOS 26+, Apple silicon; resume works). Sandboxed sessions show a shield icon in the sidebar — hover it to see which backend. The sandbox protects your machine — everything not explicitly mounted (SSH keys, Keychain, other repos, the rest of your home dir) stays out of reach — but not the mounted project or Claude state, and outbound network stays open. See the User Guide for the full boundary.")
                     concept("Sandbox Login (Apple container)",
                             "macOS keeps Claude's credentials in the Keychain, which the Linux VM can't read. Run /login once inside your first sandboxed session — credentials persist in the mounted ~/.claude for all later sessions.")
+                    concept("Sandbox Image (Apple container)",
+                            "The Apple container backend runs Claude inside an image you build once from Settings → Build Image. Claude Code is baked into the image with its auto-updater disabled, so its version is frozen until you rebuild. To pull a newer Claude Code, click Update (next to Build Image) — it rebuilds from scratch so the latest version is fetched.")
                 }
 
                 // Config

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -143,8 +143,13 @@ struct SettingsView: View {
                                                 buildImage()
                                             }
                                             .disabled(buildingImage || containerImage.trimmingCharacters(in: .whitespaces).isEmpty)
+                                            Button("Update") {
+                                                buildImage(noCache: true)
+                                            }
+                                            .disabled(buildingImage || imageExists != true || containerImage.trimmingCharacters(in: .whitespaces).isEmpty)
+                                            .help("Rebuild from scratch to pull the latest Claude Code")
                                         }
-                                        Text("OCI image with claude, node, and git installed. Build Image creates it from Canopy's built-in recipe (a few minutes on first build).")
+                                        Text("OCI image with claude, node, and git installed. Build Image creates it from Canopy's built-in recipe (a few minutes on first build). Update rebuilds it from scratch to pull the latest Claude Code.")
                                             .font(.caption)
                                             .foregroundStyle(.tertiary)
                                         if containerImage.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -391,12 +396,12 @@ struct SettingsView: View {
         }
     }
 
-    private func buildImage() {
+    private func buildImage(noCache: Bool = false) {
         buildingImage = true
         buildError = nil
         let tag = containerImage.trimmingCharacters(in: .whitespaces)
         Task.detached(priority: .utility) {
-            let result = await ContainerImageBuilder.build(tag: tag)
+            let result = await ContainerImageBuilder.build(tag: tag, noCache: noCache)
             await MainActor.run {
                 buildingImage = false
                 switch result {

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Pick a sandbox backend in Settings (globally, per project, or per session in the
 **Docker Sandbox (sbx)** — a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM via `sbx run`. Session resume is disabled (session files live inside the ephemeral microVM).
 *Requirements:* [Docker Desktop](https://www.docker.com/products/docker-desktop/) and `sbx` (`brew install docker/tap/sbx`).
 
-**Apple container** — a lightweight VM via Apple's open-source [container](https://github.com/apple/container) runtime, no Docker Desktop needed. Canopy mounts the worktree, the project's main repo, and your `~/.claude` state at their host paths — so git works inside the sandbox and **session resume works**, unlike sbx. The default `canopy-claude` image is built in one click (**Settings → Build Image**); a one-time `/login` inside the first sandboxed session sets up credentials.
+**Apple container** — a lightweight VM via Apple's open-source [container](https://github.com/apple/container) runtime, no Docker Desktop needed. Canopy mounts the worktree, the project's main repo, and your `~/.claude` state at their host paths — so git works inside the sandbox and **session resume works**, unlike sbx. The default `canopy-claude` image is built in one click (**Settings → Build Image**); a one-time `/login` inside the first sandboxed session sets up credentials. Claude Code is baked into the image, so click **Update** when you want to pull a newer version into it.
 *Requirements:* macOS 26+ on Apple silicon, `brew install container`, `container system start` once per boot. Full setup steps in the [user guide](docs/guide.md#sandbox-modes).
 
 ---

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -34,6 +34,21 @@ struct ContainerImageBuilderTests {
         #expect(command.contains(#"--tag 'a'\''b'"#))
     }
 
+    @Test func buildCommandOmitsNoCacheByDefault() {
+        // A normal build reuses cached layers -- fast, and correct for the
+        // create-from-scratch case.
+        let command = ContainerImageBuilder.buildCommand(tag: "canopy-claude", contextDir: "/tmp/ctx")
+        #expect(!command.contains("--no-cache"))
+    }
+
+    @Test func buildCommandAddsNoCacheForUpdates() {
+        // Updating MUST bypass the layer cache: otherwise the cached
+        // `RUN curl install.sh` layer reinstalls the same pinned Claude
+        // version and "Update" is a no-op.
+        let command = ContainerImageBuilder.buildCommand(tag: "canopy-claude", contextDir: "/tmp/ctx", noCache: true)
+        #expect(command.contains("container build --no-cache "))
+    }
+
     @Test func dockerfileSetsRenderingEnvironment() {
         // Sessions inherit the image env when --env flags are absent (custom
         // commands, future paths). Bake sane terminal defaults into the image

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -79,7 +79,7 @@ Canopy validates the required tools before enabling a backend and shows a specif
 - `container` CLI: `brew install container` (or the `.pkg` from [github.com/apple/container](https://github.com/apple/container/releases))
 - Start the runtime once per boot: `container system start` (or `brew services start container` to keep it running)
 - First run only: install the Linux kernel with `container system kernel set --recommended` (~16 MB download)
-- Build the sandbox image once: **Settings → Build Image** (a few minutes; creates the default `canopy-claude` image)
+- Build the sandbox image once: **Settings → Build Image** (a few minutes; creates the default `canopy-claude` image). Later, **Update** rebuilds it to pull a newer Claude Code
 - First sandboxed session only: run `/login` inside it (see below)
 
 #### Docker Sandbox (sbx)
@@ -101,7 +101,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:$PATH" LANG=C.UTF-8 LC_ALL=C.UTF-8 DISABLE_AUTOUPDATER=1
 ```
 
-Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image that has claude, node, and git installed. After a Claude Code update, click **Build Image** again to refresh the image.
+Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image that has claude, node, and git installed.
+
+To pull a newer Claude Code into the image later, click **Update** (next to Build Image). Claude Code is baked into an image layer with its auto-updater disabled, so the version is frozen until you rebuild — and **Update** rebuilds with `--no-cache` so the install layer actually re-fetches the latest version (a plain **Build Image** reuses the cached layer and reinstalls the same version).
 
 What Canopy mounts into the VM (all at their host paths, so everything lines up):
 


### PR DESCRIPTION
## Problem

The Apple Container backend bakes Claude Code into an image layer (`RUN curl …install.sh | bash` → `/root/.local/bin/claude`) with the auto-updater disabled (`DISABLE_AUTOUPDATER=1`). Because `imageExists` only ever triggers a build **once**, the in-container Claude version is frozen at first-build time with **no way to refresh it from the UI**.

Worse, even a manual rebuild doesn't help: `container build` caches the `RUN curl install.sh` layer, so a plain rebuild reinstalls the *same* pinned version. The only real update path was `container rmi` + a cache-busted rebuild by hand.

## Change

Add an explicit **"Update"** button next to "Build Image" in Settings → Apple Container (enabled only when the image already exists). It rebuilds with `--no-cache`, busting the install layer so the recipe re-fetches the latest Claude Code.

- `ContainerImageBuilder.buildCommand(tag:contextDir:noCache:)` — appends `--no-cache` when `noCache` is true.
- `ContainerImageBuilder.build(tag:noCache:)` — threads it through.
- `noCache` defaults to `false`, so the create-from-scratch path and all existing callers are unchanged.
- Verified `container build --no-cache` is supported by the installed runtime (v1.0.0).

This is also the **first** way to refresh the image from the UI at all — previously `imageExists` short-circuited any rebuild.

## Why not the alternatives

- **Re-enable the in-container auto-updater + persist `/root/.local`** — splits version state across host/container, can collide with a host install, runs an updater on every launch. Rejected.
- **Update at container start** — network + latency on every session, fights the ephemeral `--rm` design. Rejected.

The image is the unit of version here, so updating = rebuilding it, reusing the builder that already exists.

## Tests

TDD (red→green): `buildCommand` omits `--no-cache` by default and includes it for updates, with the WHY (cached install layer would otherwise reinstall the pinned version) encoded in the test. Existing exact-string and escaping tests still pass.

Full suite: **566 tests passing**. Release archive via `scripts/bundle.sh` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)