### PR TITLE
Show the host Claude Code CLI version in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Host Claude Code CLI version in Settings** (#43): shown in the Claude Code
+  section. CLI behavior changes are keyed to versions (e.g. the ≥ 2.1.132
+  alternate-screen renderer) and the sandbox image can run a different version
+  than the host, so drift is now diagnosable at a glance.
+
 ## [1.1.1] - 2026-06-30
 
 ### Added

--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		7F4D62BD4537298C8412019E /* TerminalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACDA1B29536FED841DE8CD4 /* TerminalSessionTests.swift */; };
 		857F6B3E6BECD31A0EF8A30F /* GitServiceBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */; };
 		8AE649C33D49CF076C84EDE2 /* SessionInfoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3CE80C66F45F41E8AE88C5 /* SessionInfoSheet.swift */; };
+		8D6245F4C4458543D98ECB31 /* ClaudeVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC18C1C27FE7DB1317988C /* ClaudeVersionChecker.swift */; };
 		9835CF75D59788B9C7C24258 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9697FE4298A6EA5B8C4971A4 /* Project.swift */; };
 		9AC00347A124374A890D0239 /* SandboxChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A620218A72BDE454D69504 /* SandboxChecker.swift */; };
 		A1669D51D797B9FBA7C424E6 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */; };
@@ -73,6 +74,7 @@
 		BADE4D87BE6EAAE9DFC0CF9F /* WorktreeCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1731FEC2A46A90F44E14EB1 /* WorktreeCollisionTests.swift */; };
 		C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */; };
 		C20B1FD7CDB479CD9E788FA3 /* ProjectColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */; };
+		C3E5AE9F5279191992C52ECD /* ClaudeVersionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */; };
 		C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA12AC586A4E8219DE7BF6A /* CanopyApp.swift */; };
 		C727214786425B7141AE52A6 /* ContainerSandboxE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC067F40D9AF4F8D67CBC04 /* ContainerSandboxE2ETests.swift */; };
 		CAF1AB1BC545E41239724272 /* TerminalSessionOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B8F8AE3E1C9ADB56FB3F2C /* TerminalSessionOutputTests.swift */; };
@@ -126,6 +128,7 @@
 		2D0D9FD9FF67751D32B9529D /* MergeWorktreeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWorktreeSheet.swift; sourceTree = "<group>"; };
 		3577FDAC3BB3B716543493D2 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		357D44B70B337CBEA901EFC2 /* GitStatusPollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusPollingTests.swift; sourceTree = "<group>"; };
+		35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeVersionCheckerTests.swift; sourceTree = "<group>"; };
 		380F49104F9CB7D2D472F216 /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		39E41572F63722BAF89C330B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		3A290C370D646E05E78DF65A /* Splash.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Splash.jpg; sourceTree = "<group>"; };
@@ -150,6 +153,7 @@
 		82E01E5089AC7E41230C847D /* TerminalContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContentView.swift; sourceTree = "<group>"; };
 		850B26424BF5B827D9AC5AB2 /* SandboxCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxCheckerTests.swift; sourceTree = "<group>"; };
 		85B38EAAB72CA93D542089E0 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		85EC18C1C27FE7DB1317988C /* ClaudeVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeVersionChecker.swift; sourceTree = "<group>"; };
 		86F6D24CB003F4162DB9E425 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8ACDA1B29536FED841DE8CD4 /* TerminalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionTests.swift; sourceTree = "<group>"; };
 		8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
@@ -322,6 +326,7 @@
 				8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */,
 				BC1CBBF86B23C79D577B9030 /* ClaudeSessionFinderTests.swift */,
 				D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */,
+				35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */,
 				3BC4F2B628227B82EA88FC92 /* CommandPaletteTests.swift */,
 				E7D34288EE19E380DC48BB50 /* ConfigCorruptionBackupTests.swift */,
 				C81FDDD6955C0F98872E602B /* ContainerImageBuilderTests.swift */,
@@ -375,6 +380,7 @@
 			isa = PBXGroup;
 			children = (
 				D57D180AE6F7256C49CA80C3 /* ClaudeSessionFinder.swift */,
+				85EC18C1C27FE7DB1317988C /* ClaudeVersionChecker.swift */,
 				16DF06DA3F5EC110B202E67A /* ProjectColor.swift */,
 			);
 			path = Utilities;
