### PR TITLE
Nudge to update the sandbox image when it gets stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Staleness nudge for the sandbox image** (#44): when the Apple container
+  image is more than 30 days old, Settings shows "Image built N days ago —
+  Update to pull the latest Claude Code" next to the image status. Age-based
+  on purpose — Claude Code releases near-daily, so comparing against "latest"
+  would nudge constantly.
+
 ## [1.1.1] - 2026-06-30
 
 ### Added

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -148,4 +148,45 @@ struct ContainerImageBuilder {
         guard !trimmed.isEmpty else { return false }
         return await SandboxChecker.succeeds("container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))")
     }
+
+    // MARK: - Image staleness nudge (#44)
+
+    /// Claude Code is baked into the image with its auto-updater disabled,
+    /// so the version is frozen at build time while the host CLI updates
+    /// daily. Past this age, Settings nudges toward the Update button.
+    static let stalenessThresholdDays = 30
+
+    /// When the image was created, from `container image inspect`.
+    /// nil when the CLI is missing, the image doesn't exist, or the JSON
+    /// doesn't carry a creation date.
+    static func imageCreationDate(_ name: String) async -> Date? {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        let result = await runCapturingOutput(
+            "container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))",
+            timeoutSeconds: 15
+        )
+        guard result.exitCode == 0 else { return nil }
+        return parseCreationDate(fromInspectJSON: Data(result.output.utf8))
+    }
+
+    /// Extracts `configuration.creationDate` from `container image inspect`
+    /// JSON (an array of image descriptions).
+    static func parseCreationDate(fromInspectJSON data: Data) -> Date? {
+        guard let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let configuration = array.first?["configuration"] as? [String: Any],
+              let creationDate = configuration["creationDate"] as? String else {
+            return nil
+        }
+        return ClaudeSessionFinder.parseTimestamp(creationDate)
+    }
+
+    /// The nudge shown next to Build/Update, or nil while the image is
+    /// fresh. Age-based on purpose: version comparisons against "latest"
+    /// would nudge constantly given daily Claude Code releases.
+    static func stalenessMessage(created: Date, now: Date) -> String? {
+        let days = Int(now.timeIntervalSince(created) / 86_400)
+        guard days > stalenessThresholdDays else { return nil }
+        return "Image built \(days) days ago — Update to pull the latest Claude Code."
+    }
 }

--- a/Canopy/Services/ContainerImageBuilder.swift
+++ b/Canopy/Services/ContainerImageBuilder.swift
@@ -142,11 +142,19 @@ struct ContainerImageBuilder {
         }
     }
 
-    /// Returns true if the image is present in the local store.
-    static func imageExists(_ name: String) async -> Bool {
+    /// Whether the image is present in the local store, and when it was
+    /// built. One `container image inspect` answers both — existence from
+    /// the exit code, creation date from the JSON. `created` is nil for a
+    /// missing image or JSON without a creation date.
+    static func imageStatus(_ name: String) async -> (exists: Bool, created: Date?) {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return false }
-        return await SandboxChecker.succeeds("container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))")
+        guard !trimmed.isEmpty else { return (false, nil) }
+        let result = await runCapturingOutput(
+            "container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))",
+            timeoutSeconds: 15
+        )
+        guard result.exitCode == 0 else { return (false, nil) }
+        return (true, parseCreationDate(fromInspectJSON: Data(result.output.utf8)))
     }
 
     // MARK: - Image staleness nudge (#44)
@@ -155,20 +163,6 @@ struct ContainerImageBuilder {
     /// so the version is frozen at build time while the host CLI updates
     /// daily. Past this age, Settings nudges toward the Update button.
     static let stalenessThresholdDays = 30
-
-    /// When the image was created, from `container image inspect`.
-    /// nil when the CLI is missing, the image doesn't exist, or the JSON
-    /// doesn't carry a creation date.
-    static func imageCreationDate(_ name: String) async -> Date? {
-        let trimmed = name.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return nil }
-        let result = await runCapturingOutput(
-            "container image inspect \(SandboxBackend.shellSingleQuoted(trimmed))",
-            timeoutSeconds: 15
-        )
-        guard result.exitCode == 0 else { return nil }
-        return parseCreationDate(fromInspectJSON: Data(result.output.utf8))
-    }
 
     /// Extracts `configuration.creationDate` from `container image inspect`
     /// JSON (an array of image descriptions).
@@ -185,8 +179,11 @@ struct ContainerImageBuilder {
     /// fresh. Age-based on purpose: version comparisons against "latest"
     /// would nudge constantly given daily Claude Code releases.
     static func stalenessMessage(created: Date, now: Date) -> String? {
-        let days = Int(now.timeIntervalSince(created) / 86_400)
-        guard days > stalenessThresholdDays else { return nil }
+        // Threshold on the raw interval — flooring to days first would
+        // silently extend "more than 30 days" to 31.
+        let age = now.timeIntervalSince(created)
+        guard age > TimeInterval(stalenessThresholdDays) * 86_400 else { return nil }
+        let days = Int(age / 86_400)
         return "Image built \(days) days ago — Update to pull the latest Claude Code."
     }
 }

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var imageExists: Bool?
+    @State private var imageCreated: Date?
     @State private var buildingImage = false
     @State private var buildError: String?
     @State private var saveError: String?
