### PR TITLE
Pass worktree names to Claude Code sessions

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		9835CF75D59788B9C7C24258 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9697FE4298A6EA5B8C4971A4 /* Project.swift */; };
 		9AC00347A124374A890D0239 /* SandboxChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A620218A72BDE454D69504 /* SandboxChecker.swift */; };
 		A1669D51D797B9FBA7C424E6 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */; };
+		A2E3315C93FEA826BF12CBCF /* SessionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774CEE75403401F0A7DE18E9 /* SessionNameTests.swift */; };
 		A3694563A13E7FD1C1DDEA32 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 221DC70B7598F4D564E6004E /* SwiftTerm */; };
 		A76F71582F1364D48A52A2D7 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380F49104F9CB7D2D472F216 /* GitService.swift */; };
 		A81E79BF1DEB7FDB08AE364B /* ContainerImageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */; };
@@ -150,6 +151,7 @@
 		5783A7428557B472B76840C3 /* ProjectDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailView.swift; sourceTree = "<group>"; };
 		5BB59C5526224331D34114A4 /* Canopy.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Canopy.entitlements; sourceTree = "<group>"; };
 		71B9ED338BECE4C5A45CEF2F /* PromptLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibraryTests.swift; sourceTree = "<group>"; };
+		774CEE75403401F0A7DE18E9 /* SessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameTests.swift; sourceTree = "<group>"; };
 		7BBB56AB0E1FD63030164560 /* PromptPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPickerSheet.swift; sourceTree = "<group>"; };
 		82E01E5089AC7E41230C847D /* TerminalContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContentView.swift; sourceTree = "<group>"; };
 		850B26424BF5B827D9AC5AB2 /* SandboxCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxCheckerTests.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				850B26424BF5B827D9AC5AB2 /* SandboxCheckerTests.swift */,
 				4102FA193C043697E08EFD91 /* SessionCostFilteringTests.swift */,
 				4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */,
+				774CEE75403401F0A7DE18E9 /* SessionNameTests.swift */,
 				0E948527D5D146F27269411E /* SessionSandboxTests.swift */,
 				EB57402CEF34C579AE3ED054 /* SettingsEdgeCaseTests.swift */,
 				2104528AB64BB407CE23FBDE /* SettingsTests.swift */,
@@ -564,6 +567,7 @@
 				257BE9FBDC281CB300ADD349 /* SandboxCheckerTests.swift in Sources */,
 				DF5DB9329C647A612F38E808 /* SessionCostFilteringTests.swift in Sources */,
 				7403E7DA09BC3CAD7004D877 /* SessionCostServiceTests.swift in Sources */,
