### PR TITLE
Mount the main repository for worktree sessions on the sbx backend (#59)

### DIFF
--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -87,7 +87,24 @@ enum SandboxBackend: String, Codable {
             if !sbx.isEmpty {
                 parts.append(sbx)
             }
-            parts.append("claude --")
+            parts.append("claude")
+            // Extra workspaces are POSITIONAL arguments to `sbx run`
+            // (`sbx run [AGENT] [PATH...]`), and naming any of them means
+            // naming the cwd as "." too. Without this the worktree's `.git`
+            // pointer dangles inside the sandbox and every git command fails
+            // with "not a git repository" (reproduced on sbx 0.38.0).
+            //
+            // Writable, NOT ":ro": a worktree commit writes objects into the
+            // main repo's .git, so a read-only mount would break committing.
+            let workspaces = extraMountPaths
+                .map { Self.realResolvedPath($0) }
+                .filter { !$0.isEmpty }
+            if !workspaces.isEmpty {
+                parts.append(".")
+                parts.append(contentsOf: workspaces.map { Self.shellSingleQuoted($0) })
+            }
+            // Everything after this reaches claude, not sbx.
+            parts.append("--")
         case .appleContainer:
             var run = #"mkdir -p "$HOME/.claude"; [ -f "$HOME/.claude.json" ] || printf '{}' > "$HOME/.claude.json"; [ -f "$HOME/.gitconfig" ] || touch "$HOME/.gitconfig"; container run -it --rm --env TERM=xterm-256color --env COLORTERM=truecolor --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 --env DISABLE_AUTOUPDATER=1"#
             if disableAltScreen {

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -262,6 +262,41 @@ struct SessionSandboxTests {
         #expect(command.contains(#"exec claude --model fable "$@""#))
     }
 
+    // MARK: - Worktree + Docker sbx
+
+    /// AppState computed and passed the main-repo path for every backend, but
+    /// the .dockerSbx branch dropped it -- so worktree sessions on that
+    /// backend had a dangling `.git` pointer and every git command inside the
+    /// sandbox failed, with nothing surfaced to the user. Reproduced against
+    /// sbx 0.38.0 before this test was written.
+    @Test func worktreeSessionOnDockerSbxMountsMainRepository() {
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/canopy-worktrees/repo/feat",
+            projectId: project.id,
+            worktreePath: "/Users/x/dev/canopy-worktrees/repo/feat",
+            sandboxBackend: .dockerSbx
+        )
+
+        let command = state.claudeCommand(for: session)
+        #expect(command.contains("claude . '/Users/x/dev/repo' --"))
+    }
+
+    @Test func nonWorktreeSessionOnDockerSbxGetsNoExtraWorkspace() {
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/repo",
+            projectId: project.id,
+            sandboxBackend: .dockerSbx
+        )
+
+        #expect(!state.claudeCommand(for: session).contains("claude . "))
+    }
+
     // MARK: - Main-repo tool access (--add-dir)
 
     /// Mounting the main repo fixes the *filesystem*; Claude Code's own tool

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -521,4 +521,93 @@ struct SettingsTests {
         #expect(CanopySettings().sandboxBackend == .off)
     }
 
+
+    // MARK: - Sandbox — Docker sbx extra workspaces
+
+    /// Reproduced against sbx 0.38.0 before writing this: with only the
+    /// worktree as workspace, the main repo's .git is absent inside the
+    /// sandbox, so the worktree's `.git` pointer dangles and EVERY git command
+    /// fails --
+    ///
+    ///   fatal: not a git repository: .../repo/.git/worktrees/wt   (exit 128)
+    ///
+    /// Canopy computed and passed the main-repo path for every backend, but
+    /// the .dockerSbx branch silently dropped it. `sbx run` takes extra
+    /// workspaces as POSITIONAL arguments, and naming any of them means
+    /// naming the cwd too.
+    @Test func dockerSbxMountsMainRepositoryAsExtraWorkspace() {
+        let command = SandboxBackend.dockerSbx.claudeCommand(
+            claudeFlags: "--permission-mode auto", sbxFlags: "",
+            containerImage: "", containerFlags: "",
+            extraMountPaths: ["/Users/x/dev/repo"], disableAltScreen: false
+        )
+        #expect(command == "sbx run claude . '/Users/x/dev/repo' -- --permission-mode auto")
+    }
+
+    /// Writable, not `:ro`: a worktree commit writes objects into the MAIN
+    /// repo's .git, so a read-only mount would break committing rather than
+    /// fix anything.
+    @Test func dockerSbxExtraWorkspaceIsNotReadOnly() {
+        let command = SandboxBackend.dockerSbx.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "", containerFlags: "",
+            extraMountPaths: ["/Users/x/dev/repo"], disableAltScreen: false
+        )
+        #expect(!command.contains(":ro"))
+    }
+
+    /// Sessions with nothing extra to mount must emit exactly what they did
+    /// before, so this cannot regress the common case.
+    @Test func dockerSbxWithoutExtraMountsIsUnchanged() {
+        let command = SandboxBackend.dockerSbx.claudeCommand(
+            claudeFlags: "--permission-mode auto", sbxFlags: "",
+            containerImage: "", containerFlags: "", disableAltScreen: false
+        )
+        #expect(command == "sbx run claude -- --permission-mode auto")
+    }
+
+    /// The paths are `sbx` arguments, so they must land BEFORE the `--`
+    /// terminator. After it they would be handed to claude as flags.
+    @Test func dockerSbxExtraWorkspacesPrecedeTheTerminator() throws {
+        let command = SandboxBackend.dockerSbx.claudeCommand(
+            claudeFlags: "--verbose", sbxFlags: "", containerImage: "",
+            containerFlags: "", extraMountPaths: ["/Users/x/dev/repo"],
+            disableAltScreen: false
+        )
+        let path = try #require(command.range(of: "/Users/x/dev/repo"))
+        let terminator = try #require(command.range(of: " -- "))
+        #expect(path.upperBound < terminator.lowerBound)
+    }
+
+    /// The repo path is user-supplied and reaches a shell command. Replay the
+    /// real host-shell parse rather than asserting on escaped text: the token
+    /// must come back as exactly one argv element, spaces and quote included.
+    @Test func dockerSbxExtraWorkspaceIsOneShellToken() throws {
+        let hostile = "/Users/x/o'brien dev"
+        let command = SandboxBackend.dockerSbx.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "", containerFlags: "",
+            extraMountPaths: [hostile], disableAltScreen: false
+        )
+        // The workspace token sits between "claude . " and " --".
+        let start = try #require(command.range(of: "claude . ")).upperBound
+        let end = try #require(command.range(of: " --", options: .backwards)).lowerBound
+        let token = String(command[start..<end])
+
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "printf %s \(token)"]
+        process.standardOutput = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        #expect(String(decoding: data, as: UTF8.self) == hostile)
+    }
+
+    /// The mount fixes git, not session persistence: JSONLs still live inside
+    /// the ephemeral microVM, so --resume must stay off for this backend.
+    @Test func dockerSbxStillDoesNotSupportResume() {
+        #expect(!SandboxBackend.dockerSbx.supportsResume)
+    }
+
 }


