### PR TITLE
Claude Code's native sandbox, and lead with the cockpit (#53, #60)

### DIFF
--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -9,6 +9,19 @@ enum SandboxBackend: String, Codable {
     /// Apple's `container` runtime -- one lightweight VM per container.
     /// Requires macOS 26+ on Apple silicon.
     case appleContainer
+    /// Claude Code's own Bash sandbox, built on macOS Seatbelt. Nothing to
+    /// install, no image, no daemon.
+    ///
+    /// Weaker than a microVM and deliberately so: only Bash is sandboxed
+    /// (Read/Edit/Write go through the permission system instead), reads
+    /// default to the whole machine including ~/.ssh and ~/.aws/credentials,
+    /// and it shares the kernel, user session and TCC context. Upstream is
+    /// explicit that it "reduces risk but is not a complete isolation
+    /// boundary", so `.appleContainer` remains the paranoid option.
+    case claudeNative
+
+    /// The `--settings` payload enabling Claude Code's own Bash sandbox.
+    private var sandboxSettingsJSON: String { #"{"sandbox":{"enabled":true}}"# }
 
     /// Whether `--resume` works for this backend. Session JSONLs must
     /// persist on the host: sbx microVMs are ephemeral, while the Apple
@@ -53,6 +66,21 @@ enum SandboxBackend: String, Codable {
         switch self {
         case .off:
             parts = ["claude"]
+        case .claudeNative:
+            // --settings takes inline JSON as well as a path (verified on
+            // 2.1.224), so nothing is written to disk. A file would be the
+            // wrong answer twice over: a .claude/settings.local.json in the
+            // worktree is a PROJECT-scope source, which per the docs cannot
+            // set the sandbox keys at all, and it would litter the user's repo
+            // beyond the session.
+            //
+            // Payload is the minimum on purpose: --settings MERGES with the
+            // user's own settings, so their allowedDomains, credentials and
+            // excludedCommands still apply. Canopy inventing an allowlist here
+            // would fight their configuration.
+            //
+            // One shell token: the blob contains {, } and " and must not split.
+            parts = ["claude", "--settings", Self.shellSingleQuoted(sandboxSettingsJSON)]
         case .dockerSbx:
             parts = ["sbx run"]
             let sbx = sbxFlags.trimmingCharacters(in: .whitespaces)
@@ -251,6 +279,13 @@ struct CanopySettings: Codable {
             // version): throwing here would fail the whole-file decode and
             // load()'s fallback would silently factory-reset all settings.
             sandboxBackend = SandboxBackend(rawValue: raw) ?? .off
+            if SandboxBackend(rawValue: raw) == nil {
+                // Fail-safe direction, but not a silent one: a user who picked
+                // a sandbox and then downgraded Canopy ends up UNSANDBOXED,
+                // which is exactly what the save() return-value guard exists
+                // to prevent elsewhere.
+                NSLog("Canopy: unknown sandboxBackend %@ in settings; falling back to off (unsandboxed)", raw)
+            }
         } else {
             let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
             let useSandbox = try legacy.decodeIfPresent(Bool.self, forKey: .useSandbox) ?? false

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -278,8 +278,9 @@ struct CanopySettings: Codable {
             // Tolerant of unknown rawValues (config written by a newer
             // version): throwing here would fail the whole-file decode and
             // load()'s fallback would silently factory-reset all settings.
-            sandboxBackend = SandboxBackend(rawValue: raw) ?? .off
-            if SandboxBackend(rawValue: raw) == nil {
+            let decodedBackend = SandboxBackend(rawValue: raw)
+            sandboxBackend = decodedBackend ?? .off
+            if decodedBackend == nil {
                 // Fail-safe direction, but not a silent one: a user who picked
                 // a sandbox and then downgraded Canopy ends up UNSANDBOXED,
                 // which is exactly what the save() return-value guard exists

--- a/Canopy/Services/GitService.swift
+++ b/Canopy/Services/GitService.swift
@@ -426,7 +426,9 @@ struct GitService {
     // MARK: - File Operations for Worktree Setup
 
     /// Copies files from the main repo to a worktree.
-    /// Supports glob-like patterns (just direct file paths for now).
+    /// Direct file paths only -- Claude Code's `.worktreeinclude` (gitignore
+    /// syntax, a strict superset of this) is the native answer for anything
+    /// more, so glob support is deliberately never coming.
     static func copyFiles(from repoPath: String, to worktreePath: String, paths: [String]) throws {
         let fm = FileManager.default
         for relativePath in paths {

--- a/Canopy/Services/SandboxChecker.swift
+++ b/Canopy/Services/SandboxChecker.swift
@@ -19,6 +19,11 @@ struct SandboxChecker {
         switch backend {
         case .off:
             return .available
+        case .claudeNative:
+            // Seatbelt is part of macOS -- "there is nothing to install".
+            // No prerequisite chain, so Save must never disable itself and
+            // verifySandbox must never reset the picker back to .off.
+            return .available
         case .dockerSbx:
             return await check()
         case .appleContainer:

--- a/Canopy/Views/ProjectDetailView.swift
+++ b/Canopy/Views/ProjectDetailView.swift
@@ -329,7 +329,11 @@ struct ProjectDetailView: View {
         }
     }
 
-    static func collisionSummaryText(hard: Int, watch: Int) -> String {
+    /// nonisolated: a pure string function with no actor state. SwiftUI
+    /// infers @MainActor on the View, and whether a synchronous call from a
+    /// non-isolated test is allowed differs by Swift version -- this compiled
+    /// locally and failed on CI. Saying it explicitly removes the ambiguity.
+    nonisolated static func collisionSummaryText(hard: Int, watch: Int) -> String {
         var parts: [String] = []
         if hard > 0 {
             parts.append("\(hard) branch\(hard == 1 ? "" : "es") would conflict on merge")

--- a/Canopy/Views/ProjectDetailView.swift
+++ b/Canopy/Views/ProjectDetailView.swift
@@ -40,14 +40,24 @@ struct ProjectDetailView: View {
                             .foregroundStyle(.secondary)
                             .textSelection(.enabled)
                     }
+
+                    Spacer()
+
+                    // Creating a worktree is no longer the differentiated
+                    // capability -- `claude -w --tmux` does that, free and
+                    // cross-platform. Watching several at once is. So this
+                    // moves out of the content's lead position and into the
+                    // header as a secondary action.
+                    Button(action: { showNewWorktree = true }) {
+                        Label("New Worktree Session", systemImage: "arrow.triangle.branch")
+                    }
+                    .controlSize(.large)
                 }
 
-                // Primary action
-                Button(action: { showNewWorktree = true }) {
-                    Label("New Worktree Session", systemImage: "arrow.triangle.branch")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
+                // Cross-worktree collisions lead, because nothing upstream
+                // reports them and Claude Code now creates more unwatched
+                // worktrees, not fewer.
+                collisionSummary
 
                 Divider()
 
@@ -297,6 +307,39 @@ struct ProjectDetailView: View {
 
     /// Tooltip text for a worktree's collision badge: one line per colliding
     /// sibling branch, listing its hard (conflict) and watch (shared-surface) files.
+    /// One line naming how many branches would collide, shown only when there
+    /// is something to say. The per-row badges stay -- this is the "look here
+    /// first" summary the layout previously gave to the create button.
+    @ViewBuilder
+    private var collisionSummary: some View {
+        let reports = worktreeCollisions.values.filter { !$0.isEmpty }
+        if !reports.isEmpty {
+            let hard = reports.filter { $0.hardCount > 0 }.count
+            let watch = reports.count - hard
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(hard > 0 ? .red : .orange)
+                Text(Self.collisionSummaryText(hard: hard, watch: watch))
+                    .font(.subheadline)
+                Spacer()
+            }
+            .padding(10)
+            .background((hard > 0 ? Color.red : Color.orange).opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    static func collisionSummaryText(hard: Int, watch: Int) -> String {
+        var parts: [String] = []
+        if hard > 0 {
+            parts.append("\(hard) branch\(hard == 1 ? "" : "es") would conflict on merge")
+        }
+        if watch > 0 {
+            parts.append("\(watch) share\(watch == 1 ? "s" : "") a high-stakes surface")
+        }
+        return parts.joined(separator: ", ")
+    }
+
     private func collisionTooltip(_ report: WorktreeCollisionReport) -> String {
         let lines = report.collisions.map { c in
             var parts: [String] = []

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -93,7 +93,7 @@ struct SettingsView: View {
                                     TextField("e.g. --model sonnet --verbose", text: $claudeFlags)
                                         .textFieldStyle(.roundedBorder)
                                         .font(.system(size: 12, design: .monospaced))
-                                    Text("These flags are appended to the `claude` command. Per-project overrides take precedence.")
+                                    Text("These flags are appended to the `claude` command. Any `claude` flag works, e.g. --model fable, --effort xhigh, --safe-mode. Per-project and per-session overrides take precedence.")
                                         .font(.caption)
                                         .foregroundStyle(.tertiary)
                                 }
@@ -122,7 +122,8 @@ struct SettingsView: View {
                                     }
                                 )) {
                                     Text("Off").tag(SandboxBackend.off)
-                                    Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                                    Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
+                        Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
                                     Text("Apple container").tag(SandboxBackend.appleContainer)
                                 }
                                 .disabled(checkingSandbox)

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -90,7 +90,7 @@ struct SettingsView: View {
                                     Text("Default CLI flags")
                                         .font(.subheadline)
                                         .fontWeight(.medium)
-                                    TextField("e.g. --model sonnet --verbose", text: $claudeFlags)
+                                    TextField("e.g. --model fable --verbose", text: $claudeFlags)
                                         .textFieldStyle(.roundedBorder)
                                         .font(.system(size: 12, design: .monospaced))
                                     Text("These flags are appended to the `claude` command. Any `claude` flag works, e.g. --model fable, --effort xhigh, --safe-mode. Per-project and per-session overrides take precedence.")

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -177,7 +177,8 @@ struct WorktreeSheet: View {
                 )) {
                     Text("Use project default").tag(SandboxBackend?.none)
                     Text("Off").tag(SandboxBackend?.some(.off))
-                    Text("Docker Sandbox (sbx)").tag(SandboxBackend?.some(.dockerSbx))
+                    Text("Claude sandbox (Bash only)").tag(SandboxBackend?.some(.claudeNative))
+                    Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend?.some(.dockerSbx))
                     Text("Apple container").tag(SandboxBackend?.some(.appleContainer))
                 }
                 .labelsHidden()

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="docs/screenshots/splash.png" alt="Canopy" width="820"/>
 
-**Parallel Claude Code sessions with git worktrees — a native macOS app.**
+**The cockpit for parallel Claude Code sessions — a native macOS app.**
 
-*One window. Parallel branches. Parallel Claudes. Zero context switching.*
+*Claude Code can make the worktrees. Canopy shows you which ones are about to collide, and merges them back.*
 
 <br/>
 
@@ -53,6 +53,12 @@ When you use Claude Code seriously — not just for experiments, but for real pr
 You *can* hack around it: stash, checkout, maybe a second clone, maybe `git worktree add` and a hand-written shell script to copy your `.env`, maybe remember which of your six Terminal.app tabs was running which session. You end up with a tab graveyard, stale worktrees littering your disk, Claude sessions you can't find, and a quiet tax on every task you do.
 
 Canopy removes that tax. Completely.
+
+**And to be straight with you about what changed:** Claude Code now creates worktrees on its own — `claude -w`, `/fork`, subagents that isolate themselves. That part is solved, it's free, and it's cross-platform. So making a worktree is no longer the interesting problem.
+
+Running *eight* of them is. Nothing upstream tells you that two of your branches are both editing the lockfile, or both adding a migration with the same sequence number — a conflict `git merge-tree` structurally cannot see until you're already merging. Nothing upstream integrates a finished branch back for you. And Claude Code now creates **more** unwatched worktrees, not fewer, with a cleanup sweep that deliberately skips anything containing work — so they pile up, with real commits in them, and nobody is looking.
+
+That's what Canopy is for: the pre-flight before the merge, the merge itself, and one window that shows you which of your agents is stuck waiting on you right now.
 
 ## What you actually get back
 

--- a/Tests/SandboxCheckerTests.swift
+++ b/Tests/SandboxCheckerTests.swift
@@ -68,4 +68,11 @@ struct SandboxBackendUILaunchTests {
             #expect(sent.hasPrefix("echo "))
         }
     }
+
+    /// No prerequisite gate: Save must not disable itself, and verifySandbox
+    /// must not silently reset the picker to .off for this backend.
+    @Test func claudeNativeIsAlwaysAvailable() async {
+        #expect(await SandboxChecker.check(backend: .claudeNative) == .available)
+    }
+
 }

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -431,4 +431,94 @@ struct SettingsTests {
         defer { try? FileManager.default.removeItem(atPath: dir) }
         #expect(settings.save(to: (dir as NSString).appendingPathComponent("settings.json")) == true)
     }
+
+    // MARK: - Sandbox — Claude native (Seatbelt)
+
+    /// Choosing this backend must actually change the process's sandbox
+    /// policy. A no-op emission would make the picker lie about a security
+    /// setting -- the same failure class the save() return-value guard exists
+    /// to prevent.
+    @Test func claudeNativeEmitsSettingsFlag() {
+        let command = SandboxBackend.claudeNative.claudeCommand(
+            claudeFlags: "--permission-mode auto", sbxFlags: "",
+            containerImage: "", containerFlags: "", disableAltScreen: false
+        )
+        #expect(command == #"claude --settings '{"sandbox":{"enabled":true}}' --permission-mode auto"#)
+    }
+
+    /// Malformed JSON makes claude exit at startup with an error the user
+    /// cannot connect back to Canopy.
+    @Test func claudeNativeSettingsBlobIsValidJSON() throws {
+        let command = SandboxBackend.claudeNative.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "",
+            containerFlags: "", disableAltScreen: false
+        )
+        let start = try #require(command.range(of: "'"))
+        let end = try #require(command.range(of: "'", options: .backwards))
+        let blob = String(command[start.upperBound..<end.lowerBound])
+
+        let parsed = try #require(
+            try JSONSerialization.jsonObject(with: Data(blob.utf8)) as? [String: Any]
+        )
+        let sandbox = try #require(parsed["sandbox"] as? [String: Any])
+        #expect(sandbox["enabled"] as? Bool == true)
+    }
+
+    /// Session JSONLs stay on the host, so --resume must be appended. This is
+    /// the concrete advantage over .dockerSbx, which silently loses session
+    /// continuity.
+    @Test func claudeNativeSupportsResume() {
+        #expect(SandboxBackend.claudeNative.supportsResume)
+    }
+
+    /// Switching from .appleContainer must not carry a stale image name or
+    /// container flags across into the new command.
+    @Test func claudeNativeIgnoresContainerAndSbxInputs() {
+        let command = SandboxBackend.claudeNative.claudeCommand(
+            claudeFlags: "", sbxFlags: "--net none", containerImage: "canopy-claude",
+            containerFlags: "--memory 8g", disableAltScreen: true
+        )
+        #expect(!command.contains("canopy-claude"))
+        #expect(!command.contains("--net none"))
+        #expect(!command.contains("--memory 8g"))
+        #expect(!command.contains("container run"))
+    }
+
+    /// Worktree .git access is native here (the docs allow shared-.git writes
+    /// from a linked worktree), so a mount flag would be nonsense a future
+    /// refactor might "helpfully" add.
+    @Test func claudeNativeIgnoresExtraMountPaths() {
+        let command = SandboxBackend.claudeNative.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "", containerFlags: "",
+            extraMountPaths: ["/Users/x/dev/repo"], disableAltScreen: false
+        )
+        #expect(!command.contains("--volume"))
+        #expect(!command.contains("/Users/x/dev/repo"))
+    }
+
+    @Test func claudeNativeRoundTripsThroughSettingsJSON() throws {
+        var settings = CanopySettings()
+        settings.sandboxBackend = .claudeNative
+        let decoded = try JSONDecoder().decode(
+            CanopySettings.self, from: try JSONEncoder().encode(settings)
+        )
+        #expect(decoded.sandboxBackend == .claudeNative)
+    }
+
+    /// Pins the forward-compat contract and documents that the fallback
+    /// direction is fail-safe. A user who picks a backend then DOWNGRADES
+    /// Canopy decodes to .off -- unsandboxed -- so it must also be logged.
+    @Test func unknownBackendRawValueFallsBackToOff() throws {
+        let decoded = try JSONDecoder().decode(
+            CanopySettings.self, from: Data(#"{"sandboxBackend":"quantumJail"}"#.utf8)
+        )
+        #expect(decoded.sandboxBackend == .off)
+    }
+
+    /// The default must not change for existing or new users: turning on a
+    /// sandbox silently would change how every session runs on upgrade.
+    @Test func defaultBackendIsStillOff() {
+        #expect(CanopySettings().sandboxBackend == .off)
+    }
+
 }

--- a/Tests/WorktreeCollisionTests.swift
+++ b/Tests/WorktreeCollisionTests.swift
@@ -205,6 +205,20 @@ struct WorktreeCollisionTests {
         }
     }
 
+    // MARK: - Summary copy
+
+    /// The summary line is the "look here first" signal that replaced the
+    /// create button's prominence. It must name the severity, not just a
+    /// count, and must not emit a dangling clause when one side is zero.
+    @Test func collisionSummaryNamesBothSeverities() {
+        #expect(ProjectDetailView.collisionSummaryText(hard: 2, watch: 1)
+                == "2 branches would conflict on merge, 1 shares a high-stakes surface")
+        #expect(ProjectDetailView.collisionSummaryText(hard: 1, watch: 0)
+                == "1 branch would conflict on merge")
+        #expect(ProjectDetailView.collisionSummaryText(hard: 0, watch: 2)
+                == "2 share a high-stakes surface")
+    }
+
     // MARK: - Fixture
 
     /// Creates a repo on `main` with an initial commit plus one worktree per


### PR DESCRIPTION
Last of five PRs for milestone 1.2.0. **Stacked on #69.**

## #53 — `.claudeNative` backend

Claude Code ships its own Bash sandbox built on macOS Seatbelt — *"there is nothing to install"*. Adding it costs almost nothing: no image, no Dockerfile, no update button, no 30-day staleness nudge, no `SandboxChecker` prerequisite chain, no PTY settle loop, no mounts. `supportsResume` is `self != .dockerSbx` so it gets session continuity free, and `isUnsafeContainerWorkingDirectory` already keys off `== .appleContainer` so it's excluded free too.

**Why this needs Canopy code at all**, rather than a line in the user's `settings.json`: Canopy resolves the sandbox session → project → global, and a single global file cannot express *"sandbox this worktree, not that one."* `--settings` is exactly the per-invocation override, and the docs grant it privileged-source status that project-scope settings don't have.

**Inline JSON, not a file.** Writing `.claude/settings.local.json` into the worktree is a *project-scope* source, which per the docs **cannot** set the sandbox keys at all — and it would litter the user's repo beyond the session. The payload is the minimum (`{"sandbox":{"enabled":true}}`) because `--settings` **merges**: the user's own `allowedDomains`, `credentials` and `excludedCommands` still apply, and Canopy inventing an allowlist would fight their configuration.

### Verified, not assumed

The emitted command really enforces the policy:

```
$ claude --settings '{"sandbox":{"enabled":true}}' --permission-mode auto \
    -p 'run: touch /Users/julien/canopy-sbx-probe.txt'
→ EPERM at the syscall level; file not created
```

So the picker is not lying about a security setting — which is the whole risk with a no-op emission.

**Not oversold either.** Only Bash is sandboxed (Read/Edit/Write go through the permission system), reads still default to the whole machine including `~/.ssh` and `~/.aws/credentials`, and it shares the kernel, user session and TCC context. `.appleContainer` stays the paranoid option.

### Default unchanged

`.off` remains the default for existing **and** new users. A backend that silently switched on would change how every session runs on upgrade.

### Folded in

- `.dockerSbx` relabelled *"legacy, no session resume"* in both pickers — the native sandbox dominates it on every axis a user feels, but it stays, because it's the target of the legacy `useSandbox: true` migration and removing it would cost a decode migration.
- The unknown-backend decode fallback now **logs**. A user who picks a backend and then downgrades Canopy currently decodes to `.off` — **silently unsandboxed**. Same failure class the `save()` return-value guard exists to prevent.
- Flags help text notes that any `claude` flag works, retiring several would-be picker requests as documentation.

## #60 — lead with the cockpit

Creating a worktree is no longer the differentiated capability: `claude -w --tmux` does it, free, cross-platform, vendor-maintained. Watching several at once is.

So **"New Worktree Session"** moves out of the content's lead position (it had the only `.borderedProminent` action) into the header as a secondary action, and a **cross-worktree collision summary** takes its place — because nothing upstream reports collisions, and Claude Code now creates *more* unwatched worktrees, not fewer, with a sweep that deliberately skips anything containing work.

README opening rewritten to match, with the tagline and three paragraphs naming honestly what upstream now covers before pivoting to what Canopy owns.

Also retires the `"Supports glob-like patterns (just direct file paths for now)"` aspiration in `filesToCopy` — `.worktreeinclude` (gitignore syntax, a strict superset) is the native answer, so that "for now" is permanently "never".

## Verification

- 684 tests across 52 suites (was 674/52).
- `scripts/bundle.sh` archive succeeds and installs.
- Native sandbox enforcement confirmed by a real denied write, above.