+				A2E3315C93FEA826BF12CBCF /* SessionNameTests.swift in Sources */,
 				DCEC5FF914987D48A89E3D81 /* SessionSandboxTests.swift in Sources */,
 				47572C3FF5F7C52C77D0B4C5 /* SettingsEdgeCaseTests.swift in Sources */,
 				CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -933,6 +933,31 @@ struct SessionInfo: Identifiable, Codable {
 
     var isWorktreeSession: Bool { worktreePath != nil }
 
+    /// A shell-safe Claude Code display-name flag for worktree sessions.
+    /// Plain sessions start with generic names that may be renamed
+    /// asynchronously, so passing those names would race the rename.
+    var claudeNameFlag: String? {
+        guard isWorktreeSession,
+              let sanitized = Self.sanitizedClaudeName(name) else { return nil }
+        return "--name \(SandboxBackend.shellSingleQuoted(sanitized))"
+    }
+
+    /// Removes terminal control characters, normalizes whitespace, and keeps
+    /// Claude's display name compact. Shell quoting happens only after this
+    /// validation step.
+    static func sanitizedClaudeName(_ name: String) -> String? {
+        let withoutControls = name.filter { character in
+            !character.unicodeScalars.contains {
+                CharacterSet.controlCharacters.contains($0)
+            }
+        }
+        let collapsed = withoutControls
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        let sanitized = String(collapsed.prefix(64))
+        return sanitized.isEmpty ? nil : sanitized
+    }
+
     /// Claude Code session ID to resume (UUID from ~/.claude/projects/).
     /// When set, Claude is started with `--resume <id>`.
     var claudeSessionId: String?

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -936,8 +936,12 @@ struct SessionInfo: Identifiable, Codable {
     /// A shell-safe Claude Code display-name flag for worktree sessions.
     /// Plain sessions start with generic names that may be renamed
     /// asynchronously, so passing those names would race the rename.
+    /// A branch is required too: `openWorktreeSession` names detached-HEAD
+    /// worktrees the literal "session", and labelling every one of them
+    /// identically in the /resume picker is worse than letting Claude
+    /// generate its own name.
     var claudeNameFlag: String? {
-        guard isWorktreeSession,
+        guard isWorktreeSession, branchName != nil,
               let sanitized = Self.sanitizedClaudeName(name) else { return nil }
         return "--name \(SandboxBackend.shellSingleQuoted(sanitized))"
     }
@@ -946,12 +950,16 @@ struct SessionInfo: Identifiable, Codable {
     /// Claude's display name compact. Shell quoting happens only after this
     /// validation step.
     static func sanitizedClaudeName(_ name: String) -> String? {
-        let withoutControls = name.filter { character in
-            !character.unicodeScalars.contains {
-                CharacterSet.controlCharacters.contains($0)
-            }
+        // Whitespace controls (\n, \t, \r) are separators: map them to a space
+        // so the collapse below keeps word boundaries. Dropping them outright
+        // welds words together ("line\nbreak" -> "linebreak"). Other controls
+        // carry no width and are removed.
+        let scalars = name.unicodeScalars.compactMap { scalar -> Unicode.Scalar? in
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) { return " " }
+            if CharacterSet.controlCharacters.contains(scalar) { return nil }
+            return scalar
         }
-        let collapsed = withoutControls
+        let collapsed = String(String.UnicodeScalarView(scalars))
             .split(whereSeparator: { $0.isWhitespace })
             .joined(separator: " ")
         let sanitized = String(collapsed.prefix(64))

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -206,6 +206,9 @@ struct SessionView: View {
                     if backend.supportsResume, let sessionId = session.claudeSessionId {
                         command += " --resume \(sessionId)"
                     }
+                    if let nameFlag = session.claudeNameFlag {
+                        command += " \(nameFlag)"
+                    }
                     let launchCommand = command
                     // Preflight the sandbox before launching. SandboxChecker.check
                     // is nonisolated, so awaiting it from this MainActor task runs

--- a/Tests/SessionNameTests.swift
+++ b/Tests/SessionNameTests.swift
@@ -40,16 +40,77 @@ struct SessionNameTests {
         #expect(worktreeSession(named: name).claudeNameFlag == nil)
     }
 
-    @Test func appleContainerNestedQuotingRoundTrips() throws {
-        let session = worktreeSession(named: "it's-$(whoami)-`id`;a|b&c")
-        let sanitized = try #require(SessionInfo.sanitizedClaudeName(session.name))
-        let flag = try #require(session.claudeNameFlag)
-        let token = try #require(flag.split(separator: " ", maxSplits: 1).last)
+    /// Whitespace control characters are separators, not noise: dropping them
+    /// outright welds words together. Hardcoded expectations on purpose --
+    /// nameEscapingRoundTrips compares against sanitizedClaudeName's own
+    /// output, so it cannot see a sanitizer bug, only a quoting one.
+    @Test(arguments: [
+        ("line\nbreak", "line break"),
+        ("tab\tsep", "tab sep"),
+        ("crlf\r\nsep", "crlf sep"),
+        ("many \n\t  gaps", "many gaps"),
+        ("  leading and trailing  ", "leading and trailing"),
+        ("bell\u{07}kept", "bellkept"),
+    ])
+    func whitespaceControlsBecomeSeparators(_ input: String, _ expected: String) {
+        #expect(SessionInfo.sanitizedClaudeName(input) == expected)
+    }
 
-        // Apple container embeds claude flags in a single-quoted `sh -c`
-        // script, so exercise the second escaping pass from Settings.swift.
-        let escapedToken = token.replacingOccurrences(of: "'", with: #"'\''"#)
-        #expect(try shellOutput("sh -c 'printf %s \(escapedToken)'") == sanitized)
+    /// A detached-HEAD worktree has no branch, so openWorktreeSession falls
+    /// back to the literal name "session" (AppState.swift:489). Passing that
+    /// labels every such worktree identically in the /resume picker -- worse
+    /// than Claude's own generated name. Absence of a branch means absence of
+    /// a name worth sending.
+    @Test func detachedHeadWorktreeGetsNoNameFlag() {
+        let session = SessionInfo(
+            name: "session",
+            workingDirectory: "/tmp/repo-detached",
+            branchName: nil,
+            worktreePath: "/tmp/repo-detached"
+        )
+        #expect(session.claudeNameFlag == nil)
+    }
+
+    @Test func branchBackedWorktreeStillGetsNameFlag() {
+        let session = SessionInfo(
+            name: "repo-feature",
+            workingDirectory: "/tmp/repo-feature",
+            branchName: "feature",
+            worktreePath: "/tmp/repo-feature"
+        )
+        #expect(session.claudeNameFlag == "--name 'repo-feature'")
+    }
+
+    /// The name flag is appended to the command AFTER claudeCommand has built
+    /// it, so for .appleContainer it lands OUTSIDE the `sh -c '...'` wrapper
+    /// and reaches claude through the wrapper's "$@" -- Settings.swift's
+    /// second escaping pass never touches it, and single-level quoting is
+    /// correct. Exercise the real composition rather than re-applying an
+    /// escaping pass the shipping code does not perform.
+    @Test func appleContainerNameFlagSurvivesTheWrapperArgPath() throws {
+        let hostile = "it's-$(whoami)-`id`;a|b&c"
+        let session = worktreeSession(named: hostile)
+        let sanitized = try #require(SessionInfo.sanitizedClaudeName(hostile))
+        let flag = try #require(session.claudeNameFlag)
+
+        let command = SandboxBackend.appleContainer.claudeCommand(
+            claudeFlags: "--permission-mode auto",
+            sbxFlags: "",
+            containerImage: "canopy-claude",
+            containerFlags: "",
+            disableAltScreen: false
+        ) + " \(flag)"
+
+        // The flag must sit after the wrapper's closing quote, not inside it.
+        let wrapperEnd = try #require(command.range(of: "' claude"))
+        let flagStart = try #require(command.range(of: "--name"))
+        #expect(flagStart.lowerBound > wrapperEnd.lowerBound)
+
+        // Replay the production arg path: the host shell splits the appended
+        // tokens into the wrapper's positional args ($0=claude, $1=--name,
+        // $2=<name>), which `exec claude ... "$@"` forwards verbatim.
+        let tail = String(command[wrapperEnd.upperBound...])
+        #expect(try shellOutput(#"sh -c 'printf %s "$2"' claude\#(tail)"#) == sanitized)
     }
 
     @Test func plainSessionsGetNoNameFlag() {
@@ -57,10 +118,13 @@ struct SessionNameTests {
         #expect(session.claudeNameFlag == nil)
     }
 
+    /// A branch-backed worktree session -- the only shape that gets a name
+    /// flag. branchName must be set: see detachedHeadWorktreeGetsNoNameFlag.
     private func worktreeSession(named name: String) -> SessionInfo {
         SessionInfo(
             name: name,
             workingDirectory: "/tmp/repo-feature",
+            branchName: "feature",
             worktreePath: "/tmp/repo-feature"
         )
     }

--- a/Tests/SessionNameTests.swift
+++ b/Tests/SessionNameTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import Canopy
+
+@Suite("Claude Session Names")
+struct SessionNameTests {
+    @Test(arguments: [
+        "feature/foo",
+        "it's-broken",
+        "fix-$HOME",
+        "fix-$(whoami)",
+        "fix-`rm -rf /`",
+        "a;b",
+        "a|b",
+        "a&b",
+        "a>b",
+        "my session name",
+        "naïve-café-日本語-🌲",
+        "",
+        "   ",
+        String(repeating: "x", count: 500),
+        "line\nbreak",
+    ])
+    func nameEscapingRoundTrips(_ name: String) throws {
+        let session = worktreeSession(named: name)
+
+        guard let sanitized = SessionInfo.sanitizedClaudeName(name) else {
+            #expect(session.claudeNameFlag == nil)
+            return
+        }
+
+        let flag = try #require(session.claudeNameFlag)
+        let token = try #require(flag.split(separator: " ", maxSplits: 1).last)
+        #expect(try shellOutput("printf %s \(token)") == sanitized)
+        #expect(sanitized.count <= 64)
+    }
+
+    @Test(arguments: ["", "   ", "\n\t"])
+    func emptyNamesGetNoNameFlag(_ name: String) {
+        #expect(worktreeSession(named: name).claudeNameFlag == nil)
+    }
+
+    @Test func appleContainerNestedQuotingRoundTrips() throws {
+        let session = worktreeSession(named: "it's-$(whoami)-`id`;a|b&c")
+        let sanitized = try #require(SessionInfo.sanitizedClaudeName(session.name))
+        let flag = try #require(session.claudeNameFlag)
+        let token = try #require(flag.split(separator: " ", maxSplits: 1).last)
+
+        // Apple container embeds claude flags in a single-quoted `sh -c`
+        // script, so exercise the second escaping pass from Settings.swift.
+        let escapedToken = token.replacingOccurrences(of: "'", with: #"'\''"#)
+        #expect(try shellOutput("sh -c 'printf %s \(escapedToken)'") == sanitized)
+    }
+
+    @Test func plainSessionsGetNoNameFlag() {
+        let session = SessionInfo(name: "feature/foo", workingDirectory: "/tmp/repo")
+        #expect(session.claudeNameFlag == nil)
+    }
+
+    private func worktreeSession(named name: String) -> SessionInfo {
+        SessionInfo(
+            name: name,
+            workingDirectory: "/tmp/repo-feature",
+            worktreePath: "/tmp/repo-feature"
+        )
+    }
+
+    private func shellOutput(_ command: String) throws -> String {
+        let process = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        try process.run()
+        process.waitUntilExit()
+
+        let error = String(
+            data: standardError.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        #expect(process.terminationStatus == 0, "Shell failed: \(error)")
+        return String(
+            data: standardOutput.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+    }
+}


### PR DESCRIPTION
Closes #62.

## What changed

- pass `--name` when launching Claude Code for worktree-backed sessions
- sanitize session names by removing control characters, collapsing whitespace, and limiting names to 64 characters
- quote the sanitized value as a single POSIX shell token
- omit `--name` for plain sessions and for names that sanitize to an empty value

## Why

Canopy already gives worktree sessions stable, informative branch-derived names, but Claude Code was launched without them. Passing the name makes those sessions easier to identify in Claude's prompt box and resume picker. Plain sessions are intentionally excluded because their initial `Session N` names may be replaced asynchronously.

The name is treated as hostile shell input because branch-derived names may contain quotes, substitutions, pipes, redirects, and other metacharacters.

## Validation

- `swift test` — 592 tests in 47 suites passed
- table-driven `/bin/sh` round-trip coverage for quotes, substitutions, command separators, Unicode, whitespace, control characters, empty values, and truncation
- nested Apple Container quoting round-trip coverage

The additional Xcode test-scheme run was blocked by the local environment's missing Metal Toolchain and the existing `CanopyTests` Info.plist generation configuration; the application sources compiled before that unrelated build-stage failure.
