### PR TITLE
Ask Claude Code what it is doing instead of guessing from PTY silence (#52, closes #54)

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -68,15 +68,18 @@
 		A76F71582F1364D48A52A2D7 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380F49104F9CB7D2D472F216 /* GitService.swift */; };
 		A81E79BF1DEB7FDB08AE364B /* ContainerImageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */; };
 		A942B94AE83364B1A71E5560 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E1669D32944FC23A8BA7E8 /* ActivityView.swift */; };
+		A97131549ACC25F535D0E6CC /* ClaudeAgentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49C418E43653E682DB92BD0 /* ClaudeAgentsService.swift */; };
 		A99747F00CB618221698BADC /* GitServiceEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCD73E1AAF4DB1313798423 /* GitServiceEdgeCaseTests.swift */; };
 		AB36D3222DD82D33B873783A /* ActivityDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */; };
 		B44CE17C1CF9BA41D411CE90 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E2818C52F1491CECED6EA6 /* HelpView.swift */; };
 		B4670C2A691FC8A53E1BB919 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 85B38EAAB72CA93D542089E0 /* .gitkeep */; };
 		B48BFDA403A0ABE090C067B5 /* StopAllSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B7E843E7BD7B5EB66188C9 /* StopAllSessionsTests.swift */; };
 		B5EBB6002FC4E7AE9B88B3B2 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */; };
+		B62F0F2D8BE2D11A6C3AD942 /* AgentReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBA8013125A94627C67870D /* AgentReconciliationTests.swift */; };
 		B7E313D2316AD76F2C7CF7F9 /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC34A1B34310D4ECCF8BA6E /* StatusBar.swift */; };
 		BADE4D87BE6EAAE9DFC0CF9F /* WorktreeCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1731FEC2A46A90F44E14EB1 /* WorktreeCollisionTests.swift */; };
 		C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */; };
+		C1ADFB5A6E22400C85855B41 /* ClaudeAgentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9311D7F235BE554139C28AD /* ClaudeAgentsServiceTests.swift */; };
 		C20B1FD7CDB479CD9E788FA3 /* ProjectColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */; };
 		C3E5AE9F5279191992C52ECD /* ClaudeVersionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */; };
 		C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA12AC586A4E8219DE7BF6A /* CanopyApp.swift */; };
@@ -174,6 +177,7 @@
 		97282B824EEE8B84522D0A67 /* TerminalKeyPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyPolicyTests.swift; sourceTree = "<group>"; };
 		9CF6A405D64E374EAF900972 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		9D974FBD7BD5BBBDF64BE541 /* SessionCostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCostService.swift; sourceTree = "<group>"; };
+		9DBA8013125A94627C67870D /* AgentReconciliationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentReconciliationTests.swift; sourceTree = "<group>"; };
 		A0271CB539907F8DE232DFD8 /* AboutViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewTests.swift; sourceTree = "<group>"; };
 		A2C6EF49762707F54BEAD160 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		A50805AC04ABA37E1275DD68 /* ActivityDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDataTests.swift; sourceTree = "<group>"; };
@@ -181,6 +185,7 @@
 		ACB2C823DFBD1F46E0EA7D84 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		B144B4427757B08905287719 /* CanopyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CanopyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4196F92A864139C78719C45 /* ShortcutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsView.swift; sourceTree = "<group>"; };
+		B9311D7F235BE554139C28AD /* ClaudeAgentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAgentsServiceTests.swift; sourceTree = "<group>"; };
 		B94D69DB49FB6F3E798C7A07 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		B97AF671863E017A955F7A75 /* TerminalSessionEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionEdgeCaseTests.swift; sourceTree = "<group>"; };
 		B9AA8EED2BAA87F332CE3C54 /* Canopy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Canopy.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -209,6 +214,7 @@
 		F01069EB212E35C9D43FF49A /* WorktreeSessionLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSessionLookupTests.swift; sourceTree = "<group>"; };
 		F43DF5D5450E527968F656AF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F454478B3A59FAB10B6D3535 /* ActivityHeatmap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityHeatmap.swift; sourceTree = "<group>"; };
+		F49C418E43653E682DB92BD0 /* ClaudeAgentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAgentsService.swift; sourceTree = "<group>"; };
 		F9715E211F7F3C1E0B155E9B /* CanopyLogo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CanopyLogo.png; sourceTree = "<group>"; };
 		FCCD73E1AAF4DB1313798423 /* GitServiceEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceEdgeCaseTests.swift; sourceTree = "<group>"; };
 		FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
@@ -260,6 +266,7 @@
 			isa = PBXGroup;
 			children = (
 				8F75DF1CB976D5AFF46B9E9E /* ActivityDataService.swift */,
+				F49C418E43653E682DB92BD0 /* ClaudeAgentsService.swift */,
 				1B64F1A3B9D1A7D162DFE72B /* ClaudeTranscriptLoader.swift */,
 				262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */,
 				380F49104F9CB7D2D472F216 /* GitService.swift */,