@@ -173,6 +174,12 @@ struct SettingsView: View {
                                             Text("Image found locally.")
                                                 .font(.caption)
                                                 .foregroundStyle(.green)
+                                            if let created = imageCreated,
+                                               let staleness = ContainerImageBuilder.stalenessMessage(created: created, now: Date()) {
+                                                Text(staleness)
+                                                    .font(.caption)
+                                                    .foregroundStyle(.orange)
+                                            }
                                         }
                                     }
                                     // Re-check when the image NAME changes too,
@@ -391,8 +398,10 @@ struct SettingsView: View {
         guard !Task.isCancelled else { return }
         let image = containerImage
         let exists = await ContainerImageBuilder.imageExists(image)
+        let created = exists ? await ContainerImageBuilder.imageCreationDate(image) : nil
         if containerImage == image {
             imageExists = exists
+            imageCreated = created
         }
     }
 
@@ -407,9 +416,13 @@ struct SettingsView: View {
                 switch result {
                 case .success:
                     imageExists = true
+                    // A rebuild resets the image age — clear any staleness
+                    // nudge immediately rather than waiting for a re-inspect.
+                    imageCreated = Date()
                 case .failure(let output):
                     buildError = output
                     imageExists = false
+                    imageCreated = nil
                 }
             }
         }

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -397,11 +397,10 @@ struct SettingsView: View {
         try? await Task.sleep(for: .milliseconds(300))
         guard !Task.isCancelled else { return }
         let image = containerImage
-        let exists = await ContainerImageBuilder.imageExists(image)
-        let created = exists ? await ContainerImageBuilder.imageCreationDate(image) : nil
+        let status = await ContainerImageBuilder.imageStatus(image)
         if containerImage == image {
-            imageExists = exists
-            imageCreated = created
+            imageExists = status.exists
+            imageCreated = status.created
         }
     }
 

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -82,4 +82,39 @@ struct ContainerImageBuilderTests {
         let exists = await ContainerImageBuilder.imageExists("definitely-not-an-image-xyz-123")
         #expect(exists == false)
     }
+
+    // MARK: - Image staleness nudge (#44)
+
+    /// Real shape of `container image inspect` output (fields we don't
+    /// read omitted): an array with `configuration.creationDate`.
+    private static let inspectJSON = Data("""
+    [{"configuration": {"creationDate": "2026-06-30T10:32:18Z", "name": "canopy-claude:latest"}, "id": "abc"}]
+    """.utf8)
+
+    @Test func parsesCreationDateFromInspectJSON() {
+        let date = ContainerImageBuilder.parseCreationDate(fromInspectJSON: Self.inspectJSON)
+        #expect(date != nil)
+        #expect(date.map { Calendar(identifier: .gregorian).component(.year, from: $0) } == 2026)
+    }
+
+    @Test func parseCreationDateRejectsGarbage() {
+        #expect(ContainerImageBuilder.parseCreationDate(fromInspectJSON: Data("not json".utf8)) == nil)
+        #expect(ContainerImageBuilder.parseCreationDate(fromInspectJSON: Data("[]".utf8)) == nil)
+        #expect(ContainerImageBuilder.parseCreationDate(fromInspectJSON: Data(#"[{"configuration":{}}]"#.utf8)) == nil)
+    }
+
+    @Test func freshImageHasNoStalenessMessage() {
+        let now = Date()
+        #expect(ContainerImageBuilder.stalenessMessage(created: now, now: now) == nil)
+        // Boundary: exactly at the threshold is not yet stale.
+        let atThreshold = now.addingTimeInterval(-30 * 86_400)
+        #expect(ContainerImageBuilder.stalenessMessage(created: atThreshold, now: now) == nil)
+    }
+
+    @Test func staleImageMessageNamesAgeAndAction() {
+        let now = Date()
+        let created = now.addingTimeInterval(-47 * 86_400)
+        let message = ContainerImageBuilder.stalenessMessage(created: created, now: now)
+        #expect(message == "Image built 47 days ago — Update to pull the latest Claude Code.")
+    }
 }

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -76,11 +76,16 @@ struct ContainerImageBuilderTests {
         #expect(result.output.contains("timed out"))
     }
 
