### PR TITLE
Isolate settings by config dir, like sessions and projects (#66)

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		C727214786425B7141AE52A6 /* ContainerSandboxE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC067F40D9AF4F8D67CBC04 /* ContainerSandboxE2ETests.swift */; };
 		CAF1AB1BC545E41239724272 /* TerminalSessionOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B8F8AE3E1C9ADB56FB3F2C /* TerminalSessionOutputTests.swift */; };
 		CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104528AB64BB407CE23FBDE /* SettingsTests.swift */; };
+		D0FC25C2C20B1E45C81F7946 /* SettingsIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334F06A81ABA6B06194B661A /* SettingsIsolationTests.swift */; };
 		D25D5684810B60D6B03D8100 /* GitServiceStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8815ACE4151F62175FCCC17 /* GitServiceStatusTests.swift */; };
 		D4B3A1927CC6F2B3C0249BB5 /* canopy-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 211150E144900E5C953921DB /* canopy-logo.svg */; };
 		D9227BD1898EF4FE74C4125D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F43DF5D5450E527968F656AF /* Assets.xcassets */; };
@@ -136,6 +137,7 @@
 		2AEF32F025B580FFE656B31C /* TranscriptSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSheet.swift; sourceTree = "<group>"; };
 		2CD910CDF81D1FB6B5AE3840 /* Canopy.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Canopy.icns; sourceTree = "<group>"; };
 		2D0D9FD9FF67751D32B9529D /* MergeWorktreeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWorktreeSheet.swift; sourceTree = "<group>"; };
+		334F06A81ABA6B06194B661A /* SettingsIsolationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIsolationTests.swift; sourceTree = "<group>"; };
 		3577FDAC3BB3B716543493D2 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		357D44B70B337CBEA901EFC2 /* GitStatusPollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusPollingTests.swift; sourceTree = "<group>"; };
 		35FE3AB3398096E42931EF0C /* ClaudeVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeVersionCheckerTests.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 				774CEE75403401F0A7DE18E9 /* SessionNameTests.swift */,
 				0E948527D5D146F27269411E /* SessionSandboxTests.swift */,
 				EB57402CEF34C579AE3ED054 /* SettingsEdgeCaseTests.swift */,
+				334F06A81ABA6B06194B661A /* SettingsIsolationTests.swift */,
 				2104528AB64BB407CE23FBDE /* SettingsTests.swift */,
 				E5B7E843E7BD7B5EB66188C9 /* StopAllSessionsTests.swift */,
 				DC75183751A4B23284AEDEC2 /* SwiftTermMouseEncodingTests.swift */,
@@ -594,6 +597,7 @@
 				A2E3315C93FEA826BF12CBCF /* SessionNameTests.swift in Sources */,
 				DCEC5FF914987D48A89E3D81 /* SessionSandboxTests.swift in Sources */,
 				47572C3FF5F7C52C77D0B4C5 /* SettingsEdgeCaseTests.swift in Sources */,