### PR DESCRIPTION
Final PR for milestone 1.2.0. **Stacked on #70.**

This issue asked for a repro before any code. Here it is — and it's a real bug.

## Reproduced (sbx 0.38.0)

A temp repo with a real worktree, opened in an sbx sandbox whose workspace is the worktree:

```
$ sbx exec <sandbox> sh -c 'cd <worktree> && cat .git; ls -d <repo>/.git; git status'

gitdir: .../sbx59/repo/.git/worktrees/wt
ls: cannot access '.../sbx59/repo/.git': No such file or directory
fatal: not a git repository: .../sbx59/repo/.git/worktrees/wt
GIT_EXIT=128
```

So **worktree + `.dockerSbx` was quietly broken** — every git command inside the sandbox failed, exactly the failure mode the `Settings.swift` comment already documents for the container backend, and Canopy surfaced nothing.

`AppState.claudeCommand(for:)` computed and passed the main-repo path for **every** backend; the `.dockerSbx` branch silently dropped the parameter while the caller believed it was handled.

## Fix, verified before it was written

`sbx run` takes extra workspaces as **positional** arguments (`sbx run [AGENT] [PATH...]`), and naming any of them means naming the cwd as `.` too:

```
$ sbx run shell . <main-repo> -d --name shape59 -- -c true
$ sbx exec shape59 sh -c 'cd <worktree> && git status'
On branch feature
nothing to commit, working tree clean
GIT_EXIT=0
```

That run used the **exact shape Canopy now emits**, including the `--` terminator, so the arg ordering is confirmed against the real CLI rather than inferred from its help text.

- **Writable, not `:ro`.** A worktree commit writes objects into the *main* repo's `.git`, so a read-only mount would break committing rather than fix anything.
- **Before the `--`.** Everything after the terminator reaches `claude`, not `sbx`. A test pins the ordering.
- **`supportsResume` unchanged.** Session JSONLs still live inside the ephemeral microVM — a separate limitation from the git one, and this fix doesn't touch it.
- **Sessions with nothing extra to mount emit exactly what they did before**, pinned by a regression test.

The single-shell-token test replays the real host-shell parse (a path containing `'` and a space must come back as one argv element) rather than asserting on escaped text.

## Note on the earlier blocker

The "Not authenticated to Docker" wall from my first attempt was misleading — `sbx daemon start` was failing on a revoked OAuth refresh token and deleting the credential, leaving the daemon stopped. `sbx login` fixed it. Worth knowing if it recurs: `sbx diagnose` reports the real cause, the top-level error does not.

## Verification

- 692 tests across 52 suites (was 684/52).
- `scripts/bundle.sh` archive succeeds and installs.