### PR TITLE
ci: assert BuildInfo.version matches VERSION before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Gate: tag must match VERSION file
+      # Gate: tag must match VERSION file AND BuildInfo.swift
       - name: Validate tag matches VERSION
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           FILE_VERSION=$(cat VERSION)
           if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
             echo "ERROR: tag $GITHUB_REF_NAME does not match VERSION file ($FILE_VERSION)"
+            exit 1
+          fi
+          # BuildInfo.swift is committed and CI does NOT regenerate it. The app reads
+          # BuildInfo.version for the About panel and the update-checker comparison, so
+          # a stale value ships a wrong version string and puts every user in a
+          # perpetual "update available" loop. Catch it here, before signing.
+          BUILDINFO_VERSION=$(grep -oE 'static let version = "[^"]+"' Canopy/App/BuildInfo.swift | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ "$BUILDINFO_VERSION" != "$FILE_VERSION" ]; then
+            echo "ERROR: BuildInfo.swift version ($BUILDINFO_VERSION) does not match VERSION file ($FILE_VERSION) -- regenerate via scripts/bundle.sh before tagging"
             exit 1
           fi
           echo "Version: $FILE_VERSION"


### PR DESCRIPTION
## Problem (review finding W1 from the v1.1.1 release)

`release.yml` builds via `xcodebuild archive` and **never regenerates `BuildInfo.swift`** — whatever is committed is what ships. Its only version gate compares the **VERSION file** against the tag; it never checks the `BuildInfo.version` Swift constant.

But the app reads `BuildInfo.version`, not the Info.plist:
- About panel "Version" row (`AboutView.swift`)
- `UpdateChecker.compareSemver(BuildInfo.version, release.tagName)` (`AppState.swift`)

So a bump that edits only `VERSION` (+ CHANGELOG) and forgets to regenerate `BuildInfo.swift` would **pass the tag gate**, yet ship a build that shows the *old* version in About and reports "update available" to every user forever — a self-inflicted nag loop, invisible to CI.

## Change

Extend the existing "Validate tag matches VERSION" step to also require `BuildInfo.version == VERSION`, failing fast (before signing/notarization) with a message pointing at `scripts/bundle.sh`. No new step, no new dependency — just a second string compare in the gate that already runs first.

## Verification

Simulated the assertion block locally against the real tree:
- match (`BuildInfo=1.1.1`, `VERSION=1.1.1`) → **PASS**
- mismatch (`BuildInfo=1.1.1`, `VERSION=1.1.2`) → **FAIL (exit 1)**

YAML parses cleanly (`ruby -ryaml`). No untrusted input enters the shell — only `$GITHUB_REF_NAME` (already used by the existing gate) and a grep of the committed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)