+				D0FC25C2C20B1E45C81F7946 /* SettingsIsolationTests.swift in Sources */,
 				CEF733D3EB0A67115C18B758 /* SettingsTests.swift in Sources */,
 				B48BFDA403A0ABE090C067B5 /* StopAllSessionsTests.swift in Sources */,
 				8801D68EF40EEFBDF852421E /* SwiftTermMouseEncodingTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -397,8 +397,15 @@ final class AppState: ObservableObject {
     /// `.working` again.
     func abandonAgentReconciliation() {
         agentIdleObservations.removeAll()
-        for terminal in terminalSessions.values {
-            releaseNeedsInput(terminal)
+        // Every state we imposed is frozen, not just .needsInput:
+        // setAuthoritativeActivity cancels the PTY idle and justFinished
+        // timers, so a session left .working has nothing left to move it and
+        // would sit there until the next byte arrives -- which for a session
+        // waiting on a long API turn may be minutes, or never.
+        // .idle is the safe resting state; the next byte restarts the
+        // heuristic normally.
+        for terminal in terminalSessions.values where terminal.activity != .idle {
+            terminal.setAuthoritativeActivity(.idle)
         }
     }
 

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -260,7 +260,9 @@ final class AppState: ObservableObject {
     }
 
     /// Consecutive idle observations per session, for the flap guard above.
-    private var agentIdleObservations: [UUID: Int] = [:]
+    /// Cleared in performCloseSession alongside the other per-session
+    /// dictionaries, so it cannot outlive the sessions it describes.
+    private(set) var agentIdleObservations: [UUID: Int] = [:]
 
     /// Applies a poll of `claude agents --json` to the live sessions.
     ///
@@ -363,6 +365,7 @@ final class AppState: ObservableObject {
                         // Not an error state: the fallback is the behaviour
                         // Canopy shipped with. Say so once and stop trying.
                         NSLog("Canopy: `claude agents --json` unavailable; using the PTY heuristic")
+                        self.abandonAgentReconciliation()
                         return
                     }
                     continue
@@ -373,9 +376,18 @@ final class AppState: ObservableObject {
         }
     }
 
-    func stopAgentPolling() {
-        agentsPollTask?.cancel()
-        agentsPollTask = nil
+    /// Hands control back to the PTY heuristic when live data stops arriving.
+    ///
+    /// `.needsInput` is deliberately sticky against PTY output, so ONLY
+    /// authoritative data can clear it. If the poll gives up while a session
+    /// is blocked, nothing ever would -- the tab would sit amber forever.
+    /// Resetting to `.idle` is safe: the next byte on the PTY moves it to
+    /// `.working` again.
+    func abandonAgentReconciliation() {
+        agentIdleObservations.removeAll()
+        for terminal in terminalSessions.values where terminal.activity == .needsInput {
+            terminal.setAuthoritativeActivity(.idle)
+        }
     }
 
     // MARK: - Git Status Polling
@@ -745,11 +757,12 @@ final class AppState: ObservableObject {
         // microVM, so neither resuming nor assigning means anything there.
         // The Apple container backend mounts ~/.claude from the host.
         if backend.supportsResume {
-            if let existing = session.claudeSessionId, UUID(uuidString: existing) != nil {
+            if let existing = session.claudeSessionId, UUID(uuidString: existing) != nil,
+               Self.transcriptExists(for: session, claudeSessionId: existing) {
                 command += " --resume \(existing)"
             } else {
                 if let junk = session.claudeSessionId {
-                    NSLog("Canopy: discarding non-UUID claudeSessionId %@ for session %@",
+                    NSLog("Canopy: discarding unusable claudeSessionId %@ for session %@",
                           junk, session.id.uuidString)
                 }
                 let fresh = session.id.uuidString
@@ -762,6 +775,21 @@ final class AppState: ObservableObject {
             command += " \(nameFlag)"
         }
         return (command, assignedId)
+    }
+
+    /// Whether the transcript an id names actually exists on disk.
+    ///
+    /// `claude --resume <unknown-id>` prints "No conversation found with
+    /// session ID: <id>" and exits, so the tab never starts claude at all.
+    /// Canopy can bank an unusable id by its own hand: the id is persisted
+    /// before the command is sent, but a failed sandbox preflight echoes a
+    /// warning INSTEAD of running claude, so nothing ever creates the session.
+    /// Mirrors the check TranscriptSheet.computeJSONLPath already makes.
+    private static func transcriptExists(for session: SessionInfo, claudeSessionId: String) -> Bool {
+        FileManager.default.fileExists(atPath: ClaudeTranscriptLoader.sessionFilePath(
+            workingDirectory: session.workingDirectory,
+            sessionId: claudeSessionId
+        ))
     }
 
     /// Records an assigned Claude session ID. Must be called before the
@@ -882,6 +910,7 @@ final class AppState: ObservableObject {
         sessionDiffStats.removeValue(forKey: id)
         sessionCommitsAhead.removeValue(forKey: id)
         sessionPRCount.removeValue(forKey: id)
+        agentIdleObservations.removeValue(forKey: id)
         withAnimation(.easeOut(duration: 0.25)) {
             sessions.removeAll { $0.id == id }
             if activeSessionId == id {

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -277,7 +277,7 @@ final class AppState: ObservableObject {
     /// their status cannot be trusted. `.dockerSbx` shares nothing at all.
     func applyAgents(_ agents: [ClaudeAgent]) {
         for session in sessions {
-            guard sandboxBackend(for: session) == .off,
+            guard sandboxBackend(for: session).reportsToHostAgentRegistry,
                   let terminal = terminalSessions[session.id] else { continue }
 
             // Ambiguous means two claudes under one directory (a split
@@ -288,13 +288,25 @@ final class AppState: ObservableObject {
                 forWorktree: session.workingDirectory, in: agents
             ) else {
                 agentIdleObservations[session.id] = 0
+                // No live agent speaks for this tab. .needsInput is sticky
+                // against PTY output, so if it is not released here nothing
+                // ever will: quitting claude back to the shell prompt makes
+                // the agent vanish while the PTY lives on, and the tab would
+                // sit amber (and counted in "N need input") for the rest of
+                // the app's life.
+                releaseNeedsInput(terminal)
                 continue
             }
 
-            // Adopt an id only from a conversation that started after this tab
-            // opened. Without this, a claude the user has had running in that
-            // worktree since yesterday would be adopted on the first poll.
-            if let startedAt = agent.startedAt,
+            // Fill in a missing id only -- never replace one we already have.
+            // Overwriting would reintroduce exactly the hijack loadSessions
+            // was hardened against: the tab's claude exits, the user runs a
+            // plain `claude` in that worktree, and Canopy adopts a stranger's
+            // conversation and --resumes into it. An established id is user
+            // data. The startedAt guard additionally rejects a claude that was
+            // already running in the worktree before this tab opened.
+            if session.claudeSessionId == nil,
+               let startedAt = agent.startedAt,
                Date(timeIntervalSince1970: startedAt / 1000) >= terminal.openedAt {
                 assignClaudeSessionId(agent.sessionId, to: session.id)
             }
@@ -343,7 +355,7 @@ final class AppState: ObservableObject {
     /// sandboxed -- the poll's subprocess would be pure waste on a 2-second
     /// loop, so the cycle skips it entirely.
     var hasReconcilableSessions: Bool {
-        sessions.contains { sandboxBackend(for: $0) == .off }
+        sessions.contains { sandboxBackend(for: $0).reportsToHostAgentRegistry }
     }
 
     /// Polls Claude Code for live session state. Separate from the 10 s git
@@ -385,7 +397,15 @@ final class AppState: ObservableObject {
     /// `.working` again.
     func abandonAgentReconciliation() {
         agentIdleObservations.removeAll()
-        for terminal in terminalSessions.values where terminal.activity == .needsInput {
+        for terminal in terminalSessions.values {
+            releaseNeedsInput(terminal)
+        }
+    }
+
+    /// Hands a blocked session back to the PTY heuristic. Safe unconditionally:
+    /// the next byte on the PTY moves it to `.working` again.
+    private func releaseNeedsInput(_ terminal: TerminalSession) {
+        if terminal.activity == .needsInput {
             terminal.setAuthoritativeActivity(.idle)
         }
     }
@@ -765,7 +785,15 @@ final class AppState: ObservableObject {
                     NSLog("Canopy: discarding unusable claudeSessionId %@ for session %@",
                           junk, session.id.uuidString)
                 }
-                let fresh = session.id.uuidString
+                // Seeded from SessionInfo.id so no new Codable field is
+                // needed -- but only while that id is still free. If its
+                // transcript already exists (an earlier launch used it, and
+                // the persisted id has since moved on) reusing it would abort
+                // with "Session ID ... is already in use".
+                let seed = session.id.uuidString
+                let fresh = Self.transcriptExists(for: session, claudeSessionId: seed)
+                    ? UUID().uuidString
+                    : seed
                 command += " --session-id \(fresh)"
                 assignedId = fresh
             }

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -32,7 +32,12 @@ final class AppState: ObservableObject {
     @Published var splitSessionIds: Set<UUID> = []
 
     /// App settings (auto-start claude, flags, etc.)
-    @Published var settings = CanopySettings.load()
+    ///
+    /// Loaded in `init` rather than as a stored-property default, because a
+    /// property initializer cannot see the injected `configDir` -- it always
+    /// resolved the real ~/.config/canopy/settings.json, so a test with a temp
+    /// config dir was isolated for sessions and projects but not for settings.
+    @Published var settings: CanopySettings
 
     /// Saved prompts for the prompt library.
     @Published var prompts: [SavedPrompt] = []
@@ -95,7 +100,12 @@ final class AppState: ObservableObject {
     private let configDir: String
 
     init(configDir: String? = nil) {
-        self.configDir = configDir ?? (NSHomeDirectory() as NSString).appendingPathComponent(".config/canopy")
+        let resolvedConfigDir = configDir
+            ?? (NSHomeDirectory() as NSString).appendingPathComponent(".config/canopy")
+        self.configDir = resolvedConfigDir
+        self.settings = CanopySettings.load(
+            from: (resolvedConfigDir as NSString).appendingPathComponent("settings.json")
+        )
         installKeyboardShortcutObservers()
     }
 
@@ -992,6 +1002,14 @@ final class AppState: ObservableObject {
     private var sessionsFilePath: String {
         try? FileManager.default.createDirectory(atPath: configDir, withIntermediateDirectories: true)
         return (configDir as NSString).appendingPathComponent("sessions.json")
+    }
+
+    /// Settings live in the same injected dir as sessions and projects, so a
+    /// temp config dir isolates all three. Not private: SettingsView writes
+    /// through this rather than the global default path.
+    var settingsFilePath: String {
+        try? FileManager.default.createDirectory(atPath: configDir, withIntermediateDirectories: true)
+        return (configDir as NSString).appendingPathComponent("settings.json")
     }
 
     private var promptsFilePath: String {

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -21,7 +21,23 @@ enum SandboxBackend: String, Codable {
     case claudeNative
 
     /// The `--settings` payload enabling Claude Code's own Bash sandbox.
-    private var sandboxSettingsJSON: String { #"{"sandbox":{"enabled":true}}"# }
+    ///
+    /// `allowUnsandboxedCommands` is explicitly false because the CLI defaults
+    /// it to TRUE: with `enabled` alone, the model may retry any blocked
+    /// command via `dangerouslyDisableSandbox`, and Canopy's default
+    /// `--permission-mode auto` auto-approves that retry. Observed end to end:
+    /// a `touch ~/probe.txt` denied by the sandbox succeeded immediately on
+    /// the unsandboxed retry, so the picker was promising isolation it did not
+    /// deliver.
+    ///
+    /// This is a different thing from inventing an allowlist. `allowedDomains`
+    /// and `excludedCommands` are user preferences and are deliberately left
+    /// to merge from the user's own settings; this key is the difference
+    /// between "sandboxed" and "sandboxed unless the agent asks nicely", and
+    /// the user picked a sandbox.
+    private var sandboxSettingsJSON: String {
+        #"{"sandbox":{"enabled":true,"allowUnsandboxedCommands":false}}"#
+    }
 
     /// Whether `claude` runs as a plain host process, so the host's
     /// `claude agents --json` registry actually describes it.

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -23,6 +23,17 @@ enum SandboxBackend: String, Codable {
     /// The `--settings` payload enabling Claude Code's own Bash sandbox.
     private var sandboxSettingsJSON: String { #"{"sandbox":{"enabled":true}}"# }
 
+    /// Whether `claude` runs as a plain host process, so the host's
+    /// `claude agents --json` registry actually describes it.
+    ///
+    /// `.claudeNative` qualifies: Seatbelt confines what Bash may touch, but
+    /// the process is an ordinary host grandchild of Canopy's PTY shell.
+    /// `.appleContainer` does not -- it writes its registry entry into the
+    /// bind-mounted host ~/.claude, but the pid is a guest-namespace pid and
+    /// the peer socket is unreachable from the host. `.dockerSbx` shares
+    /// nothing of ~/.claude at all.
+    var reportsToHostAgentRegistry: Bool { self == .off || self == .claudeNative }
+
     /// Whether `--resume` works for this backend. Session JSONLs must
     /// persist on the host: sbx microVMs are ephemeral, while the Apple
     /// container backend bind-mounts ~/.claude from the host.

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -47,25 +47,31 @@ enum ClaudeAgentsService {
         static let idle = "idle"
     }
 
+    /// Decodes to nil rather than throwing, so one undecodable element
+    /// cannot fail the whole array.
+    private struct FailableAgent: Decodable {
+        let agent: ClaudeAgent?
+        init(from decoder: Decoder) throws {
+            agent = try? ClaudeAgent(from: decoder)
+        }
+    }
+
     /// Decodes the CLI's output. Returns nil for anything that is not a
     /// top-level array, so an old CLI printing usage text or a shell error is
     /// **detected** rather than read as "zero sessions running" -- the latter
     /// would push every tab to a wrong state at once.
     static func parse(_ data: Data) -> [ClaudeAgent]? {
-        guard let elements = try? JSONSerialization.jsonObject(with: data) as? [Any] else {
+        // Per element, not all-or-nothing: ONE entry of a shape Canopy does
+        // not care about -- a future kind without `cwd`, say -- would
+        // otherwise return nil for the entire poll, and consecutive nils
+        // permanently disable reconciliation.
+        //
+        // A non-array still fails outright, because "old or missing CLI" must
+        // stay distinguishable from "no claude running".
+        guard let wrapped = try? JSONDecoder().decode([FailableAgent].self, from: data) else {
             return nil
         }
-        // Per element, not all-or-nothing. Decoding the array as a whole means
-        // ONE entry of a shape Canopy does not care about -- a future kind
-        // without `cwd`, say -- returns nil for the entire poll, and three of
-        // those in a row permanently disable reconciliation.
-        let decoder = JSONDecoder()
-        return elements.compactMap { element in
-            guard let elementData = try? JSONSerialization.data(withJSONObject: element) else {
-                return nil
-            }
-            return try? decoder.decode(ClaudeAgent.self, from: elementData)
-        }
+        return wrapped.compactMap(\.agent)
     }
 
     /// Resolves both sides before comparing: /tmp is a symlink to /private/tmp

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -52,7 +52,20 @@ enum ClaudeAgentsService {
     /// **detected** rather than read as "zero sessions running" -- the latter
     /// would push every tab to a wrong state at once.
     static func parse(_ data: Data) -> [ClaudeAgent]? {
-        try? JSONDecoder().decode([ClaudeAgent].self, from: data)
+        guard let elements = try? JSONSerialization.jsonObject(with: data) as? [Any] else {
+            return nil
+        }
+        // Per element, not all-or-nothing. Decoding the array as a whole means
+        // ONE entry of a shape Canopy does not care about -- a future kind
+        // without `cwd`, say -- returns nil for the entire poll, and three of
+        // those in a row permanently disable reconciliation.
+        let decoder = JSONDecoder()
+        return elements.compactMap { element in
+            guard let elementData = try? JSONSerialization.data(withJSONObject: element) else {
+                return nil
+            }
+            return try? decoder.decode(ClaudeAgent.self, from: elementData)
+        }
     }
 
     /// Resolves both sides before comparing: /tmp is a symlink to /private/tmp
@@ -94,16 +107,26 @@ enum ClaudeAgentsService {
     /// `nonisolated(unsafe)` matches the shared-formatter precedent in
     /// ClaudeSessionFinder: written once from the poll loop, read from it.
     private nonisolated(unsafe) static var cachedClaudePath: String?
+    /// Cache the FAILURE too. Without this, a claude exposed only as a shell
+    /// function or alias (which `isExecutableFile` rightly rejects) makes every
+    /// poll spawn two login shells instead of one -- re-sourcing the user's rc
+    /// files ~3600x/hour, the precise cost this resolution exists to avoid.
+    private nonisolated(unsafe) static var didAttemptClaudePathResolution = false
 
     private static func resolvedClaudePath() async -> String? {
         // Re-check the cached path is still executable. claude auto-updates
         // and can be moved or removed while Canopy runs; a stale path would
         // fail every poll, and consecutive failures disable reconciliation for
-        // the rest of the session.
+        // the rest of the session. A stale entry re-opens the resolution.
         if let cached = cachedClaudePath {
             if FileManager.default.isExecutableFile(atPath: cached) { return cached }
             cachedClaudePath = nil
+            didAttemptClaudePathResolution = false
         }
+        // Nothing cached and we already tried: don't spawn a login shell every
+        // poll only to fail the same way.
+        if didAttemptClaudePathResolution { return nil }
+        didAttemptClaudePathResolution = true
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: SandboxChecker.loginShell())
@@ -113,8 +136,15 @@ enum ClaudeAgentsService {
         process.standardError = FileHandle.nullDevice
 
         guard (try? process.run()) != nil else { return nil }
+        // Same watchdog as fetch(): a hung rc file must not wedge the poll
+        // loop, and this process is spawned before fetch()'s own watchdog.
+        let watchdog = DispatchWorkItem { [weak process] in
+            if process?.isRunning == true { process?.terminate() }
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5, execute: watchdog)
         let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
         process.waitUntilExit()
+        watchdog.cancel()
         guard process.terminationStatus == 0 else { return nil }
 
         let path = String(decoding: data, as: UTF8.self)

--- a/Canopy/Views/ActivityDot.swift
+++ b/Canopy/Views/ActivityDot.swift
@@ -6,6 +6,10 @@ struct ActivityDot: View {
     var projectColor: Color = .gray
 
     @State private var isSpinning = false
+    /// Separate from isSpinning: sharing one flag let a working → needsInput
+    /// transition deliver the spinner's onDisappear AFTER the ring's onAppear,
+    /// leaving no value change to drive repeatForever and freezing both.
+    @State private var isPulsing = false
 
     var body: some View {
         ZStack {
@@ -36,13 +40,13 @@ struct ActivityDot: View {
                 Circle()
                     .stroke(Color.orange, lineWidth: 1.5)
                     .frame(width: 12, height: 12)
-                    .opacity(isSpinning ? 0.35 : 1.0)
+                    .opacity(isPulsing ? 0.35 : 1.0)
                     .animation(
                         .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
-                        value: isSpinning
+                        value: isPulsing
                     )
-                    .onAppear { isSpinning = true }
-                    .onDisappear { isSpinning = false }
+                    .onAppear { isPulsing = true }
+                    .onDisappear { isPulsing = false }
             }
 
             // Glow for justFinished

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -187,7 +187,8 @@ struct AddProjectSheet: View {
                             }
                         )) {
                             Text("Off").tag(SandboxBackend.off)
-                            Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                            Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
+                            Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
                             Text("Apple container").tag(SandboxBackend.appleContainer)
                         }
                             .font(.subheadline)

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -165,7 +165,8 @@ struct EditProjectSheet: View {
                             }
                         )) {
                             Text("Off").tag(SandboxBackend.off)
-                            Text("Docker Sandbox (sbx)").tag(SandboxBackend.dockerSbx)
+                            Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
+                            Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
                             Text("Apple container").tag(SandboxBackend.appleContainer)
                         }
                             .font(.subheadline)

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -508,8 +508,10 @@ struct SettingsView: View {
         settings.containerPath = containerPath
         // A failed write must keep the sheet open: dismissing would let the
         // user believe their (possibly security-relevant) choice persisted.
-        guard settings.save() else {
-            saveError = "Could not write ~/.config/canopy/settings.json"
+        // Through appState's path, not the global default: otherwise a save
+        // would escape an injected config dir and hit the real file.
+        guard settings.save(to: appState.settingsFilePath) else {
+            saveError = "Could not write \(appState.settingsFilePath)"
             return
         }
         appState.settings = settings

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -220,6 +220,41 @@ struct AgentReconciliationTests {
         #expect(!AppState.confirmsFinish(wasWorking: false, consecutiveIdleObservations: 5))
     }
 
+    // MARK: - Giving up
+
+    /// .needsInput is sticky against PTY output on purpose, so only
+    /// authoritative data can clear it. If the poll gives up while a session
+    /// is blocked, nothing else ever would and the tab sits amber forever.
+    @Test func abandoningReconciliationReleasesStuckNeedsInput() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-n")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-n", status: "waiting")])
+        #expect(terminal.activity == .needsInput)
+
+        state.abandonAgentReconciliation()
+        #expect(terminal.activity == .idle)
+
+        // And the PTY heuristic is back in charge.
+        terminal.handleOutputData(Data("output".utf8))
+        #expect(terminal.activity == .working)
+    }
+
+    /// Per-session bookkeeping must not outlive the session, matching the
+    /// other per-session dictionaries cleared in performCloseSession.
+    @Test func closingASessionClearsItsIdleBookkeeping() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-o")
+        let id = state.sessions[0].id
+
+        state.applyAgents([agent(cwd: "/tmp/wt-o", status: "idle")])
+        #expect(state.agentIdleObservations[id] != nil)
+
+        state.performCloseSession(id: id)
+        #expect(state.agentIdleObservations[id] == nil)
+    }
+
     // MARK: - Persistence
 
     /// saveSessions does an atomic file write. A 2-second loop must not

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -301,6 +301,70 @@ struct AgentReconciliationTests {
         #expect(terminal.activity == .working)
     }
 
+    // MARK: - Review findings
+
+    /// Quitting claude back to the shell prompt makes the agent vanish while
+    /// the PTY lives on, so onProcessExit never fires. .needsInput is sticky
+    /// against PTY output, so without an explicit handback the tab sat amber
+    /// -- and counted in "N need input" -- for the rest of the app's life.
+    @Test func agentDisappearingReleasesStuckNeedsInput() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-p")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-p", status: "waiting")])
+        #expect(terminal.activity == .needsInput)
+
+        state.applyAgents([])
+        #expect(terminal.activity == .idle)
+    }
+
+    /// Same hole via the other skip path: a second claude in the directory
+    /// makes the match ambiguous, and ambiguity must not mean "stay amber".
+    @Test func ambiguousMatchReleasesStuckNeedsInput() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-q")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-q", status: "waiting")])
+        #expect(terminal.activity == .needsInput)
+
+        state.applyAgents([
+            agent(cwd: "/tmp/wt-q", sessionId: "a", status: "waiting"),
+            agent(cwd: "/tmp/wt-q/sub", sessionId: "b", status: "busy"),
+        ])
+        #expect(terminal.activity == .idle)
+    }
+
+    /// .claudeNative runs claude as an ordinary host process -- Seatbelt
+    /// confines Bash, not the process's registry entry. Gating literally on
+    /// .off silently removed the whole needs-input feature from the backend
+    /// this milestone promotes.
+    @Test func claudeNativeSessionIsReconciled() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-r", backend: .claudeNative)
+        let live = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-r", sessionId: live, status: "waiting")])
+
+        #expect(state.sessions[0].claudeSessionId == live)
+        #expect(state.terminalSessions[state.sessions[0].id]?.activity == .needsInput)
+    }
+
+    /// An established id is user data -- the principle loadSessions was
+    /// hardened around. Replacing it here would reintroduce the same hijack:
+    /// the tab's claude exits, the user runs a plain `claude` in that
+    /// worktree, and Canopy --resumes into a stranger's conversation.
+    @Test func doesNotReplaceAnEstablishedSessionId() {
+        let state = makeState()
+        let owned = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-s", claudeSessionId: owned)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-s", sessionId: "stranger", status: "idle")])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
 
     // MARK: - Poll gating
 

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -385,4 +385,23 @@ struct AgentReconciliationTests {
         #expect(state.hasReconcilableSessions)
     }
 
+    /// Giving up must release EVERY imposed state, not only .needsInput.
+    /// setAuthoritativeActivity cancels the PTY timers, so a session left
+    /// .working has nothing to move it on and would sit there indefinitely.
+    @Test func abandoningReconciliationReleasesStuckWorking() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-u")
+        let terminal = try! #require(state.terminalSessions[state.sessions[0].id])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-u", status: "busy")])
+        #expect(terminal.activity == .working)
+
+        state.abandonAgentReconciliation()
+        #expect(terminal.activity == .idle)
+
+        // And the heuristic is driving again.
+        terminal.handleOutputData(Data("output".utf8))
+        #expect(terminal.activity == .working)
+    }
+
 }

--- a/Tests/ClaudeAgentsServiceTests.swift
+++ b/Tests/ClaudeAgentsServiceTests.swift
@@ -209,4 +209,28 @@ struct ClaudeAgentsServiceTests {
         #expect(Date().timeIntervalSince(started) < 15)
     }
 
+    // MARK: - Review findings
+
+    /// One undecodable entry must not blind Canopy to every other session.
+    /// Decoding the array as a whole meant a single future entry without
+    /// `cwd` returned nil for the entire poll -- and three such polls in a
+    /// row permanently disable reconciliation.
+    @Test func oneUndecodableElementDoesNotDiscardTheRest() throws {
+        let agents = try #require(ClaudeAgentsService.parse(data("""
+        [
+          {"cwd":"/tmp/wt","sessionId":"good-1","status":"busy"},
+          {"kind":"some-future-thing","startedAt":123},
+          {"cwd":"/tmp/other","sessionId":"good-2","status":"idle"}
+        ]
+        """)))
+
+        #expect(agents.map(\.sessionId) == ["good-1", "good-2"])
+    }
+
+    /// Still a hard failure, not an empty result: a non-array must remain
+    /// distinguishable from "no claude running".
+    @Test func nonArrayStillReturnsNilAfterPerElementDecoding() {
+        #expect(ClaudeAgentsService.parse(data(#"{"cwd":"/tmp","sessionId":"x"}"#)) == nil)
+    }
+
 }

--- a/Tests/ClaudeLaunchCommandTests.swift
+++ b/Tests/ClaudeLaunchCommandTests.swift
@@ -48,8 +48,12 @@ struct ClaudeLaunchCommandTests {
     /// "Session ID ... is already in use", so the flags must swap over.
     @Test func resumesInsteadOfAssigningWhenIdKnown() {
         let state = makeState()
+        let workDir = "/tmp/canopy-known-\(UUID().uuidString)"
         let known = UUID().uuidString
-        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt", claudeSessionId: known)
+        let projectDir = makeTranscript(workDir: workDir, sessionId: known)
+        defer { try? FileManager.default.removeItem(atPath: projectDir) }
+
+        let session = SessionInfo(name: "s", workingDirectory: workDir, claudeSessionId: known)
         state.sessions = [session]
 
         let launch = state.claudeLaunchCommand(for: session)
@@ -60,21 +64,40 @@ struct ClaudeLaunchCommandTests {
 
     /// The highest-value test here: an app restart re-runs the launch path
     /// with the same persisted session. Drive it twice, persisting between,
-    /// exactly as MainWindow does.
+    /// exactly as MainWindow does -- and create the transcript in between,
+    /// because that is what claude does with the id it was handed.
     @Test func secondLaunchResumesRatherThanColliding() {
         let state = makeState()
-        let session = SessionInfo(name: "s", workingDirectory: "/tmp/wt")
+        let workDir = "/tmp/canopy-second-\(UUID().uuidString)"
+        let session = SessionInfo(name: "s", workingDirectory: workDir)
         state.sessions = [session]
 
         let first = state.claudeLaunchCommand(for: session)
         let assigned = try! #require(first.assignedId)
         state.assignClaudeSessionId(assigned, to: session.id)
 
+        // claude now owns that id and has written its transcript.
+        let projectDir = makeTranscript(workDir: workDir, sessionId: assigned)
+        defer { try? FileManager.default.removeItem(atPath: projectDir) }
+
         let reloaded = state.sessions[0]
         let second = state.claudeLaunchCommand(for: reloaded)
         #expect(second.command.contains("--resume \(assigned)"))
         #expect(!second.command.contains("--session-id"))
         #expect(second.assignedId == nil)
+    }
+
+    /// Simulates claude having created the transcript for `sessionId`.
+    /// Returns the project directory so callers can clean it up.
+    @discardableResult
+    private func makeTranscript(workDir: String, sessionId: String) -> String {
+        let projectDir = ClaudeSessionFinder.projectDirectory(for: workDir)
+        try? FileManager.default.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(
+            atPath: (projectDir as NSString).appendingPathComponent("\(sessionId).jsonl"),
+            contents: Data("{}".utf8)
+        )
+        return projectDir
     }
 
     /// sbx session files live inside the ephemeral microVM, which is why
@@ -125,6 +148,57 @@ struct ClaudeLaunchCommandTests {
         let assigned = state.claudeLaunchCommand(for: session).assignedId
         #expect(assigned == session.id.uuidString)
         #expect(assigned == assigned?.uppercased())
+    }
+
+    // MARK: - Stale ids
+
+    /// Verified against the CLI: resuming an id that has no transcript prints
+    ///
+    ///   No conversation found with session ID: <id>
+    ///
+    /// and exits, so the tab never starts claude at all.
+    ///
+    /// Canopy can reach that state by its own hand: the id is persisted before
+    /// the command is sent, but the sandbox-preflight path echoes a warning
+    /// INSTEAD of running claude (SandboxBackendUI.launchCommand). A failed
+    /// preflight therefore banked an id that was never used, and every later
+    /// launch resumed into nothing. Deleting ~/.claude/projects gets there too.
+    ///
+    /// So an id is only worth resuming if its transcript exists -- the same
+    /// check TranscriptSheet.computeJSONLPath already makes before rendering.
+    @Test func doesNotResumeASessionWhoseTranscriptIsMissing() {
+        let state = makeState()
+        let workDir = "/tmp/canopy-stale-\(UUID().uuidString)"
+        let session = SessionInfo(
+            name: "s", workingDirectory: workDir,
+            claudeSessionId: UUID().uuidString   // valid UUID, no file on disk
+        )
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(!launch.command.contains("--resume"))
+        #expect(launch.command.contains("--session-id \(session.id.uuidString)"))
+        #expect(launch.assignedId == session.id.uuidString)
+    }
+
+    @Test func resumesWhenTheTranscriptExists() throws {
+        let state = makeState()
+        let workDir = "/tmp/canopy-live-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: workDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: workDir) }
+
+        let known = UUID().uuidString
+        let projectDir = makeTranscript(workDir: workDir, sessionId: known)
+        defer { try? FileManager.default.removeItem(atPath: projectDir) }
+
+        let session = SessionInfo(
+            name: "s", workingDirectory: workDir, claudeSessionId: known
+        )
+        state.sessions = [session]
+
+        let launch = state.claudeLaunchCommand(for: session)
+        #expect(launch.command.contains("--resume \(known)"))
+        #expect(!launch.command.contains("--session-id"))
     }
 
     // MARK: - Adversarial

--- a/Tests/SettingsIsolationTests.swift
+++ b/Tests/SettingsIsolationTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// `AppState(configDir:)` must isolate ALL three config files, not just two.
+///
+/// `settings` was initialised as a stored-property default, which cannot see
+/// the injected `configDir` and so always resolved the real
+/// `~/.config/canopy/settings.json`. That made every test that did not
+/// explicitly assign `state.settings.…` run against whatever the developer
+/// happened to have configured -- a test could pass locally and fail in CI
+/// (where no settings file exists) for reasons invisible in its body, and
+/// changing your own sandbox preference could turn the suite red.
+///
+/// `CanopySettings.defaultFilePath` already documents the intent: "Tests pass
+/// an explicit path instead so they never clobber the user's settings." The
+/// AppState property initializer defeated it.
+@Suite("Settings isolation")
+@MainActor
+struct SettingsIsolationTests {
+
+    private func tempDir() -> String {
+        NSTemporaryDirectory() + "canopy-test-\(UUID().uuidString)"
+    }
+
+    /// The regression test: an empty config dir must yield DEFAULTS, not the
+    /// developer's real configuration. This fails on any machine whose real
+    /// settings.json differs from the defaults.
+    @Test func emptyConfigDirYieldsDefaultsNotTheRealFile() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let state = AppState(configDir: dir)
+
+        #expect(state.settings.sandboxBackend == CanopySettings().sandboxBackend)
+        #expect(state.settings.claudeFlags == CanopySettings().claudeFlags)
+        #expect(state.settings.containerImage == CanopySettings().containerImage)
+    }
+
+    @Test func settingsAreLoadedFromInjectedConfigDir() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+
+        var written = CanopySettings()
+        written.sandboxBackend = .appleContainer
+        written.claudeFlags = "--model fable"
+        #expect(written.save(to: (dir as NSString).appendingPathComponent("settings.json")))
+
+        let state = AppState(configDir: dir)
+        #expect(state.settings.sandboxBackend == .appleContainer)
+        #expect(state.settings.claudeFlags == "--model fable")
+    }
+
+    /// Saving must land in the injected dir too, or a test that saves would
+    /// overwrite the developer's real settings.
+    @Test func settingsSaveRoundTripsThroughInjectedConfigDir() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let state = AppState(configDir: dir)
+        state.settings.claudeFlags = "--effort xhigh"
+        #expect(state.settings.save(to: state.settingsFilePath))
+
+        let reloaded = AppState(configDir: dir)
+        #expect(reloaded.settings.claudeFlags == "--effort xhigh")
+    }
+
+    /// The injected path must be inside the injected dir -- not merely
+    /// different from the default.
+    @Test func settingsFilePathIsInsideTheConfigDir() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let state = AppState(configDir: dir)
+        #expect(state.settingsFilePath == (dir as NSString).appendingPathComponent("settings.json"))
+    }
+
+    /// Two states on different dirs must not see each other's settings.
+    @Test func twoConfigDirsAreIndependent() {
+        let dirA = tempDir(), dirB = tempDir()
+        defer {
+            try? FileManager.default.removeItem(atPath: dirA)
+            try? FileManager.default.removeItem(atPath: dirB)
+        }
+
+        let a = AppState(configDir: dirA)
+        a.settings.claudeFlags = "--from-a"
+        #expect(a.settings.save(to: a.settingsFilePath))
+
+        let b = AppState(configDir: dirB)
+        #expect(b.settings.claudeFlags == CanopySettings().claudeFlags)
+    }
+
+    /// Production behaviour must be unchanged: no configDir means the real
+    /// file, which is what the shipping app relies on.
+    @Test func defaultInitStillUsesTheRealConfigDirectory() {
+        let state = AppState()
+        let expected = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".config/canopy/settings.json")
+        #expect(state.settingsFilePath == expected)
+    }
+}

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -443,7 +443,7 @@ struct SettingsTests {
             claudeFlags: "--permission-mode auto", sbxFlags: "",
             containerImage: "", containerFlags: "", disableAltScreen: false
         )
-        #expect(command == #"claude --settings '{"sandbox":{"enabled":true}}' --permission-mode auto"#)
+        #expect(command == #"claude --settings '{"sandbox":{"enabled":true,"allowUnsandboxedCommands":false}}' --permission-mode auto"#)
     }
 
     /// Malformed JSON makes claude exit at startup with an error the user
@@ -619,6 +619,36 @@ struct SettingsTests {
         #expect(SandboxBackend.claudeNative.reportsToHostAgentRegistry)
         #expect(!SandboxBackend.appleContainer.reportsToHostAgentRegistry)
         #expect(!SandboxBackend.dockerSbx.reportsToHostAgentRegistry)
+    }
+
+
+    /// The escape hatch must be shut, or the picker lies.
+    ///
+    /// `allowUnsandboxedCommands` defaults to TRUE in the CLI
+    /// (`allowUnsandboxedCommands ?? true`), so with only `enabled: true` the
+    /// model may retry any blocked command via `dangerouslyDisableSandbox` --
+    /// and Canopy's default `--permission-mode auto` auto-approves the retry.
+    /// Observed end to end: a `touch ~/probe.txt` denied by the sandbox
+    /// succeeded on the immediate unsandboxed retry.
+    ///
+    /// This is not Canopy overriding a user preference the way an invented
+    /// allowlist would be. It is the difference between "sandboxed" and
+    /// "sandboxed unless the agent asks", and the user picked a sandbox.
+    @Test func claudeNativeForbidsUnsandboxedRetries() throws {
+        let command = SandboxBackend.claudeNative.claudeCommand(
+            claudeFlags: "", sbxFlags: "", containerImage: "",
+            containerFlags: "", disableAltScreen: false
+        )
+        let start = try #require(command.range(of: "'"))
+        let end = try #require(command.range(of: "'", options: .backwards))
+        let blob = String(command[start.upperBound..<end.lowerBound])
+
+        let parsed = try #require(
+            try JSONSerialization.jsonObject(with: Data(blob.utf8)) as? [String: Any]
+        )
+        let sandbox = try #require(parsed["sandbox"] as? [String: Any])
+        #expect(sandbox["enabled"] as? Bool == true)
+        #expect(sandbox["allowUnsandboxedCommands"] as? Bool == false)
     }
 
 }

--- a/Tests/SettingsTests.swift
+++ b/Tests/SettingsTests.swift
@@ -610,4 +610,15 @@ struct SettingsTests {
         #expect(!SandboxBackend.dockerSbx.supportsResume)
     }
 
+
+    /// Which backends the host's `claude agents --json` can actually describe.
+    /// Container pids are guest-namespace pids and sbx shares no ~/.claude;
+    /// .claudeNative is an ordinary host process.
+    @Test func onlyHostBackendsReportToTheAgentRegistry() {
+        #expect(SandboxBackend.off.reportsToHostAgentRegistry)
+        #expect(SandboxBackend.claudeNative.reportsToHostAgentRegistry)
+        #expect(!SandboxBackend.appleContainer.reportsToHostAgentRegistry)
+        #expect(!SandboxBackend.dockerSbx.reportsToHostAgentRegistry)
+    }
+
 }


### PR DESCRIPTION
Stacked on #71.

`AppState(configDir:)` redirected `sessions.json` and `projects.json` but **not** `settings.json`:

```swift
@Published var settings = CanopySettings.load()   // no path -> the REAL file
```

A stored-property default cannot see the injected `configDir`, so it always resolved `~/.config/canopy/settings.json`.

## Why it matters

Every test that didn't explicitly assign `state.settings.…` ran against whatever the developer happened to have configured. I found this while adding the `--add-dir` tests in #65: a test that set no backend produced a `container run …` command, because this machine's real settings use `.appleContainer`. On CI, where no settings file exists, the same test resolves `.off` and asserts against a completely different string.

That's the bad failure mode — **a test passing locally and failing in CI, or vice versa, for a reason invisible in its body.** It also means changing your own sandbox preference could turn the suite red.

`CanopySettings.defaultFilePath` already documents the intent:

> The real config file. Tests pass an explicit path instead so they never clobber the user's settings.

The AppState property initializer defeated it.

## Fix

Settings load in `init` from the resolved config dir, and `SettingsView` saves through `appState.settingsFilePath` rather than the global default — otherwise a save would escape an injected dir and hit the real file. `settingsFilePath` follows the existing `sessionsFilePath` / `projectsFilePath` shape.

## Mutation-tested

Restoring the old initializer fails 3 of the 6 new tests, including one that reports the leaked value directly:

```
✘ emptyConfigDirYieldsDefaultsNotTheRealFile
  (state.settings.sandboxBackend → .appleContainer) == (CanopySettings().sandboxBackend → .off)
```

That is the bug, reproduced by the test.

Production behaviour is unchanged and pinned: `AppState()` with no `configDir` still resolves the real path.

## Verification

- 698 tests across 53 suites (was 692/52).
- `scripts/bundle.sh` archive succeeds and installs.
- No `.corrupt` file appears in the real `~/.config/canopy` after a full run.