### PR TITLE
Assign the Claude session ID with --session-id instead of inferring it (#61)

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00B294BB543063C18696691C /* ClaudeLaunchCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C0B65E7E197C57411BA159 /* ClaudeLaunchCommandTests.swift */; };
 		05AF5195350C4C67FF9FA5BC /* PromptLibrarySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497546CA25721070281597DB /* PromptLibrarySettingsView.swift */; };
 		06DB2B91D0DFC978E1F49EF1 /* CreateWorktreeTrimTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949F9A98DDF728757AFD830A /* CreateWorktreeTrimTests.swift */; };
 		07478539E82EBBAE81225E0D /* ProjectColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DF06DA3F5EC110B202E67A /* ProjectColor.swift */; };
@@ -147,6 +148,7 @@
 		449CEEDE520CA879418BFDB0 /* ActivityData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityData.swift; sourceTree = "<group>"; };
 		46D422E570979B7E618CD81A /* ProjectResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectResolutionTests.swift; sourceTree = "<group>"; };
 		497546CA25721070281597DB /* PromptLibrarySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibrarySettingsView.swift; sourceTree = "<group>"; };
+		49C0B65E7E197C57411BA159 /* ClaudeLaunchCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeLaunchCommandTests.swift; sourceTree = "<group>"; };
 		4A4D3C785D57591E26D53FD6 /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
 		4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCostServiceTests.swift; sourceTree = "<group>"; };
 		4C85444255E7242BE9164BC3 /* PromptLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibrary.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 				CACD793440D91EF9CE9D003D /* AppStateSelectionTests.swift */,
 				8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */,
 				2A50AE6A4115D9E40781BA5E /* BundleScriptTests.swift */,
+				49C0B65E7E197C57411BA159 /* ClaudeLaunchCommandTests.swift */,
 				BC1CBBF86B23C79D577B9030 /* ClaudeSessionFinderTests.swift */,
 				D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */,
 				35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */,
@@ -549,6 +552,7 @@
 				E9221CF570EFEDB632B60747 /* AppStateSelectionTests.swift in Sources */,
 				C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */,
 				C4AE8BB890EB915996AB56DD /* BundleScriptTests.swift in Sources */,