@@ -331,10 +338,12 @@
 			children = (
 				A0271CB539907F8DE232DFD8 /* AboutViewTests.swift */,
 				A50805AC04ABA37E1275DD68 /* ActivityDataTests.swift */,
+				9DBA8013125A94627C67870D /* AgentReconciliationTests.swift */,
 				FDCCBC975F1E040A1EB8E648 /* AppStatePersistenceTests.swift */,
 				CACD793440D91EF9CE9D003D /* AppStateSelectionTests.swift */,
 				8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */,
 				2A50AE6A4115D9E40781BA5E /* BundleScriptTests.swift */,
+				B9311D7F235BE554139C28AD /* ClaudeAgentsServiceTests.swift */,
 				49C0B65E7E197C57411BA159 /* ClaudeLaunchCommandTests.swift */,
 				BC1CBBF86B23C79D577B9030 /* ClaudeSessionFinderTests.swift */,
 				D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */,
@@ -507,6 +516,7 @@
 				7D0C18601F227CEF202B5C4A /* AppState.swift in Sources */,
 				7718A73098A0749B5F797469 /* BuildInfo.swift in Sources */,
 				C49ACE7BADCCFCA5978031B6 /* CanopyApp.swift in Sources */,
+				A97131549ACC25F535D0E6CC /* ClaudeAgentsService.swift in Sources */,
 				44FD7A8C10F00F715B09A452 /* ClaudeSessionFinder.swift in Sources */,
 				78D62DB77DC10FAD4E4A328F /* ClaudeTranscriptLoader.swift in Sources */,
 				8D6245F4C4458543D98ECB31 /* ClaudeVersionChecker.swift in Sources */,
@@ -548,10 +558,12 @@
 			files = (
 				FD98025C78918A7284021A0A /* AboutViewTests.swift in Sources */,
 				505CFEC35A9A1970F752EE1C /* ActivityDataTests.swift in Sources */,
+				B62F0F2D8BE2D11A6C3AD942 /* AgentReconciliationTests.swift in Sources */,
 				A1669D51D797B9FBA7C424E6 /* AppStatePersistenceTests.swift in Sources */,
 				E9221CF570EFEDB632B60747 /* AppStateSelectionTests.swift in Sources */,
 				C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */,
 				C4AE8BB890EB915996AB56DD /* BundleScriptTests.swift in Sources */,
+				C1ADFB5A6E22400C85855B41 /* ClaudeAgentsServiceTests.swift in Sources */,
 				00B294BB543063C18696691C /* ClaudeLaunchCommandTests.swift in Sources */,
 				248F3097C1BB13616D1D98BC /* ClaudeSessionFinderTests.swift in Sources */,
 				5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -81,6 +81,7 @@ final class AppState: ObservableObject {
     private var cachedPRsByRepo: [String: [GitPRInfo]] = [:]
     private var lastPRRefreshByRepo: [String: Date] = [:]
     private var gitPollTask: Task<Void, Never>?
+    private var agentsPollTask: Task<Void, Never>?
 
     private let lastUpdateCheckKey = "canopy.lastUpdateCheck"
     private let updateCheckInterval: TimeInterval = 24 * 60 * 60
@@ -218,6 +219,141 @@ final class AppState: ObservableObject {
             subtitle: session.name,
             sessionId: sessionId
         )
+    }
+
+    /// Unlike the finish notification, this fires even when Canopy is the
+    /// active app -- you are usually looking at a DIFFERENT tab while another
+    /// one blocks, and a blocked session stays blocked forever until answered.
+    private func postNeedsInputNotification(for sessionId: UUID) {
+        guard settings.notifyOnNeedsInput else { return }
+        guard !NSApp.isActive || sessionId != activeSessionId else { return }
+        guard let session = sessions.first(where: { $0.id == sessionId }) else { return }
+
+        let projectName = projects.first(where: { $0.id == session.projectId })?.name
+        NotificationService.shared.postSessionNeedsInput(
+            title: projectName ?? "Canopy",
+            subtitle: session.name,
+            sessionId: sessionId
+        )
+    }
+
+    // MARK: - Live Agent Reconciliation
+
+    /// Consecutive idle observations required before a turn counts as
+    /// finished. Status flaps to idle between tool calls inside a single
+    /// turn, so one observation is not a turn boundary.
+    static let confirmedIdlePolls = 2
+
+    /// Whether a busy → idle transition is confirmed rather than a flap.
+    static func confirmsFinish(wasWorking: Bool, consecutiveIdleObservations: Int) -> Bool {
+        wasWorking && consecutiveIdleObservations >= confirmedIdlePolls
+    }
+
+    /// Consecutive idle observations per session, for the flap guard above.
+    private var agentIdleObservations: [UUID: Int] = [:]
+
+    /// Applies a poll of `claude agents --json` to the live sessions.
+    ///
+    /// Claude Code reports what it is actually doing, which the PTY cannot:
+    /// a permission prompt emits no bytes, so the 5-second silence heuristic
+    /// declared such sessions finished mid-turn and then decayed them to a
+    /// grey dot indistinguishable from an empty prompt.
+    ///
+    /// Gated on the `.off` backend. Container sessions write their registry
+    /// entry into the bind-mounted host ~/.claude, but `pid` is a guest
+    /// namespace pid and the peer socket is unreachable from the host, so
+    /// their status cannot be trusted. `.dockerSbx` shares nothing at all.
+    func applyAgents(_ agents: [ClaudeAgent]) {
+        for session in sessions {
+            guard sandboxBackend(for: session) == .off,
+                  let terminal = terminalSessions[session.id] else { continue }
+
+            // Ambiguous means two claudes under one directory (a split
+            // terminal, or one the user started by hand). Canopy cannot know
+            // which is this tab's, and guessing binds it to the wrong
+            // transcript -- so keep the existing behaviour.
+            guard case .one(let agent) = ClaudeAgentsService.agent(
+                forWorktree: session.workingDirectory, in: agents
+            ) else {
+                agentIdleObservations[session.id] = 0
+                continue
+            }
+
+            // Adopt an id only from a conversation that started after this tab
+            // opened. Without this, a claude the user has had running in that
+            // worktree since yesterday would be adopted on the first poll.
+            if let startedAt = agent.startedAt,
+               Date(timeIntervalSince1970: startedAt / 1000) >= terminal.openedAt {
+                assignClaudeSessionId(agent.sessionId, to: session.id)
+            }
+
+            // No opinion -> leave the PTY heuristic in charge.
+            guard let reported = ClaudeAgentsService.activity(for: agent.status) else { continue }
+
+            let previous = terminal.activity
+            guard reported == .idle else {
+                agentIdleObservations[session.id] = 0
+                terminal.setAuthoritativeActivity(reported)
+                // Only on the transition: a session sits in `waiting` for as
+                // long as the prompt is open, and re-notifying every poll
+                // would be a 2-second alarm clock.
+                if reported == .needsInput, previous != .needsInput {
+                    postNeedsInputNotification(for: session.id)
+                }
+                continue
+            }
+
+            let idleCount = (agentIdleObservations[session.id] ?? 0) + 1
+            agentIdleObservations[session.id] = idleCount
+            let wasWorking = previous == .working || previous == .needsInput
+            guard Self.confirmsFinish(wasWorking: wasWorking, consecutiveIdleObservations: idleCount)
+                    || !wasWorking else { continue }
+
+            if wasWorking {
+                terminal.setAuthoritativeActivity(.justFinished)
+                postFinishNotification(for: session.id)
+            } else if previous != .idle {
+                // Decays the checkmark on the following poll.
+                terminal.setAuthoritativeActivity(.idle)
+            }
+        }
+    }
+
+    /// Polls Claude Code for live session state. Separate from the 10 s git
+    /// poll because this drives the activity dots and wants to be responsive.
+    ///
+    /// One `claude agents --json` invocation per cycle covers every session.
+    func startAgentPolling() {
+        agentsPollTask?.cancel()
+        agentsPollTask = Task { @MainActor [weak self] in
+            var consecutiveFailures = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled, let self else { break }
+                // Nothing to reconcile if every session is sandboxed: the
+                // subprocess would be pure waste on a 2-second loop.
+                guard self.sessions.contains(where: { self.sandboxBackend(for: $0) == .off })
+                else { continue }
+
+                guard let agents = await ClaudeAgentsService.fetch() else {
+                    consecutiveFailures += 1
+                    if consecutiveFailures >= 3 {
+                        // Not an error state: the fallback is the behaviour
+                        // Canopy shipped with. Say so once and stop trying.
+                        NSLog("Canopy: `claude agents --json` unavailable; using the PTY heuristic")
+                        return
+                    }
+                    continue
+                }
+                consecutiveFailures = 0
+                self.applyAgents(agents)
+            }
+        }
+    }
+
+    func stopAgentPolling() {
+        agentsPollTask?.cancel()
+        agentsPollTask = nil
     }
 
     // MARK: - Git Status Polling

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -326,6 +326,14 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Whether any session's activity could be reconciled from the host
+    /// registry. When nothing qualifies -- no sessions, or every one of them
+    /// sandboxed -- the poll's subprocess would be pure waste on a 2-second
+    /// loop, so the cycle skips it entirely.
+    var hasReconcilableSessions: Bool {
+        sessions.contains { sandboxBackend(for: $0) == .off }
+    }
+
     /// Polls Claude Code for live session state. Separate from the 10 s git
     /// poll because this drives the activity dots and wants to be responsive.
     ///
@@ -337,10 +345,7 @@ final class AppState: ObservableObject {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled, let self else { break }
-                // Nothing to reconcile if every session is sandboxed: the
-                // subprocess would be pure waste on a 2-second loop.
-                guard self.sessions.contains(where: { self.sandboxBackend(for: $0) == .off })
-                else { continue }
+                guard self.hasReconcilableSessions else { continue }
 
                 guard let agents = await ClaudeAgentsService.fetch() else {
                     consecutiveFailures += 1

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -287,8 +287,15 @@ final class AppState: ObservableObject {
                 assignClaudeSessionId(agent.sessionId, to: session.id)
             }
 
-            // No opinion -> leave the PTY heuristic in charge.
-            guard let reported = ClaudeAgentsService.activity(for: agent.status) else { continue }
+            // No opinion -> leave the PTY heuristic in charge. Reset the
+            // counter too: "two consecutive idle polls" must mean consecutive.
+            // Keeping a stale count across an opinion-less poll lets an idle
+            // from before the gap pair with one after it and confirm a finish
+            // that never happened.
+            guard let reported = ClaudeAgentsService.activity(for: agent.status) else {
+                agentIdleObservations[session.id] = 0
+                continue
+            }
 
             let previous = terminal.activity
             guard reported == .idle else {

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -156,6 +156,11 @@ struct CanopySettings: Codable {
     /// Whether to show macOS notifications when a session finishes.
     var notifyOnFinish: Bool
 
+    /// Notify when a session becomes blocked waiting on the user. Separate
+    /// from notifyOnFinish because it is the more urgent of the two: a
+    /// finished session costs you nothing, a stalled one costs you the turn.
+    var notifyOnNeedsInput: Bool
+
     /// Keep the terminal scroll bar by opting Claude Code out of the
     /// alternate screen buffer (CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1).
     /// Claude Code ≥ 2.1.206 renders in the alt buffer, where SwiftTerm has
@@ -195,13 +200,14 @@ struct CanopySettings: Codable {
         ((terminalPath as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 
-    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, disableAltScreen: Bool = true, checkForUpdatesOnLaunch: Bool = true, sandboxBackend: SandboxBackend = .off, sbxFlags: String = "", containerImage: String = "canopy-claude", containerFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil, containerPath: String? = nil) {
+    init(autoStartClaude: Bool = true, claudeFlags: String = "--permission-mode auto", confirmBeforeClosing: Bool = true, idePath: String = "/Applications/Cursor.app", terminalPath: String = "/System/Applications/Utilities/Terminal.app", notifyOnFinish: Bool = true, notifyOnNeedsInput: Bool = true, disableAltScreen: Bool = true, checkForUpdatesOnLaunch: Bool = true, sandboxBackend: SandboxBackend = .off, sbxFlags: String = "", containerImage: String = "canopy-claude", containerFlags: String = "", ghPath: String? = nil, sbxPath: String? = nil, containerPath: String? = nil) {
         self.autoStartClaude = autoStartClaude
         self.claudeFlags = claudeFlags
         self.confirmBeforeClosing = confirmBeforeClosing
         self.idePath = idePath
         self.terminalPath = terminalPath
         self.notifyOnFinish = notifyOnFinish
+        self.notifyOnNeedsInput = notifyOnNeedsInput
         self.disableAltScreen = disableAltScreen
         self.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
         self.sandboxBackend = sandboxBackend
@@ -236,6 +242,8 @@ struct CanopySettings: Codable {
         idePath = try container.decodeIfPresent(String.self, forKey: .idePath) ?? "/Applications/Cursor.app"
         terminalPath = try container.decodeIfPresent(String.self, forKey: .terminalPath) ?? "/System/Applications/Utilities/Terminal.app"
         notifyOnFinish = try container.decodeIfPresent(Bool.self, forKey: .notifyOnFinish) ?? true
+        // Absent in settings saved before this existed -> default on.
+        notifyOnNeedsInput = try container.decodeIfPresent(Bool.self, forKey: .notifyOnNeedsInput) ?? true
         disableAltScreen = try container.decodeIfPresent(Bool.self, forKey: .disableAltScreen) ?? true
         checkForUpdatesOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .checkForUpdatesOnLaunch) ?? true
         if let raw = try container.decodeIfPresent(String.self, forKey: .sandboxBackend) {

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -96,7 +96,14 @@ enum ClaudeAgentsService {
     private nonisolated(unsafe) static var cachedClaudePath: String?
 
     private static func resolvedClaudePath() async -> String? {
-        if let cached = cachedClaudePath { return cached }
+        // Re-check the cached path is still executable. claude auto-updates
+        // and can be moved or removed while Canopy runs; a stale path would
+        // fail every poll, and consecutive failures disable reconciliation for
+        // the rest of the session.
+        if let cached = cachedClaudePath {
+            if FileManager.default.isExecutableFile(atPath: cached) { return cached }
+            cachedClaudePath = nil
+        }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// One live `claude` process, as reported by `claude agents --json`.
+///
+/// Only the fields Canopy actually uses are decoded. The real payload also
+/// carries `pid`, `kind` and `name`; `pid` is useless to us (a container
+/// session's pid is a guest-namespace pid, meaningless on the host) and
+/// decoding fields we don't read only adds ways for a schema change to break
+/// the whole array.
+///
+/// `status` and `startedAt` are optional because they really are absent in
+/// practice: sdk-cli entries carry no `status` key at all.
+struct ClaudeAgent: Decodable, Equatable, Sendable {
+    let cwd: String
+    let sessionId: String
+    let status: String?
+    let startedAt: Double?
+}
+
+/// Asks Claude Code which conversations are live, rather than inferring it.
+///
+/// Shaped like `ClaudeVersionChecker` / `SandboxChecker`: a `nonisolated` enum
+/// of pure functions plus one impure `fetch()`. No protocol, no injected
+/// provider -- the seam for tests is the pure functions.
+enum ClaudeAgentsService {
+
+    /// Which live agent, if any, belongs to a given worktree.
+    enum Match: Equatable {
+        case none
+        case one(ClaudeAgent)
+        /// Two or more agents under the same directory. Canopy cannot know
+        /// which is this tab's, and guessing would bind the tab to the wrong
+        /// transcript, so callers must fall back rather than pick.
+        case ambiguous
+    }
+
+    /// Status values the CLI can report, from its own union
+    /// (`["busy","shell","idle","waiting"]`).
+    private enum Status {
+        static let busy = "busy"
+        /// A Bash tool call is running. Still working, not idle.
+        static let shell = "shell"
+        /// Blocked on a dialog -- which includes permission prompts. This is
+        /// the signal the PTY cannot provide: a waiting prompt emits no bytes,
+        /// so the silence heuristic reads it as "finished".
+        static let waiting = "waiting"
+        static let idle = "idle"
+    }
+
+    /// Decodes the CLI's output. Returns nil for anything that is not a
+    /// top-level array, so an old CLI printing usage text or a shell error is
+    /// **detected** rather than read as "zero sessions running" -- the latter
+    /// would push every tab to a wrong state at once.
+    static func parse(_ data: Data) -> [ClaudeAgent]? {
+        try? JSONDecoder().decode([ClaudeAgent].self, from: data)
+    }
+
+    /// Resolves both sides before comparing: /tmp is a symlink to /private/tmp
+    /// on macOS and claude reports its resolved cwd. Matches "at or under" the
+    /// worktree, mirroring the CLI's own `--cwd` semantics -- but never
+    /// upward, since a claude in the parent directory is a different session.
+    static func agent(forWorktree worktree: String, in agents: [ClaudeAgent]) -> Match {
+        let target = SandboxBackend.realResolvedPath(worktree)
+        guard !target.isEmpty else { return .none }
+
+        let matches = agents.filter { agent in
+            let resolved = SandboxBackend.realResolvedPath(agent.cwd)
+            return resolved == target || resolved.hasPrefix(target + "/")
+        }
+        switch matches.count {
+        case 0: return .none
+        case 1: return .one(matches[0])
+        default: return .ambiguous
+        }
+    }
+
+    /// Maps a reported status to an activity, or nil for "no opinion".
+    ///
+    /// Unknown and absent both map to nil deliberately. Treating them as
+    /// `.idle` would fire a false "finished" notification for every sdk-cli
+    /// entry and for every status value the CLI adds in future; nil leaves the
+    /// existing PTY heuristic in charge, which is the current behaviour and
+    /// therefore always a safe fallback.
+    static func activity(for status: String?) -> SessionActivity? {
+        switch status {
+        case Status.busy, Status.shell: return .working
+        case Status.waiting: return .needsInput
+        case Status.idle: return .idle
+        default: return nil
+        }
+    }
+
+    /// Cached absolute path to `claude`, resolved through a login shell.
+    /// `nonisolated(unsafe)` matches the shared-formatter precedent in
+    /// ClaudeSessionFinder: written once from the poll loop, read from it.
+    private nonisolated(unsafe) static var cachedClaudePath: String?
+
+    private static func resolvedClaudePath() async -> String? {
+        if let cached = cachedClaudePath { return cached }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
+        process.arguments = ["-ilc", "command -v claude"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        guard (try? process.run()) != nil else { return nil }
+        let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+
+        let path = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        cachedClaudePath = path
+        return path
+    }
+
+    /// Runs `claude agents --json` and decodes it. Returns nil on any failure,
+    /// which callers treat as "no data this cycle", not as "no sessions".
+    ///
+    /// ONE invocation per poll cycle for ALL sessions -- deliberately no
+    /// `--cwd`. At ~0.3 s per call, filtering per worktree would cost
+    /// 0.3 × N for data a single call already contains.
+    static func fetch() async -> [ClaudeAgent]? {
+        let process = Process()
+        // Resolve claude through a login shell ONCE, then invoke it directly.
+        // The GUI PATH is not the shell PATH (claude is usually only on PATH
+        // via .zshrc), but re-sourcing the rc files on a 2-second loop costs
+        // ~0.1 s of the 0.33 s per call and re-runs the user's shell startup
+        // 1800 times an hour for a path that does not change.
+        if let path = await resolvedClaudePath() {
+            process.executableURL = URL(fileURLWithPath: path)
+            process.arguments = ["agents", "--json"]
+        } else {
+            process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
+            process.arguments = ["-ilc", "claude agents --json"]
+        }
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            NSLog("Canopy: could not run `claude agents --json` (%@)", "\(error)")
+            return nil
+        }
+
+        // A hung rc file would otherwise wedge the poll loop forever.
+        let watchdog = DispatchWorkItem { [weak process] in
+            if process?.isRunning == true { process?.terminate() }
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5, execute: watchdog)
+
+        // Read to EOF BEFORE waiting: a full pipe buffer with the parent
+        // blocked in waitUntilExit is the classic deadlock, and this repo has
+        // a regression test for exactly that shape in GitService.
+        let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+        process.waitUntilExit()
+        watchdog.cancel()
+
+        guard process.terminationStatus == 0 else { return nil }
+        return parse(data)
+    }
+}

--- a/Canopy/Services/NotificationService.swift
+++ b/Canopy/Services/NotificationService.swift
@@ -26,6 +26,22 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         center.add(request, withCompletionHandler: nil)
     }
 
+    /// A blocked session is not a finished one, and saying "Session finished"
+    /// for a permission prompt is actively misleading -- the agent is stalled
+    /// and will stay stalled until someone answers.
+    func postSessionNeedsInput(title: String, subtitle: String, sessionId: UUID) {
+        let content = Self.makeContent(
+            title: title, subtitle: subtitle, sessionId: sessionId,
+            body: Self.needsInputBody
+        )
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        center.add(request, withCompletionHandler: nil)
+    }
+
     func postUpdateAvailable(version: String) {
         let content = UNMutableNotificationContent()
         content.title = "Canopy update available"
@@ -39,11 +55,19 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         center.add(request, withCompletionHandler: nil)
     }
 
-    nonisolated static func makeContent(title: String, subtitle: String, sessionId: UUID) -> UNMutableNotificationContent {
+    nonisolated static let finishedBody = "Session finished"
+    nonisolated static let needsInputBody = "Waiting for your input"
+
+    nonisolated static func makeContent(
+        title: String,
+        subtitle: String,
+        sessionId: UUID,
+        body: String = finishedBody
+    ) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = title
         content.subtitle = subtitle
-        content.body = "Session finished"
+        content.body = body
         content.sound = .default
         content.threadIdentifier = sessionId.uuidString
         content.userInfo = ["sessionId": sessionId.uuidString]

--- a/Canopy/Services/TerminalSession.swift
+++ b/Canopy/Services/TerminalSession.swift
@@ -191,8 +191,24 @@ final class TerminalSession: ObservableObject {
         }
 
         guard Self.containsVisibleContent(data) else { return }
-        activity = .working
+        // .needsInput is sticky against PTY output. A permission prompt keeps
+        // redrawing (spinner, caret blink), and treating those bytes as
+        // progress would stomp the state back to .working every frame. Only
+        // authoritative data may clear it.
+        if activity != .needsInput {
+            activity = .working
+        }
         restartIdleTimer()
+    }
+
+    /// Applies activity reported by Claude Code itself, which outranks the
+    /// PTY-silence heuristic. Cancels the pending timers so the two mechanisms
+    /// cannot fight: without this, the 5-second timer would still fire
+    /// `.justFinished` over an authoritative `.needsInput`.
+    func setAuthoritativeActivity(_ newActivity: SessionActivity) {
+        idleTimer?.cancel()
+        justFinishedTimer?.cancel()
+        activity = newActivity
     }
 
     /// Returns true if data contains printable characters beyond terminal control sequences.
@@ -292,12 +308,18 @@ final class TerminalSession: ObservableObject {
 enum SessionActivity: String {
     case idle
     case working
+    /// Claude is blocked waiting on the user -- a permission prompt, a
+    /// sandbox request, any open dialog. Only ever set from authoritative
+    /// data (`claude agents --json`), never guessed from the PTY, because a
+    /// waiting prompt is indistinguishable from silence at the byte level.
+    case needsInput
     case justFinished
 
     var label: String {
         switch self {
         case .idle: return "Idle"
         case .working: return "Working"
+        case .needsInput: return "Needs Input"
         case .justFinished: return "Just Finished"
         }
     }

--- a/Canopy/Views/ActivityDot.swift
+++ b/Canopy/Views/ActivityDot.swift
@@ -29,6 +29,22 @@ struct ActivityDot: View {
                     .onDisappear { isSpinning = false }
             }
 
+            // Pulsing amber ring: a blocked session must be findable at a
+            // glance across eight tabs, and must not look like the blue
+            // checkmark of a finished one.
+            if activity == .needsInput {
+                Circle()
+                    .stroke(Color.orange, lineWidth: 1.5)
+                    .frame(width: 12, height: 12)
+                    .opacity(isSpinning ? 0.35 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                        value: isSpinning
+                    )
+                    .onAppear { isSpinning = true }
+                    .onDisappear { isSpinning = false }
+            }
+
             // Glow for justFinished
             if activity == .justFinished {
                 Circle()
@@ -37,11 +53,15 @@ struct ActivityDot: View {
                     .blur(radius: 4)
             }
 
-            // Center dot or checkmark
+            // Center dot, checkmark, or raised hand
             if activity == .justFinished {
                 Image(systemName: "checkmark")
                     .font(.system(size: 6, weight: .bold))
                     .foregroundStyle(.blue)
+            } else if activity == .needsInput {
+                Image(systemName: "hand.raised.fill")
+                    .font(.system(size: 6, weight: .bold))
+                    .foregroundStyle(.orange)
             } else {
                 Circle()
                     .fill(centerColor)
@@ -57,6 +77,7 @@ struct ActivityDot: View {
         switch activity {
         case .idle: return 0.15
         case .working: return 0.3
+        case .needsInput: return 0.0
         case .justFinished: return 0.0
         }
     }
@@ -65,6 +86,7 @@ struct ActivityDot: View {
         switch activity {
         case .idle: return .gray
         case .working: return .green
+        case .needsInput: return .orange
         case .justFinished: return .blue
         }
     }
@@ -73,6 +95,7 @@ struct ActivityDot: View {
         switch activity {
         case .idle: return 0.4
         case .working: return 1.0
+        case .needsInput: return 1.0
         case .justFinished: return 1.0
         }
     }

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -45,6 +45,7 @@ struct MainWindow: View {
             .navigationSplitViewStyle(.balanced)
             .onAppear {
                 appState.startGitStatusPolling()
+                appState.startAgentPolling()
             }
             .onChange(of: appState.activeSessionId) { _, _ in
                 appState.activeGitStatus = nil

--- a/Canopy/Views/SessionTabBar.swift
+++ b/Canopy/Views/SessionTabBar.swift
@@ -132,9 +132,11 @@ struct SessionTab: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            // Project color dot (replaces ActivityDot in tabs)
+            // Project color dot (replaces ActivityDot in tabs). A blocked
+            // session is tinted amber rather than the project colour --
+            // otherwise it looks identical to one that is working.
             Circle()
-                .fill(projectColor)
+                .fill(activity == .needsInput ? Color.orange : projectColor)
                 .opacity(activity == .idle ? 0.5 : 1.0)
                 .frame(width: 7, height: 7)
 

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @State private var idePath: String
     @State private var terminalPath: String
     @State private var notifyOnFinish: Bool
+    @State private var notifyOnNeedsInput: Bool
     @State private var disableAltScreen: Bool
     @State private var checkForUpdatesOnLaunch: Bool
     @State private var sandboxBackend: SandboxBackend
@@ -37,6 +38,7 @@ struct SettingsView: View {
         self._idePath = State(initialValue: settings.idePath)
         self._terminalPath = State(initialValue: settings.terminalPath)
         self._notifyOnFinish = State(initialValue: settings.notifyOnFinish)
+        self._notifyOnNeedsInput = State(initialValue: settings.notifyOnNeedsInput)
         self._disableAltScreen = State(initialValue: settings.disableAltScreen)
         self._checkForUpdatesOnLaunch = State(initialValue: settings.checkForUpdatesOnLaunch)
         self._sandboxBackend = State(initialValue: settings.sandboxBackend)
@@ -246,6 +248,10 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             Toggle("Notify when sessions finish", isOn: $notifyOnFinish)
                             Text("Show a macOS notification when a session transitions from working to idle while Canopy is in the background.")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                            Toggle("Notify when sessions need input", isOn: $notifyOnNeedsInput)
+                            Text("Show a notification when Claude blocks on a permission prompt. Also fires while Canopy is in front, since the blocked session is usually not the tab you are looking at. Requires the unsandboxed backend.")
                                 .font(.caption)
                                 .foregroundStyle(.tertiary)
                         }
@@ -489,6 +495,7 @@ struct SettingsView: View {
         settings.idePath = idePath
         settings.terminalPath = terminalPath
         settings.notifyOnFinish = notifyOnFinish
+        settings.notifyOnNeedsInput = notifyOnNeedsInput
         settings.disableAltScreen = disableAltScreen
         settings.checkForUpdatesOnLaunch = checkForUpdatesOnLaunch
         settings.sandboxBackend = sandboxBackend

--- a/Canopy/Views/StatusBar.swift
+++ b/Canopy/Views/StatusBar.swift
@@ -175,31 +175,49 @@ struct StatusBar: View {
             return (session.id, activity)
         }
         let workingCount = activities.filter { $0.1 == .working }.count
+        let needsInputCount = activities.filter { $0.1 == .needsInput }.count
         let totalCount = sessions.count
 
         HStack(spacing: 4) {
             ForEach(activities, id: \.0) { _, activity in
                 Circle()
-                    .fill(activity == .working ? Color.green : Color.gray.opacity(0.4))
+                    .fill(Self.dotColor(for: activity))
                     .frame(width: 5, height: 5)
             }
 
             if totalCount > 0 {
-                Text(summaryText(working: workingCount, total: totalCount))
+                Text(Self.summaryText(working: workingCount, needsInput: needsInputCount, total: totalCount))
                     .font(.system(size: 11))
                     .foregroundStyle(.tertiary)
             }
         }
     }
 
-    private func summaryText(working: Int, total: Int) -> String {
-        if working == 0 {
-            return "\(total) session\(total == 1 ? "" : "s")"
-        } else if working == total {
-            return "\(total) working"
-        } else {
-            return "\(working) working, \(total - working) idle"
+    static func dotColor(for activity: SessionActivity) -> Color {
+        switch activity {
+        case .working: return .green
+        // A blocked session used to be counted and coloured as idle, which is
+        // exactly backwards: it is the one that needs you.
+        case .needsInput: return .orange
+        case .idle, .justFinished: return .gray.opacity(0.4)
         }
+    }
+
+    /// "N need input" leads: with eight worktrees open, which one is blocked
+    /// is the single most valuable thing the status bar can say.
+    static func summaryText(working: Int, needsInput: Int, total: Int) -> String {
+        var parts: [String] = []
+        if needsInput > 0 { parts.append("\(needsInput) need\(needsInput == 1 ? "s" : "") input") }
+        if working > 0 { parts.append("\(working) working") }
+
+        let accounted = needsInput + working
+        if parts.isEmpty {
+            return "\(total) session\(total == 1 ? "" : "s")"
+        }
+        if accounted < total {
+            parts.append("\(total - accounted) idle")
+        }
+        return parts.joined(separator: ", ")
     }
 
     // MARK: - Helpers

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -266,4 +266,24 @@ struct AgentReconciliationTests {
         #expect(terminal.activity == .working)
     }
 
+
+    // MARK: - Poll gating
+
+    /// The poll skips its subprocess entirely when nothing could be
+    /// reconciled. On a 2-second loop that is the difference between an idle
+    /// app and one spawning a process every 2 seconds for no reason.
+    @Test func pollIsSkippedWhenNoSessionQualifies() {
+        let state = makeState()
+        #expect(!state.hasReconcilableSessions)          // no sessions at all
+
+        addSession(to: state, dir: "/tmp/wt-v", backend: .appleContainer)
+        #expect(!state.hasReconcilableSessions)          // sandboxed: invisible to the host
+
+        addSession(to: state, dir: "/tmp/wt-w", backend: .dockerSbx)
+        #expect(!state.hasReconcilableSessions)
+
+        addSession(to: state, dir: "/tmp/wt-x")          // .off
+        #expect(state.hasReconcilableSessions)
+    }
+
 }

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -1,0 +1,251 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Applying a `claude agents --json` poll to live sessions.
+///
+/// Tests call `applyAgents` directly with fixture arrays, so nothing here
+/// spawns a subprocess or waits on a timer.
+@Suite("Agent reconciliation")
+@MainActor
+struct AgentReconciliationTests {
+
+    private func makeState() -> AppState {
+        let state = AppState(configDir: NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)")
+        state.settings.sandboxBackend = .off
+        // Notifications are guarded on NSApp.isActive; these tests only assert
+        // on activity and persisted ids, never on delivery.
+        state.settings.notifyOnFinish = false
+        state.settings.notifyOnNeedsInput = false
+        return state
+    }
+
+    /// A session with a live TerminalSession, as the app would have.
+    @discardableResult
+    private func addSession(
+        to state: AppState,
+        dir: String,
+        backend: SandboxBackend? = nil,
+        claudeSessionId: String? = nil
+    ) -> SessionInfo {
+        let session = SessionInfo(
+            name: "s", workingDirectory: dir,
+            claudeSessionId: claudeSessionId,
+            sandboxBackend: backend
+        )
+        state.sessions.append(session)
+        _ = state.terminalSession(for: session)
+        return session
+    }
+
+    private func agent(
+        cwd: String, sessionId: String = UUID().uuidString,
+        status: String?, startedAt: Date = Date().addingTimeInterval(60)
+    ) -> ClaudeAgent {
+        ClaudeAgent(
+            cwd: cwd, sessionId: sessionId, status: status,
+            startedAt: startedAt.timeIntervalSince1970 * 1000
+        )
+    }
+
+    // MARK: - Identity adoption
+
+    /// The reason this exists: createWorktreeSession builds a session with no
+    /// claudeSessionId, so the transcript viewer and token counts were dead
+    /// for exactly the sessions Canopy creates.
+    @Test func adoptsLiveSessionIdForSessionCreatedWithoutOne() {
+        let state = makeState()
+        let session = addSession(to: state, dir: "/tmp/wt-a")
+        let live = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-a", sessionId: live, status: "idle")])
+
+        #expect(state.sessions[0].claudeSessionId == live)
+        #expect(session.claudeSessionId == nil) // the local copy is stale, by design
+    }
+
+    /// A claude the user has had running in that worktree since yesterday is
+    /// not this tab's conversation.
+    @Test func doesNotAdoptAgentStartedBeforeTheTabOpened() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-b")
+
+        state.applyAgents([agent(
+            cwd: "/tmp/wt-b", status: "idle",
+            startedAt: Date().addingTimeInterval(-86400)
+        )])
+
+        #expect(state.sessions[0].claudeSessionId == nil)
+    }
+
+    @Test func doesNotAdoptWhenAmbiguous() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-c")
+
+        state.applyAgents([
+            agent(cwd: "/tmp/wt-c", sessionId: "a", status: "busy"),
+            agent(cwd: "/tmp/wt-c/sub", sessionId: "b", status: "busy"),
+        ])
+
+        #expect(state.sessions[0].claudeSessionId == nil)
+        #expect(state.terminalSessions[state.sessions[0].id]?.activity == .idle)
+    }
+
+    // MARK: - Sandbox gate
+
+    /// The executable form of the degradation matrix. Both cases use a
+    /// MATCHING cwd, so only the backend gate can be what stops them.
+    @Test(arguments: [SandboxBackend.dockerSbx, .appleContainer])
+    func sandboxedSessionIgnoresAgentData(_ backend: SandboxBackend) {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-sbx", backend: backend)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-sbx", status: "waiting")])
+
+        #expect(state.sessions[0].claudeSessionId == nil)
+        #expect(state.terminalSessions[state.sessions[0].id]?.activity == .idle)
+    }
+
+    // MARK: - Activity
+
+    @Test func waitingStatusSurfacesAsNeedsInput() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-d")
+
+        state.applyAgents([agent(cwd: "/tmp/wt-d", status: "waiting")])
+
+        #expect(state.terminalSessions[state.sessions[0].id]?.activity == .needsInput)
+    }
+
+    /// The regression test for the whole feature: a permission prompt keeps
+    /// redrawing, and treating those bytes as progress would stomp the state
+    /// back to .working every frame.
+    @Test func ptyOutputDoesNotClearNeedsInput() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-e")
+        state.applyAgents([agent(cwd: "/tmp/wt-e", status: "waiting")])
+
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+        terminal.handleOutputData(Data("redrawing spinner".utf8))
+
+        #expect(terminal.activity == .needsInput)
+    }
+
+    /// No agent data at all must leave the existing heuristic untouched --
+    /// that fallback is what every unsupported configuration relies on.
+    @Test func noAgentDataLeavesPtyHeuristicIntact() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-f")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+        terminal.handleOutputData(Data("output".utf8))
+        #expect(terminal.activity == .working)
+
+        state.applyAgents([])
+
+        #expect(terminal.activity == .working)
+    }
+
+    /// An absent status (sdk-cli entries) must be "no opinion", not "idle".
+    @Test func absentStatusDoesNotOverrideActivity() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-g")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+        terminal.handleOutputData(Data("output".utf8))
+
+        state.applyAgents([agent(cwd: "/tmp/wt-g", status: nil)])
+
+        #expect(terminal.activity == .working)
+    }
+
+    // MARK: - Finish edge
+
+    /// Status flaps to idle between tool calls inside a single turn, so one
+    /// idle observation is not a turn boundary.
+    @Test func singleIdleObservationDoesNotFinish() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-h")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-h", status: "busy")])
+        #expect(terminal.activity == .working)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-h", status: "idle")])
+        #expect(terminal.activity == .working)
+    }
+
+    @Test func confirmedBusyToIdleFinishes() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-i")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-i", status: "busy")])
+        state.applyAgents([agent(cwd: "/tmp/wt-i", status: "idle")])
+        state.applyAgents([agent(cwd: "/tmp/wt-i", status: "idle")])
+
+        #expect(terminal.activity == .justFinished)
+    }
+
+    /// An idle flap mid-turn must reset the counter, not accumulate toward a
+    /// spurious finish two tool calls later.
+    @Test func idleFlapBetweenToolCallsResetsTheCounter() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-j")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-j", status: "busy")])
+        state.applyAgents([agent(cwd: "/tmp/wt-j", status: "idle")])
+        state.applyAgents([agent(cwd: "/tmp/wt-j", status: "shell")])
+        state.applyAgents([agent(cwd: "/tmp/wt-j", status: "idle")])
+
+        #expect(terminal.activity == .working)
+    }
+
+    /// An agent disappearing is `claude` exiting, already handled by
+    /// onProcessExit. Firing a finish here would double-notify.
+    @Test func doesNotFinishWhenAgentDisappears() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-k")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-k", status: "busy")])
+        state.applyAgents([])
+        state.applyAgents([])
+
+        #expect(terminal.activity == .working)
+    }
+
+    @Test func confirmsFinishRequiresBothConditions() {
+        #expect(!AppState.confirmsFinish(wasWorking: true, consecutiveIdleObservations: 1))
+        #expect(AppState.confirmsFinish(wasWorking: true, consecutiveIdleObservations: 2))
+        #expect(!AppState.confirmsFinish(wasWorking: false, consecutiveIdleObservations: 5))
+    }
+
+    // MARK: - Persistence
+
+    /// saveSessions does an atomic file write. A 2-second loop must not
+    /// rewrite it 1800 times an hour.
+    @Test func persistsOnlyWhenSessionIdChanges() {
+        let state = makeState()
+        let known = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-l", claudeSessionId: known)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-l", sessionId: known, status: "idle")])
+        #expect(state.sessions[0].claudeSessionId == known)
+    }
+
+    /// The authoritative state must cancel the PTY timers, or the 5-second
+    /// silence timer would still fire .justFinished over a live .needsInput.
+    @Test func authoritativeStatusCancelsThePtySilenceTimer() async throws {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-m")
+        let terminal = try #require(state.terminalSessions[state.sessions[0].id])
+
+        terminal.handleOutputData(Data("starting".utf8))  // arms the 5s timer
+        state.applyAgents([agent(cwd: "/tmp/wt-m", status: "waiting")])
+        #expect(terminal.activity == .needsInput)
+
+        // Well short of the 5s timer, but proves the state survives a tick.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(terminal.activity == .needsInput)
+    }
+}

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -248,4 +248,22 @@ struct AgentReconciliationTests {
         try await Task.sleep(for: .milliseconds(50))
         #expect(terminal.activity == .needsInput)
     }