-    @Test func imageExistsFalseForBogusImage() async {
-        // Stable on any machine: false whether the container CLI is
-        // missing or the image is simply not present.
-        let exists = await ContainerImageBuilder.imageExists("definitely-not-an-image-xyz-123")
-        #expect(exists == false)
+    @Test func imageStatusFalseForBogusOrEmptyImage() async {
+        // Stable on any machine: not-found whether the container CLI is
+        // missing or the image is simply not present. One inspect call
+        // answers both existence and creation date.
+        let bogus = await ContainerImageBuilder.imageStatus("definitely-not-an-image-xyz-123")
+        #expect(bogus.exists == false)
+        #expect(bogus.created == nil)
+        let empty = await ContainerImageBuilder.imageStatus("  ")
+        #expect(empty.exists == false)
+        #expect(empty.created == nil)
     }
 
     // MARK: - Image staleness nudge (#44)
@@ -103,19 +108,21 @@ struct ContainerImageBuilderTests {
         #expect(ContainerImageBuilder.parseCreationDate(fromInspectJSON: Data(#"[{"configuration":{}}]"#.utf8)) == nil)
     }
 
-    /// End-to-end over the real CLI path (like `imageExistsFalseForBogusImage`):
-    /// nil whether the container CLI is missing (CI) or the image isn't present.
-    @Test func imageCreationDateNilForBogusOrEmptyImage() async {
-        #expect(await ContainerImageBuilder.imageCreationDate("definitely-not-an-image-xyz-123") == nil)
-        #expect(await ContainerImageBuilder.imageCreationDate("  ") == nil)
-    }
-
     @Test func freshImageHasNoStalenessMessage() {
         let now = Date()
         #expect(ContainerImageBuilder.stalenessMessage(created: now, now: now) == nil)
         // Boundary: exactly at the threshold is not yet stale.
         let atThreshold = now.addingTimeInterval(-30 * 86_400)
         #expect(ContainerImageBuilder.stalenessMessage(created: atThreshold, now: now) == nil)
+    }
+
+    @Test func justOverThresholdIsStale() {
+        // The threshold compares the raw interval, not floored days:
+        // flooring first would silently extend "more than 30 days" to 31.
+        let now = Date()
+        let justOver = now.addingTimeInterval(-(30 * 86_400 + 1))
+        let message = ContainerImageBuilder.stalenessMessage(created: justOver, now: now)
+        #expect(message == "Image built 30 days ago — Update to pull the latest Claude Code.")
     }
 
     @Test func staleImageMessageNamesAgeAndAction() {

--- a/Tests/ContainerImageBuilderTests.swift
+++ b/Tests/ContainerImageBuilderTests.swift
@@ -103,6 +103,13 @@ struct ContainerImageBuilderTests {
         #expect(ContainerImageBuilder.parseCreationDate(fromInspectJSON: Data(#"[{"configuration":{}}]"#.utf8)) == nil)
     }
 
+    /// End-to-end over the real CLI path (like `imageExistsFalseForBogusImage`):
+    /// nil whether the container CLI is missing (CI) or the image isn't present.
+    @Test func imageCreationDateNilForBogusOrEmptyImage() async {
+        #expect(await ContainerImageBuilder.imageCreationDate("definitely-not-an-image-xyz-123") == nil)
+        #expect(await ContainerImageBuilder.imageCreationDate("  ") == nil)
+    }
+
     @Test func freshImageHasNoStalenessMessage() {
         let now = Date()
         #expect(ContainerImageBuilder.stalenessMessage(created: now, now: now) == nil)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -103,7 +103,7 @@ ENV PATH="/root/.local/bin:$PATH" LANG=C.UTF-8 LC_ALL=C.UTF-8 DISABLE_AUTOUPDATE
 
 Claude Code is installed with the native installer (not npm) on purpose: your host `~/.claude.json` is mounted into the container and declares a native install, so `/doctor` inside the sandbox expects a binary at `/root/.local/bin/claude`. You can also point the image field at any custom image that has claude, node, and git installed.
 
-To pull a newer Claude Code into the image later, click **Update** (next to Build Image). Claude Code is baked into an image layer with its auto-updater disabled, so the version is frozen until you rebuild — and **Update** rebuilds with `--no-cache` so the install layer actually re-fetches the latest version (a plain **Build Image** reuses the cached layer and reinstalls the same version).
+To pull a newer Claude Code into the image later, click **Update** (next to Build Image). Claude Code is baked into an image layer with its auto-updater disabled, so the version is frozen until you rebuild — and **Update** rebuilds with `--no-cache` so the install layer actually re-fetches the latest version (a plain **Build Image** reuses the cached layer and reinstalls the same version). When the image is more than 30 days old, Settings shows a reminder next to the image status ("Image built N days ago — Update to pull the latest Claude Code").
 
 What Canopy mounts into the VM (all at their host paths, so everything lines up):
 


### PR DESCRIPTION
Closes #44

## What

When the Apple container image is more than 30 days old, Settings shows "Image built N days ago — Update to pull the latest Claude Code" (orange caption) under the existing "Image found locally" status.

- Creation date comes from `container image inspect` (`configuration.creationDate`) via the existing `runCapturingOutput` helper — no VM spin-up, no stored metadata; images Canopy didn't build work the same way.
- Timestamp parsing reuses `ClaudeSessionFinder.parseTimestamp` (the single-sourced ISO8601 parser from #36).
- Age-based on purpose: comparing against "latest" would nudge constantly given near-daily Claude Code releases (rationale in the code and CHANGELOG).
- A successful rebuild clears the nudge immediately; the inspect re-runs on the existing `.task(id:)` debounce when the backend or image name changes.

## Testing

- TDD: 4 new tests written first (inspect-JSON parse with the real output shape, garbage rejection, threshold boundary at exactly 30 days, message wording at 47 days).
- Full suite: 573 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)