+				00B294BB543063C18696691C /* ClaudeLaunchCommandTests.swift in Sources */,
 				248F3097C1BB13616D1D98BC /* ClaudeSessionFinderTests.swift in Sources */,
 				5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */,
 				C3E5AE9F5279191992C52ECD /* ClaudeVersionCheckerTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -558,6 +558,64 @@ final class AppState: ObservableObject {
         )
     }
 
+    /// The full command used to launch `claude` for a session, plus the
+    /// Claude session ID this call newly assigned (nil when none was).
+    ///
+    /// This lived inside a SwiftUI `.onAppear`, where it could not be tested.
+    /// It also carries three rules that are easy to get wrong:
+    ///
+    /// 1. `--session-id` and `--resume` are mutually exclusive absent
+    ///    `--fork-session`, so exactly one is emitted.
+    /// 2. Reusing a session ID in the same project directory aborts the CLI
+    ///    ("Session ID <id> is already in use"). An app restart re-runs this
+    ///    path with the same persisted `SessionInfo.id`, so once an id is
+    ///    known the flags must swap to `--resume`.
+    /// 3. `claudeSessionId` is decoded straight from sessions.json and gets
+    ///    interpolated into a shell command. The discovery path validates it
+    ///    as a UUID; this one must too, or a junk value reaches the shell.
+    ///
+    /// The id is seeded from `SessionInfo.id` -- already a stable persisted
+    /// per-tab UUID -- so there is no new Codable field and no migration.
+    /// Uniqueness is scoped per project directory, so reuse across worktrees
+    /// is a non-issue.
+    func claudeLaunchCommand(for session: SessionInfo) -> (command: String, assignedId: String?) {
+        var command = claudeCommand(for: session)
+        let backend = sandboxBackend(for: session)
+        var assignedId: String?
+
+        // Skipped for sbx -- its session files live inside the ephemeral
+        // microVM, so neither resuming nor assigning means anything there.
+        // The Apple container backend mounts ~/.claude from the host.
+        if backend.supportsResume {
+            if let existing = session.claudeSessionId, UUID(uuidString: existing) != nil {
+                command += " --resume \(existing)"
+            } else {
+                if let junk = session.claudeSessionId {
+                    NSLog("Canopy: discarding non-UUID claudeSessionId %@ for session %@",
+                          junk, session.id.uuidString)
+                }
+                let fresh = session.id.uuidString
+                command += " --session-id \(fresh)"
+                assignedId = fresh
+            }
+        }
+
+        if let nameFlag = session.claudeNameFlag {
+            command += " \(nameFlag)"
+        }
+        return (command, assignedId)
+    }
+
+    /// Records an assigned Claude session ID. Must be called before the
+    /// command is actually sent: a crash in between would otherwise leave a
+    /// session file on disk that the next launch collides with.
+    func assignClaudeSessionId(_ claudeSessionId: String, to sessionId: UUID) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionId }),
+              sessions[index].claudeSessionId != claudeSessionId else { return }
+        sessions[index].claudeSessionId = claudeSessionId
+        saveSessions()
+    }
+
     func createWorktreeSession(
         project: Project,
         branchName: String,

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -198,18 +198,17 @@ struct SessionView: View {
                         }
                         return
                     }
-                    var command = appState.claudeCommand(for: session)
-                    // Resume a specific Claude session if we have its ID.
-                    // Skipped for sbx -- its session files live inside the
-                    // ephemeral microVM. The Apple container backend mounts
-                    // ~/.claude from the host, so resume works there.
-                    if backend.supportsResume, let sessionId = session.claudeSessionId {
-                        command += " --resume \(sessionId)"
+                    // Flag selection (assign vs resume, and the validation
+                    // behind it) lives in AppState so it can be tested.
+                    let launch = appState.claudeLaunchCommand(for: session)
+                    // Persist BEFORE the command is sent below: a crash in
+                    // between must not leave claude holding a session ID that
+                    // Canopy has forgotten, which the next launch would then
+                    // collide with ("Session ID ... is already in use").
+                    if let assignedId = launch.assignedId {
+                        appState.assignClaudeSessionId(assignedId, to: session.id)
                     }
-                    if let nameFlag = session.claudeNameFlag {
-                        command += " \(nameFlag)"
-                    }
-                    let launchCommand = command
+                    let launchCommand = launch.command
                     // Preflight the sandbox before launching. SandboxChecker.check
                     // is nonisolated, so awaiting it from this MainActor task runs
                     // its blocking subprocess off the main actor while the UI stays

--- a/Tests/ClaudeLaunchCommandTests.swift
+++ b/Tests/ClaudeLaunchCommandTests.swift
@@ -1,0 +1,223 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Canopy used to reverse-engineer the Claude session ID from JSONL mtimes.
+/// The CLI lets us *assign* it with `--session-id`, which removes a whole
+/// class of bugs -- most visibly that a brand-new worktree session had no id
+/// at all for the entire app run, leaving the transcript viewer empty and the
+/// token counts missing for exactly the sessions Canopy itself creates.
+///
+/// The CLI's constraints drive the design (confirmed against 2.1.224):
+///
+///   --session-id and --resume are mutually exclusive absent --fork-session;
+///   the id must be a valid UUID;
+///   reusing an id in the same project directory aborts with
+///   "Error: Session ID <id> is already in use."
+///
+/// That last one is why a second launch must switch to --resume: an app
+/// restart re-runs this path with the same persisted SessionInfo.id.
+///
+/// The decision lives in AppState rather than the SwiftUI .onAppear it used to
+/// occupy, so it can be tested at all.
+@Suite("Claude launch command")
+@MainActor
+struct ClaudeLaunchCommandTests {
+
+    private func makeState() -> AppState {
+        let state = AppState(configDir: NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)")
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = ""
+        return state
+    }
+
+    // MARK: - Flag selection
+
+    @Test func assignsSessionIdOnFirstLaunch() {
+        let state = makeState()
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt")
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(launch.command.contains("--session-id \(session.id.uuidString)"))
+        #expect(!launch.command.contains("--resume"))
+        #expect(launch.assignedId == session.id.uuidString)
+    }
+
+    /// Passing --session-id again after the id is known aborts the CLI with
+    /// "Session ID ... is already in use", so the flags must swap over.
+    @Test func resumesInsteadOfAssigningWhenIdKnown() {
+        let state = makeState()
+        let known = UUID().uuidString
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt", claudeSessionId: known)
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(launch.command.contains("--resume \(known)"))
+        #expect(!launch.command.contains("--session-id"))
+        #expect(launch.assignedId == nil)
+    }
+
+    /// The highest-value test here: an app restart re-runs the launch path
+    /// with the same persisted session. Drive it twice, persisting between,
+    /// exactly as MainWindow does.
+    @Test func secondLaunchResumesRatherThanColliding() {
+        let state = makeState()
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt")
+        state.sessions = [session]
+
+        let first = state.claudeLaunchCommand(for: session)
+        let assigned = try! #require(first.assignedId)
+        state.assignClaudeSessionId(assigned, to: session.id)
+
+        let reloaded = state.sessions[0]
+        let second = state.claudeLaunchCommand(for: reloaded)
+        #expect(second.command.contains("--resume \(assigned)"))
+        #expect(!second.command.contains("--session-id"))
+        #expect(second.assignedId == nil)
+    }
+
+    /// sbx session files live inside the ephemeral microVM, which is why
+    /// supportsResume is false. Assigning an id there buys nothing and risks
+    /// an "already in use" abort if a future sbx persists state.
+    @Test func dockerSbxGetsNeitherFlag() {
+        let state = makeState()
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp/wt",
+            claudeSessionId: UUID().uuidString,
+            sandboxBackend: .dockerSbx
+        )
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(!launch.command.contains("--session-id"))
+        #expect(!launch.command.contains("--resume"))
+        #expect(launch.assignedId == nil)
+    }
+
+    /// For .appleContainer the flags must land AFTER the `sh -c '...'`
+    /// wrapper's closing quote so they reach claude through "$@". Assert
+    /// ordering, not containment: containment would still pass if someone
+    /// moved the injection inside claudeFlags, where the second escaping pass
+    /// would mangle it.
+    @Test func appleContainerAppendsFlagsAfterWrapper() throws {
+        let state = makeState()
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp/wt",
+            sandboxBackend: .appleContainer
+        )
+        state.sessions = [session]
+
+        let command = state.claudeLaunchCommand(for: session).command
+        let wrapperEnd = try #require(command.range(of: "' claude"))
+        let flag = try #require(command.range(of: "--session-id"))
+        #expect(flag.lowerBound > wrapperEnd.lowerBound)
+    }
+
+    /// UUID().uuidString is uppercase and claude echoes the string verbatim
+    /// into the JSONL filename -- no normalization. ClaudeTranscriptLoader
+    /// .sessionFilePath depends on that, so do NOT add a lowercasing step.
+    @Test func uppercaseUuidIsPassedVerbatim() {
+        let state = makeState()
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt")
+        state.sessions = [session]
+
+        let assigned = state.claudeLaunchCommand(for: session).assignedId
+        #expect(assigned == session.id.uuidString)
+        #expect(assigned == assigned?.uppercased())
+    }
+
+    // MARK: - Adversarial
+
+    /// claudeSessionId is decoded straight from sessions.json and was
+    /// interpolated into a shell command with no validation. The discovery
+    /// path validates as a UUID; the persistence path did not. A junk value
+    /// must be discarded and a fresh id assigned, never emitted.
+    @Test(arguments: [
+        "abc; rm -rf ~",
+        "",
+        "../../etc/passwd",
+        "not-a-uuid",
+        "$(whoami)",
+        "`id`",
+    ])
+    func rejectsNonUuidPersistedSessionId(_ hostile: String) {
+        let state = makeState()
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp/wt", claudeSessionId: hostile
+        )
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(!launch.command.contains("--resume"))
+        #expect(!launch.command.contains(hostile.isEmpty ? "\u{0}" : hostile))
+        #expect(launch.assignedId == session.id.uuidString)
+    }
+
+    // MARK: - Persistence
+
+    @Test func assignMutatorPersistsAcrossReload() {
+        let dir = NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let state = AppState(configDir: dir)
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt-\(UUID().uuidString)")
+        state.sessions = [session]
+        let assigned = state.claudeLaunchCommand(for: session).assignedId!
+        state.assignClaudeSessionId(assigned, to: session.id)
+
+        let reloaded = AppState(configDir: dir)
+        reloaded.loadSessions()
+        #expect(reloaded.sessions.first?.claudeSessionId == assigned)
+    }
+
+    @Test func assignIsIgnoredForUnknownSession() {
+        let state = makeState()
+        state.sessions = [SessionInfo(name: "s", workingDirectory: "/tmp/wt")]
+        state.assignClaudeSessionId(UUID().uuidString, to: UUID())
+        #expect(state.sessions.first?.claudeSessionId == nil)
+    }
+
+    // MARK: - Upstream contract
+
+    /// Characterization test, same spirit as the SwiftTerm SGR one: it does
+    /// not test Canopy, it tells you when the CLI contract this feature is
+    /// built on has moved. Skips when `claude` is not installed (CI).
+    @Test func claudeCliStillSupportsSessionId() throws {
+        guard let help = try? shellOutput("claude --help 2>/dev/null"), !help.isEmpty else { return }
+        #expect(help.contains("--session-id"))
+        // --resume must still exist too: it is the other half of the pair.
+        #expect(help.contains("--resume"))
+    }
+
+    private func shellOutput(_ command: String) throws -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-lc", command]
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        // Drain before waiting, per the repo's anti-deadlock convention.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - Composition with the name flag
+
+    /// --name was added in #63 and is appended at the same call site. Both
+    /// flags must survive together, after the wrapper.
+    @Test func nameFlagStillAppendedAlongsideSessionId() {
+        let state = makeState()
+        let session = SessionInfo(
+            name: "repo-feature", workingDirectory: "/tmp/wt",
+            branchName: "feature", worktreePath: "/tmp/wt"
+        )
+        state.sessions = [session]
+
+        let command = state.claudeLaunchCommand(for: session).command
+        #expect(command.contains("--session-id \(session.id.uuidString)"))
+        #expect(command.contains("--name 'repo-feature'"))
+    }
+}

--- a/Tests/ClaudeLaunchCommandTests.swift
+++ b/Tests/ClaudeLaunchCommandTests.swift
@@ -195,11 +195,18 @@ struct ClaudeLaunchCommandTests {
         let pipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-lc", command]
+        let errPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = errPipe
         try process.run()
-        // Drain before waiting, per the repo's anti-deadlock convention.
+        // BOTH pipes drained before waiting. An unread stderr pipe fills its
+        // 64K buffer and blocks the child forever -- the deadlock this repo
+        // already has a regression test for -- and a login shell's rc files
+        // can be noisy. Kept separate rather than merged so that a machine
+        // without `claude` still yields empty stdout and skips the test,
+        // instead of asserting against "command not found".
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        _ = errPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         return String(data: data, encoding: .utf8) ?? ""
     }


### PR DESCRIPTION
Third of five PRs for milestone 1.2.0. **Stacked on #67** (which is stacked on #65).

Canopy reverse-engineered which conversation a tab owned by picking the newest `.jsonl` by mtime. The CLI lets us *assign* it, which removes the guess.

## The defect this fixes

`createWorktreeSession` built `SessionInfo` with **no** `claudeSessionId`, and nothing wrote one back. So a brand-new worktree session had no id for the entire app run:

- `TranscriptSheet.computeJSONLPath` returns nil (it deliberately refuses a newest-mtime fallback) → transcript viewer empty
- `SessionCostService.loadUsage` returns an empty `TokenUsage` → the token row silently vanishes

**Two of Canopy's features were broken for exactly the sessions Canopy itself creates.**

## CLI constraints — verified by running it, not read from docs

All confirmed against 2.1.224:

```
$ SID=$(uuidgen)          # 9ACE85E1-A7DE-4E04-AD00-3A83DB88C412
$ claude --session-id "$SID" -p 'say ok'
$ ls ~/.claude/projects/<encoded-cwd>/
9ACE85E1-A7DE-4E04-AD00-3A83DB88C412.jsonl     # case preserved verbatim

$ claude --session-id "$SID" -p 'say ok'       # same cwd, second time
Error: Session ID 9ACE85E1-A7DE-4E04-AD00-3A83DB88C412 is already in use.
```

Three consequences drive the design:

1. **`--session-id` and `--resume` are mutually exclusive** absent `--fork-session`, so exactly one is emitted.
2. **First launch only.** An app restart re-runs this path with the same persisted `SessionInfo.id`, so once an id is known the flags must swap to `--resume` — otherwise the session aborts on startup. That is the highest-value test in the suite (`secondLaunchResumesRatherThanColliding`, which drives the launch twice, persisting between).
3. **Uppercase is fine and must stay.** claude echoes the string verbatim into the filename, so `ClaudeTranscriptLoader.sessionFilePath` matches with no lowercasing. A test pins the no-normalization contract so nobody "helpfully" adds one.

## The seam

Launch logic lived inside a SwiftUI `.onAppear`, where it could not be tested at all. It moved to `AppState.claudeLaunchCommand(for:) -> (command, assignedId)`, and the view collapsed to one call plus "persist if non-nil".

The assigned id is persisted **before** the delayed `sendCommand` — a crash in between would otherwise leave claude holding an id Canopy has forgotten, and the next launch would collide with it.

## Latent hole closed

`claudeSessionId` is decoded straight from `sessions.json` and was interpolated into a shell command with **no validation**, while the discovery path validated it as a UUID. A non-UUID value is now discarded and logged, and a fresh id assigned. Covered by a parameterized adversarial test (`abc; rm -rf ~`, `$(whoami)`, `../../etc/passwd`, …).

## Compatibility

The id is seeded from `SessionInfo.id`, an existing stable persisted per-tab UUID — **no new Codable field, no decoder change, no migration**. Uniqueness is scoped per project directory, so reuse across worktrees is a non-issue. Sessions with a discovered id keep behaving byte-identically. `.dockerSbx` gets neither flag, since its session files live inside the ephemeral microVM.

This depends on #65's `loadSessions` fix: without it, every restart would overwrite the assigned id with the newest JSONL and the assignment would be pointless.

## Known limitation, accepted

An assigned id goes stale after `/clear` or `--fork-session`, and the transcript/cost sheets then read the old file. mtime discovery would have caught that; assignment won't. Deliberately not building reconciliation here — the next PR's live-agent data corrects it for the `.off` backend.

## Verification

- 637 tests across 50 suites (was 626/49).
- `scripts/bundle.sh` archive succeeds and installs.