@@ -488,6 +494,7 @@
 				C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */,
 				44FD7A8C10F00F715B09A452 /* ClaudeSessionFinder.swift in Sources */,
 				78D62DB77DC10FAD4E4A328F /* ClaudeTranscriptLoader.swift in Sources */,
+				8D6245F4C4458543D98ECB31 /* ClaudeVersionChecker.swift in Sources */,
 				216CA915FF3647FAB9BD25BB /* CommandPaletteView.swift in Sources */,
 				A81E79BF1DEB7FDB08AE364B /* ContainerImageBuilder.swift in Sources */,
 				54F01BBD042D8ED56E51C8C2 /* EditProjectSheet.swift in Sources */,
@@ -531,6 +538,7 @@
 				C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */,
 				248F3097C1BB13616D1D98BC /* ClaudeSessionFinderTests.swift in Sources */,
 				5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */,
+				C3E5AE9F5279191992C52ECD /* ClaudeVersionCheckerTests.swift in Sources */,
 				DCC63E6C6208E9ECCA4DAF7E /* CommandPaletteTests.swift in Sources */,
 				10E092005495D331F7C372A3 /* ConfigCorruptionBackupTests.swift in Sources */,
 				7D893C4E9CB4191632B869A6 /* ContainerImageBuilderTests.swift in Sources */,

--- a/Canopy/Utilities/ClaudeVersionChecker.swift
+++ b/Canopy/Utilities/ClaudeVersionChecker.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Fetches and parses the host Claude Code CLI version for display in
+/// Settings (#43). CLI behavior changes are keyed to versions (e.g. the
+/// ≥ 2.1.132 alternate-screen renderer), and the sandbox image can run a
+/// different version than the host — showing the host version makes drift
+/// diagnosable at a glance.
+struct ClaudeVersionChecker {
+
+    /// Extracts the version from `claude --version` output
+    /// (e.g. "2.1.206 (Claude Code)" → "2.1.206"). Returns nil when the
+    /// output doesn't start with a semver-shaped token — such as a shell
+    /// "command not found" error.
+    static func parse(_ output: String) -> String? {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let token = trimmed.split(separator: " ").first else { return nil }
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }) else {
+            return nil
+        }
+        return String(token)
+    }
+
+    /// Runs `claude --version` in a login shell (same PATH resolution as
+    /// SandboxChecker: GUI apps don't inherit Homebrew/~/.local paths).
+    /// Returns nil when the CLI is missing or the output is unparseable.
+    static func hostVersion() async -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
+        process.arguments = ["-ilc", "claude --version"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            // Drain before waiting: one line can't fill the pipe, but the
+            // repo convention is to never read after waitUntilExit.
+            let data = try pipe.fileHandleForReading.readToEnd() ?? Data()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0,
+                  let output = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return parse(output)
+        } catch {
+            NSLog("Canopy: could not run claude --version (%@)", "\(error)")
+            return nil
+        }
+    }
+}

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -73,8 +73,12 @@ struct SettingsView: View {
                                 Text(claudeVersion ?? (versionChecked ? "not found" : "checking…"))
                                     .font(.system(size: 11, design: .monospaced))
                                     .foregroundStyle(claudeVersion == nil ? .tertiary : .primary)
-                                    .accessibilityLabel("Claude Code CLI version")
                             }