+
+    /// "Two consecutive idle polls" must mean consecutive. A poll with no
+    /// opinion (absent or unknown status) between two idles is a gap, and
+    /// pairing across it would confirm a finish that never happened.
+    @Test func opinionlessPollResetsTheIdleCounter() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-t")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-t", status: "busy")])
+        state.applyAgents([agent(cwd: "/tmp/wt-t", status: "idle")])
+        state.applyAgents([agent(cwd: "/tmp/wt-t", status: nil)])   // no opinion
+        state.applyAgents([agent(cwd: "/tmp/wt-t", status: "idle")])
+
+        // Without the reset this reaches two idles and fires .justFinished.
+        #expect(terminal.activity == .working)
+    }
+
 }

--- a/Tests/ClaudeAgentsServiceTests.swift
+++ b/Tests/ClaudeAgentsServiceTests.swift
@@ -1,0 +1,178 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// `claude agents --json` reports every live `claude` process on the machine.
+/// Canopy uses it to answer two questions it previously guessed at:
+/// which conversation a tab is running, and whether that conversation is busy,
+/// idle, or blocked waiting on the user.
+///
+/// Fixtures are literal JSON copied from real output, including a real
+/// status-less sdk-cli entry (3 of 11 live entries had no `status` key when
+/// this was written).
+@Suite("ClaudeAgentsService")
+struct ClaudeAgentsServiceTests {
+
+    private func data(_ json: String) -> Data { Data(json.utf8) }
+
+    // MARK: - Parsing
+
+    @Test func parsesRealWorldArray() throws {
+        let agents = try #require(ClaudeAgentsService.parse(data("""
+        [
+          {"pid":69798,"cwd":"/Users/julien/Development/canopy","kind":"interactive",
+           "startedAt":1786035803954,"sessionId":"28619ed8-8eb5-4461-883b-b9dc15f2a591",
+           "name":"canopy-b5","status":"busy"},
+          {"pid":21880,"cwd":"/Users/julien/Development/repos/ghost","kind":"interactive",
+           "startedAt":1785410059006,"sessionId":"4927529c-7991-4eaf-a9c3-d40e876ed2ee",
+           "name":"ghost-20","status":"idle"}
+        ]
+        """)))
+
+        #expect(agents.count == 2)
+        #expect(agents[0].sessionId == "28619ed8-8eb5-4461-883b-b9dc15f2a591")
+        #expect(agents[0].cwd == "/Users/julien/Development/canopy")
+        #expect(agents[0].status == "busy")
+        #expect(agents[0].startedAt == 1786035803954)
+    }
+
+    /// sdk-cli entries carry no `status` key at all. One odd entry must never
+    /// blind Canopy to every other session, so `status` is optional -- this
+    /// fails the moment someone makes it required.
+    @Test func missingStatusDecodesRatherThanFailing() throws {
+        let agents = try #require(ClaudeAgentsService.parse(data("""
+        [
+          {"pid":18660,"cwd":"/Users/julien/.claude-mem/observer-sessions",
+           "kind":"interactive","startedAt":1786096015426,
+           "sessionId":"0a61d62b-4b0b-45ff-ae63-c3cdd94b5c88","name":"observer-sessions-e1"},
+          {"pid":1,"cwd":"/tmp/wt","sessionId":"abc","status":"idle"}
+        ]
+        """)))
+
+        #expect(agents.count == 2)
+        #expect(agents[0].status == nil)
+        #expect(agents[1].status == "idle")
+    }
+
+    @Test func unknownStatusValueDoesNotFailDecode() throws {
+        let agents = try #require(ClaudeAgentsService.parse(data(
+            #"[{"cwd":"/tmp/wt","sessionId":"abc","status":"teleporting"}]"#
+        )))
+        #expect(agents[0].status == "teleporting")
+    }
+
+    /// An old CLI prints usage text; a missing one prints a shell error.
+    /// Either must be DETECTED, never read as "zero sessions running" --
+    /// that would push every tab to a wrong state at once.
+    @Test(arguments: [
+        "command not found: claude",
+        #"{"error":"nope"}"#,
+        "",
+        "Usage: claude [options]",
+    ])
+    func nonArrayOutputReturnsNil(_ junk: String) {
+        #expect(ClaudeAgentsService.parse(data(junk)) == nil)
+    }
+
+    /// An empty array is a real answer -- no claude running -- and must be
+    /// distinguishable from a failure.
+    @Test func emptyArrayIsNotAFailure() {
+        #expect(ClaudeAgentsService.parse(data("[]")) == [])
+    }
+
+    // MARK: - Matching
+
+    private func agent(cwd: String, sessionId: String = "s", status: String? = "idle",
+                       startedAt: Double? = 0) -> ClaudeAgent {
+        ClaudeAgent(cwd: cwd, sessionId: sessionId, status: status, startedAt: startedAt)
+    }
+
+    @Test func matchesExactWorktreePath() {
+        let match = ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: [agent(cwd: "/tmp/wt")])
+        #expect(match == .one(agent(cwd: "/tmp/wt")))
+    }
+
+    /// `--cwd` semantics are "at or under", so a claude started in a
+    /// subdirectory of the worktree still belongs to that tab.
+    @Test func matchesSessionStartedInSubdirectory() {
+        let match = ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: [agent(cwd: "/tmp/wt/src")])
+        if case .one = match {} else { Issue.record("expected .one, got \(match)") }
+    }
+
+    /// Prefix matching must not run upward: a claude in the PARENT directory
+    /// is a different session, and adopting its id would resume the wrong
+    /// transcript.
+    @Test func doesNotMatchParentDirectory() {
+        #expect(ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: [agent(cwd: "/tmp")]) == .none)
+    }
+
+    /// Nor a sibling whose name merely starts with the same characters.
+    @Test func doesNotMatchSiblingWithSharedPrefix() {
+        #expect(ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: [agent(cwd: "/tmp/wt-other")]) == .none)
+    }
+
+    /// /tmp is a symlink to /private/tmp on macOS and claude reports the
+    /// resolved cwd, so both sides must be resolved before comparing.
+    @Test func matchesThroughSymlinkedPath() throws {
+        let dir = "/tmp/canopy-agents-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let resolved = SandboxBackend.realResolvedPath(dir)
+        #expect(resolved.hasPrefix("/private/tmp"))
+
+        let match = ClaudeAgentsService.agent(forWorktree: dir, in: [agent(cwd: resolved)])
+        if case .one = match {} else { Issue.record("symlinked path did not match") }
+    }
+
+    /// A split terminal, or the user starting a second claude by hand, puts
+    /// two agents in one directory. Canopy cannot know which one is this
+    /// tab's, and guessing would resume the wrong transcript -- so it must
+    /// say so and keep the existing behaviour.
+    @Test func twoAgentsInSameCwdIsAmbiguous() {
+        let match = ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: [
+            agent(cwd: "/tmp/wt", sessionId: "a"),
+            agent(cwd: "/tmp/wt/sub", sessionId: "b"),
+        ])
+        #expect(match == .ambiguous)
+    }
+
+    @Test func noMatchReturnsNone() {
+        #expect(ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: []) == .none)
+    }
+
+    // MARK: - Status mapping
+
+    @Test func busyMapsToWorking() {
+        #expect(ClaudeAgentsService.activity(for: "busy") == .working)
+    }
+
+    /// `shell` means a Bash tool call is running -- still working, not idle.
+    @Test func shellMapsToWorking() {
+        #expect(ClaudeAgentsService.activity(for: "shell") == .working)
+    }
+
+    /// The whole point of this service: claude reports `waiting` when it is
+    /// blocked on a dialog, which includes permission prompts. The PTY goes
+    /// silent in exactly that situation, which is why the 5-second heuristic
+    /// declared the session finished mid-turn.
+    @Test func waitingMapsToNeedsInput() {
+        #expect(ClaudeAgentsService.activity(for: "waiting") == .needsInput)
+    }
+
+    @Test func idleMapsToIdle() {
+        #expect(ClaudeAgentsService.activity(for: "idle") == .idle)
+    }
+
+    /// The most important mapping in the suite: conflating "unknown" with
+    /// "idle" would fire a false finish notification for every sdk-cli entry
+    /// and every status value the CLI adds later. No opinion means the PTY
+    /// heuristic keeps running.
+    @Test func absentStatusMapsToNilNotIdle() {
+        #expect(ClaudeAgentsService.activity(for: nil) == nil)
+    }
+
+    @Test func unknownStatusMapsToNil() {
+        #expect(ClaudeAgentsService.activity(for: "teleporting") == nil)
+    }
+}

--- a/Tests/ClaudeAgentsServiceTests.swift
+++ b/Tests/ClaudeAgentsServiceTests.swift
@@ -175,4 +175,38 @@ struct ClaudeAgentsServiceTests {
     @Test func unknownStatusMapsToNil() {
         #expect(ClaudeAgentsService.activity(for: "teleporting") == nil)
     }
+
+    // MARK: - fetch (the impure edge)
+
+    /// Runs the real subprocess path: shell resolution, spawn, watchdog,
+    /// drain-before-wait, and parse. Deliberately tolerant of the outcome,
+    /// because it legitimately differs by machine -- a developer box has
+    /// `claude` on PATH and gets an array, a CI runner does not and gets nil.
+    /// What it pins is that BOTH are handled: no hang, no crash, and never a
+    /// half-decoded entry.
+    @Test func fetchCompletesAndReturnsNilOrWellFormedAgents() async {
+        let started = Date()
+        let result = await ClaudeAgentsService.fetch()
+        let elapsed = Date().timeIntervalSince(started)
+
+        // The watchdog terminates at 5s; anything beyond that means it hung.
+        #expect(elapsed < 15, "fetch() took \(elapsed)s -- watchdog did not fire")
+
+        guard let agents = result else { return }   // claude not installed: valid
+        for agent in agents {
+            #expect(!agent.cwd.isEmpty)
+            #expect(!agent.sessionId.isEmpty)
+        }
+    }
+
+    /// Second call must be cheap: the resolved claude path is cached, so this
+    /// exercises the cache-hit branch rather than re-resolving through a
+    /// login shell.
+    @Test func fetchIsRepeatableAndUsesTheCachedPath() async {
+        _ = await ClaudeAgentsService.fetch()
+        let started = Date()
+        _ = await ClaudeAgentsService.fetch()
+        #expect(Date().timeIntervalSince(started) < 15)
+    }
+
 }

--- a/Tests/NotificationServiceTests.swift
+++ b/Tests/NotificationServiceTests.swift
@@ -97,4 +97,30 @@ struct NotificationServiceTests {
     // Note: we can't instantiate NotificationService.shared under `swift test` —
     // UNUserNotificationCenter.current() requires a bundled app and crashes
     // otherwise. The post methods are therefore only exercised via the real app.
+
+    /// "Session finished" for a permission prompt is actively misleading:
+    /// nothing finished, the agent is stalled and stays stalled.
+    @Test func needsInputNotificationBodyDiffersFromFinished() {
+        let id = UUID()
+        let finished = NotificationService.makeContent(title: "p", subtitle: "s", sessionId: id)
+        let needsInput = NotificationService.makeContent(
+            title: "p", subtitle: "s", sessionId: id,
+            body: NotificationService.needsInputBody
+        )
+        #expect(finished.body == NotificationService.finishedBody)
+        #expect(needsInput.body != finished.body)
+    }
+
+    /// Routing must be identical so clicking either notification selects the
+    /// same session.
+    @Test func needsInputNotificationRoutesToSession() {
+        let id = UUID()
+        let content = NotificationService.makeContent(
+            title: "p", subtitle: "s", sessionId: id,
+            body: NotificationService.needsInputBody
+        )
+        #expect(content.threadIdentifier == id.uuidString)
+        #expect(content.userInfo["sessionId"] as? String == id.uuidString)
+    }
+
 }

--- a/Tests/SettingsEdgeCaseTests.swift
+++ b/Tests/SettingsEdgeCaseTests.swift
@@ -84,4 +84,24 @@ struct SettingsEdgeCaseTests {
         // .whitespaces only includes space and tab
         #expect(settings.claudeCommand == "claude \n")
     }
+
+    /// Settings saved before the toggle existed must default it ON -- the
+    /// whole point is that a blocked session is the thing you most need told
+    /// about, so silence-by-default would be the wrong failure direction.
+    @Test func notifyOnNeedsInputDefaultsTrueWhenAbsent() throws {
+        let decoded = try JSONDecoder().decode(
+            CanopySettings.self, from: Data("{}".utf8)
+        )
+        #expect(decoded.notifyOnNeedsInput)
+    }
+
+    @Test func notifyOnNeedsInputRoundTrips() throws {
+        var settings = CanopySettings()
+        settings.notifyOnNeedsInput = false
+        let decoded = try JSONDecoder().decode(
+            CanopySettings.self, from: try JSONEncoder().encode(settings)
+        )
+        #expect(!decoded.notifyOnNeedsInput)
+    }
+
 }


### PR DESCRIPTION
Fourth of five PRs for milestone 1.2.0. **Stacked on #68.**

## The bug

Activity had exactly one input: bytes on the PTY. Any visible byte meant working; five seconds of silence meant finished.

When Claude renders `Do you want to allow…?` and waits, **the PTY goes silent**. Five seconds later the session flipped to `.justFinished`, showed a checkmark, and fired a `"Session finished"` notification. Nothing finished — the agent was stalled and would stay stalled forever. Three seconds after that the dot decayed to grey, at which point **a session blocked on a permission prompt looked identical to one sitting at an empty prompt**. With eight worktrees open you had to click every tab to find it, and the status bar counted it as idle.

The reverse failure too: `npm run dev` or `tail -f` pinned a tab to "working" permanently.

## Why this closes #54 rather than implementing it

#54 proposed learning the same bit from Claude Code hooks — a ~120-line bridge, an injected `--settings` file **whose absence hard-fails `claude` at startup**, a world-writable event directory polled by `DispatchSource`, whitelist parsing, and a byte cap so a hostile local process couldn't OOM the app.

It isn't needed. The status union in the 2.1.224 binary is not `busy|idle`:

```js
c1b = ["busy","shell","idle","waiting"];

function R7T(e){                                       // the reason behind "waiting"
  if (e.sandboxHostPrompt || e.workerSandboxPrompt) return "sandbox request";
  if (e.elicitationPrompt)                          return "input needed";
  if (e.topDialogWaitingFor !== undefined)          return e.topDialogWaitingFor;  // permission prompts
  ...
}
```

So `waiting` **is** the needs-input signal, over a transport this PR needed anyway. #54's UI work — the `.needsInput` state, the amber dot, `"N need input"`, the distinct notification — is kept in full; only its transport is discarded.

**Cost:** needs-input does not work for `.appleContainer` sessions. That is consistent with #60's own recorded decision to freeze investment in that backend.

## Design

`ClaudeAgentsService`, shaped like `ClaudeVersionChecker`: pure `parse` / `agent(forWorktree:in:)` / `activity(for:)` plus one impure `fetch()`. Tests use literal JSON copied from real output, including a real status-less sdk-cli entry — **3 of 11 live entries carried no `status` key**, so it must be optional or one odd entry blinds Canopy to every other session.

`busy`/`shell` → working, `waiting` → needsInput, `idle` → idle, **anything else or absent → nil (no opinion)**. Treating unknown as idle would fire a false finish for every sdk-cli entry and for every status value the CLI adds later; nil leaves today's heuristic in charge, which is always a safe fallback.

Reconciliation guards, all tested: gated on the `.off` backend (container `pid` is a guest-namespace pid and the peer socket is unreachable from the host); ambiguous matches skipped rather than guessed; an id adopted only from a conversation that started **after** the tab opened; the finish notification requires **two consecutive** idle polls, because status flaps to idle between tool calls inside one turn.

`.needsInput` is sticky against PTY output — a permission prompt keeps redrawing, and treating those bytes as progress would stomp the state back to `.working` every frame.

## Mutation-tested

Removing the sticky guard fails `ptyOutputDoesNotClearNeedsInput`. Mapping `waiting`→`idle` fails **10** tests. Neither is vacuous.

## Poll cost, measured before committing

`0.33 s` per call, of which ~`0.10 s` was re-sourcing the user's shell rc files — 1800 times an hour, for a path that never changes. `claude` is now resolved through a login shell **once** and invoked directly, and the poll skips entirely when no session is eligible.

## Status-value verification

`busy` and `idle` were observed live while writing this. **`waiting` and `shell` were initially taken only from the CLI's own status union and the `R7T` reason function in the binary** — I could not drive an interactive permission prompt from a tool call to observe them.

**Now confirmed by hand on the built app (2026-08-07):** a session under `--permission-mode manual` blocked on a permission prompt goes amber with "N needs input", fires the *"Waiting for your input"* notification rather than *"Session finished"*, and releases back to grey when claude is quit to the shell prompt. So `waiting → .needsInput` and the stuck-state handback both behave as designed against the real CLI.

## Verification

- 674 tests across 52 suites (was 637/50).
- `scripts/bundle.sh` archive succeeds and installs.