+                            // One element: a label on the value Text alone
+                            // would replace the version for VoiceOver.
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("Claude Code CLI version")
+                            .accessibilityValue(claudeVersion ?? (versionChecked ? "not found" : "checking"))
 
                             if autoStartClaude {
                                 VStack(alignment: .leading, spacing: 4) {

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -25,6 +25,8 @@ struct SettingsView: View {
     @State private var ghPath: String
     @State private var sbxPath: String
     @State private var containerPath: String
+    @State private var claudeVersion: String?
+    @State private var versionChecked = false
 
     init(settings: CanopySettings) {
         self._autoStartClaude = State(initialValue: settings.autoStartClaude)
@@ -63,6 +65,16 @@ struct SettingsView: View {
                     GroupBox {
                         VStack(alignment: .leading, spacing: 12) {
                             Toggle("Auto-start Claude Code in new sessions", isOn: $autoStartClaude)
+
+                            HStack(spacing: 4) {
+                                Text("Host CLI version:")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(claudeVersion ?? (versionChecked ? "not found" : "checking…"))
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundStyle(claudeVersion == nil ? .tertiary : .primary)
+                                    .accessibilityLabel("Claude Code CLI version")
+                            }
 
                             if autoStartClaude {
                                 VStack(alignment: .leading, spacing: 4) {
@@ -349,6 +361,10 @@ struct SettingsView: View {
                         Label("Updates", systemImage: "arrow.down.circle")
                     }
                 }
+            }
+            .task {
+                claudeVersion = await ClaudeVersionChecker.hostVersion()
+                versionChecked = true
             }
 
             Divider()

--- a/Tests/ClaudeVersionCheckerTests.swift
+++ b/Tests/ClaudeVersionCheckerTests.swift
@@ -28,4 +28,15 @@ struct ClaudeVersionCheckerTests {
         // e.g. a shell error like "command not found: claude"
         #expect(ClaudeVersionChecker.parse("zsh: command not found: claude") == nil)
     }
+
+    /// Exercises the real CLI path end to end (repo convention, like
+    /// `imageExistsFalseForBogusImage`): on machines without claude the
+    /// login shell exits non-zero → nil; where it exists, the result must
+    /// be a clean semver token (parse is idempotent on its own output).
+    @Test func hostVersionReturnsNilOrSemver() async {
+        let version = await ClaudeVersionChecker.hostVersion()
+        if let version {
+            #expect(ClaudeVersionChecker.parse(version) == version)
+        }
+    }
 }

--- a/Tests/ClaudeVersionCheckerTests.swift
+++ b/Tests/ClaudeVersionCheckerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Canopy
+
+/// The host Claude Code CLI version shown in Settings (#43). Behavior changes
+/// are keyed to CLI versions (e.g. the ≥ 2.1.132 alternate-screen renderer),
+/// so surfacing the version turns "terminal behaves differently" into a glance.
+@Suite("ClaudeVersionChecker")
+struct ClaudeVersionCheckerTests {
+
+    @Test func parsesStandardOutput() {
+        #expect(ClaudeVersionChecker.parse("2.1.206 (Claude Code)") == "2.1.206")
+    }
+
+    @Test func parsesBareVersion() {
+        #expect(ClaudeVersionChecker.parse("2.1.206") == "2.1.206")
+    }
+
+    @Test func trimsWhitespaceAndNewline() {
+        #expect(ClaudeVersionChecker.parse("  2.1.206 (Claude Code)\n") == "2.1.206")
+    }
+
+    @Test func rejectsEmptyOutput() {
+        #expect(ClaudeVersionChecker.parse("") == nil)
+        #expect(ClaudeVersionChecker.parse("   \n") == nil)
+    }
+
+    @Test func rejectsNonVersionOutput() {
+        // e.g. a shell error like "command not found: claude"
+        #expect(ClaudeVersionChecker.parse("zsh: command not found: claude") == nil)
+    }
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -308,6 +308,7 @@ Prompts are stored globally in `~/.config/canopy/prompts.json` and shared across
 | Setting | Default | Purpose |
 |---------|---------|---------|
 | Auto-start Claude | On | Launch Claude Code when opening a session |
+| Host CLI version | *(read-only)* | The `claude --version` of the host CLI, shown in the Claude Code section — useful when diagnosing version-keyed behavior changes or drift against the sandbox image |
 | Claude flags | `--permission-mode auto` | Flags passed to the `claude` command |
 | Sandbox | Off | Backend for isolated sessions: Docker Sandbox (`sbx`, requires Docker Desktop) or Apple container (requires macOS 26+, Apple silicon) |
 | Sandbox flags | *(empty)* | Additional flags passed to `sbx run` (e.g., `--memory 8g`) |


### PR DESCRIPTION
Closes #43

## What

A read-only "Host CLI version" row in Settings → Claude Code, populated asynchronously from `claude --version`.

- `ClaudeVersionChecker.hostVersion()` runs the CLI in a login shell — same PATH-resolution rationale as `SandboxChecker` (GUI apps don't inherit Homebrew/`~/.local` paths) — and drains the pipe before `waitUntilExit` per repo convention.
- `ClaudeVersionChecker.parse` extracts the leading semver token ("2.1.206 (Claude Code)" → "2.1.206") and rejects non-version output such as shell "command not found" errors, which display as "not found" rather than garbage.

## Why

CLI behavior changes are keyed to versions — the alternate-screen renderer (≥ 2.1.132) behind #40 being the motivating case — and the sandbox image can run a different Claude Code than the host. This makes drift a glance instead of archaeology.

## Testing

- TDD: 5 parse tests written first (RED verified via missing type), then implementation.
- Full suite: 574 tests in 45 suites pass.
- `xcodegen generate` run for the new files (archive builds use the explicit pbxproj file list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)