### PR TITLE
Show sandbox and flags in Session Info (#73)

### DIFF
--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -735,10 +735,7 @@ final class AppState: ObservableObject {
         // verified on CLI 2.1.224, reading a main-repo file from a worktree
         // session under `--permission-mode manual` is refused outright.
         // --add-dir grants it, using the path we already resolved above.
-        // session → project → global, mirroring sandboxBackend(for:) above.
-        // `??` and not a blank check: a session that explicitly sets "" means
-        // "no flags", which is different from inheriting.
-        var resolvedFlags = session.claudeFlags ?? project?.claudeFlags ?? settings.claudeFlags
+        var resolvedFlags = resolvedClaudeFlags(for: session)
         for path in extraMounts {
             let resolved = SandboxBackend.realResolvedPath(path)
             if !resolved.isEmpty {
@@ -835,6 +832,17 @@ final class AppState: ObservableObject {
               sessions[index].claudeSessionId != claudeSessionId else { return }
         sessions[index].claudeSessionId = claudeSessionId
         saveSessions()
+    }
+
+    /// The `claude` flags a session runs with: session → project → global,
+    /// mirroring sandboxBackend(for:). `??` and not a blank check -- a session
+    /// that explicitly sets "" means "no flags", which differs from inheriting.
+    ///
+    /// Shared with Session Info rather than resolved inline, so the value the
+    /// user is shown cannot drift from the one actually sent.
+    func resolvedClaudeFlags(for session: SessionInfo) -> String {
+        let project = projects.first { $0.id == session.projectId }
+        return session.claudeFlags ?? project?.claudeFlags ?? settings.claudeFlags
     }
 
     func createWorktreeSession(

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -719,31 +719,50 @@ final class AppState: ObservableObject {
     /// is broken without it. Only for real worktrees -- a worktree is never
     /// inside the repo, so the mounts can't overlap (overlapping virtiofs
     /// mounts are silently dropped or hang the VM).
-    func claudeCommand(for session: SessionInfo) -> String {
-        let project = projects.first { $0.id == session.projectId }
-        var extraMounts: [String] = []
-        if session.worktreePath != nil,
-           let repoPath = project?.repositoryPath,
-           // Compare resolved paths: /tmp vs /private/tmp spellings of the
-           // same directory must not produce a duplicate (overlapping) mount.
-           SandboxBackend.realResolvedPath(repoPath)
-               != SandboxBackend.realResolvedPath(session.workingDirectory) {
-            extraMounts.append(repoPath)
-        }
+    /// Host paths a session needs mounted beyond its own working directory.
+    ///
+    /// Worktree sessions get the project's MAIN repository: a worktree's
+    /// `.git` file points there, so without it every git operation inside a
+    /// sandbox fails. Only for real worktrees, and never when it resolves to
+    /// the working directory itself -- overlapping mounts are silently
+    /// dropped or hang the VM.
+    func extraMountPaths(for session: SessionInfo) -> [String] {
+        guard session.worktreePath != nil,
+              let repoPath = projects.first(where: { $0.id == session.projectId })?.repositoryPath,
+              // /tmp vs /private/tmp spellings of the same directory must not
+              // produce a duplicate mount.
+              SandboxBackend.realResolvedPath(repoPath)
+                  != SandboxBackend.realResolvedPath(session.workingDirectory)
+        else { return [] }
+        return [repoPath]
+    }
+
+    /// Every flag the session actually launches with, including the ones
+    /// Canopy injects rather than the user configuring them.
+    ///
+    /// This is what Session Info shows. `resolvedClaudeFlags` alone would
+    /// under-report: a worktree session also gets `--add-dir <main repo>`,
+    /// so the sheet could read "None" for a command that carries flags.
+    func effectiveClaudeFlags(for session: SessionInfo) -> String {
         // Mounting the main repo fixes the filesystem, but Claude Code's own
         // tool boundary is cwd-scoped independently of what is mounted:
         // verified on CLI 2.1.224, reading a main-repo file from a worktree
         // session under `--permission-mode manual` is refused outright.
-        // --add-dir grants it, using the path we already resolved above.
-        var resolvedFlags = resolvedClaudeFlags(for: session)
-        for path in extraMounts {
+        var flags = resolvedClaudeFlags(for: session)
+        for path in extraMountPaths(for: session) {
             let resolved = SandboxBackend.realResolvedPath(path)
             if !resolved.isEmpty {
-                resolvedFlags += " --add-dir \(SandboxBackend.shellSingleQuoted(resolved))"
+                flags += " --add-dir \(SandboxBackend.shellSingleQuoted(resolved))"
             }
         }
+        return flags
+    }
+
+    func claudeCommand(for session: SessionInfo) -> String {
+        let project = projects.first { $0.id == session.projectId }
+        let extraMounts = extraMountPaths(for: session)
         return sandboxBackend(for: session).claudeCommand(
-            claudeFlags: resolvedFlags,
+            claudeFlags: effectiveClaudeFlags(for: session),
             sbxFlags: project?.sbxFlags ?? settings.sbxFlags,
             containerImage: project?.containerImage ?? settings.containerImage,
             containerFlags: project?.containerFlags ?? settings.containerFlags,
@@ -838,8 +857,9 @@ final class AppState: ObservableObject {
     /// mirroring sandboxBackend(for:). `??` and not a blank check -- a session
     /// that explicitly sets "" means "no flags", which differs from inheriting.
     ///
-    /// Shared with Session Info rather than resolved inline, so the value the
-    /// user is shown cannot drift from the one actually sent.
+    /// This is only the configured chain. Canopy also injects flags of its
+    /// own (`--add-dir` for worktree sessions), so what a session actually
+    /// launches with is `effectiveClaudeFlags(for:)` -- use that for display.
     func resolvedClaudeFlags(for session: SessionInfo) -> String {
         let project = projects.first { $0.id == session.projectId }
         return session.claudeFlags ?? project?.claudeFlags ?? settings.claudeFlags

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -39,6 +39,18 @@ enum SandboxBackend: String, Codable {
         #"{"sandbox":{"enabled":true,"allowUnsandboxedCommands":false}}"#
     }
 
+    /// Human-readable name, so the four sandbox pickers and Session Info
+    /// stop each carrying their own copy of these strings -- that duplication
+    /// is why `.claudeNative` reached only two of the four pickers.
+    var displayName: String {
+        switch self {
+        case .off: return "Off"
+        case .claudeNative: return "Claude sandbox (Bash only)"
+        case .dockerSbx: return "Docker Sandbox (sbx)"
+        case .appleContainer: return "Apple container"
+        }
+    }
+
     /// Whether `claude` runs as a plain host process, so the host's
     /// `claude agents --json` registry actually describes it.
     ///

--- a/Canopy/Views/AddProjectSheet.swift
+++ b/Canopy/Views/AddProjectSheet.swift
@@ -186,10 +186,10 @@ struct AddProjectSheet: View {
                                 }
                             }
                         )) {
-                            Text("Off").tag(SandboxBackend.off)
-                            Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
-                            Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
-                            Text("Apple container").tag(SandboxBackend.appleContainer)
+                            Text(SandboxBackend.off.displayName).tag(SandboxBackend.off)
+                            Text(SandboxBackend.claudeNative.displayName).tag(SandboxBackend.claudeNative)
+                            Text("\(SandboxBackend.dockerSbx.displayName) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
+                            Text(SandboxBackend.appleContainer.displayName).tag(SandboxBackend.appleContainer)
                         }
                             .font(.subheadline)
                             .padding(.leading, 16)

--- a/Canopy/Views/EditProjectSheet.swift
+++ b/Canopy/Views/EditProjectSheet.swift
@@ -164,10 +164,10 @@ struct EditProjectSheet: View {
                                 }
                             }
                         )) {
-                            Text("Off").tag(SandboxBackend.off)
-                            Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
-                            Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
-                            Text("Apple container").tag(SandboxBackend.appleContainer)
+                            Text(SandboxBackend.off.displayName).tag(SandboxBackend.off)
+                            Text(SandboxBackend.claudeNative.displayName).tag(SandboxBackend.claudeNative)
+                            Text("\(SandboxBackend.dockerSbx.displayName) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
+                            Text(SandboxBackend.appleContainer.displayName).tag(SandboxBackend.appleContainer)
                         }
                             .font(.subheadline)
                             .padding(.leading, 16)

--- a/Canopy/Views/SessionInfoSheet.swift
+++ b/Canopy/Views/SessionInfoSheet.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SessionInfoSheet: View {
     let session: SessionInfo
     let openedAt: Date?
+    @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) var dismiss
     @State private var usage: TokenUsage?
 
@@ -18,6 +19,12 @@ struct SessionInfoSheet: View {
                 copiableRow("Working Directory", session.workingDirectory)
                 infoRow("Created", session.createdAt.formatted(date: .abbreviated, time: .shortened))
                 infoRow("Type", session.isWorktreeSession ? "Worktree" : "Plain")
+                // How this session is actually isolated. Both of these are
+                // per-session overridable and were invisible once the session
+                // was running, so a tab could be less sandboxed than the user
+                // believed with no way to check.
+                infoRow("Sandbox", appState.sandboxBackend(for: session).displayName)
+                infoRow("Claude Flags", flagsDescription)
 
                 if let branch = session.branchName {
                     copiableRow("Branch", branch)
@@ -54,6 +61,14 @@ struct SessionInfoSheet: View {
                 SessionCostService.loadUsage(for: session.workingDirectory, sessionId: session.claudeSessionId, since: openedAt)
             }.value
         }
+    }
+
+    /// Blank flags are a real, deliberate state (a session may set "" to mean
+    /// "no flags"), and an empty row reads as a rendering bug.
+    private var flagsDescription: String {
+        let flags = appState.resolvedClaudeFlags(for: session)
+            .trimmingCharacters(in: .whitespaces)
+        return flags.isEmpty ? "None" : flags
     }
 
     private func infoRow(_ label: String, _ value: String) -> some View {

--- a/Canopy/Views/SessionInfoSheet.swift
+++ b/Canopy/Views/SessionInfoSheet.swift
@@ -66,7 +66,7 @@ struct SessionInfoSheet: View {
     /// Blank flags are a real, deliberate state (a session may set "" to mean
     /// "no flags"), and an empty row reads as a rendering bug.
     private var flagsDescription: String {
-        let flags = appState.resolvedClaudeFlags(for: session)
+        let flags = appState.effectiveClaudeFlags(for: session)
             .trimmingCharacters(in: .whitespaces)
         return flags.isEmpty ? "None" : flags
     }

--- a/Canopy/Views/SettingsView.swift
+++ b/Canopy/Views/SettingsView.swift
@@ -121,10 +121,10 @@ struct SettingsView: View {
                                         }
                                     }
                                 )) {
-                                    Text("Off").tag(SandboxBackend.off)
-                                    Text("Claude sandbox (Bash only)").tag(SandboxBackend.claudeNative)
-                        Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
-                                    Text("Apple container").tag(SandboxBackend.appleContainer)
+                                    Text(SandboxBackend.off.displayName).tag(SandboxBackend.off)
+                                    Text(SandboxBackend.claudeNative.displayName).tag(SandboxBackend.claudeNative)
+                        Text("\(SandboxBackend.dockerSbx.displayName) — legacy, no session resume").tag(SandboxBackend.dockerSbx)
+                                    Text(SandboxBackend.appleContainer.displayName).tag(SandboxBackend.appleContainer)
                                 }
                                 .disabled(checkingSandbox)
 

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -176,10 +176,10 @@ struct WorktreeSheet: View {
                     }
                 )) {
                     Text("Use project default").tag(SandboxBackend?.none)
-                    Text("Off").tag(SandboxBackend?.some(.off))
-                    Text("Claude sandbox (Bash only)").tag(SandboxBackend?.some(.claudeNative))
-                    Text("Docker Sandbox (sbx) — legacy, no session resume").tag(SandboxBackend?.some(.dockerSbx))
-                    Text("Apple container").tag(SandboxBackend?.some(.appleContainer))
+                    Text(SandboxBackend.off.displayName).tag(SandboxBackend?.some(.off))
+                    Text(SandboxBackend.claudeNative.displayName).tag(SandboxBackend?.some(.claudeNative))
+                    Text("\(SandboxBackend.dockerSbx.displayName) — legacy, no session resume").tag(SandboxBackend?.some(.dockerSbx))
+                    Text(SandboxBackend.appleContainer.displayName).tag(SandboxBackend?.some(.appleContainer))
                 }
                 .labelsHidden()
                 .disabled(checkingSandbox)

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -417,4 +417,60 @@ struct SessionSandboxTests {
         let session = try JSONDecoder().decode(SessionInfo.self, from: json.data(using: .utf8)!)
         #expect(session.sandboxBackend == nil)
     }
+
+    // MARK: - Session Info visibility
+
+    /// The value Session Info shows must be the value actually sent. Resolving
+    /// the chain in two places is how they drift.
+    @Test func resolvedFlagsMatchWhatTheCommandUses() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--global"
+        let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--project")
+        state.projects = [project]
+
+        let inherited = SessionInfo(name: "s", workingDirectory: "/tmp", projectId: project.id)
+        #expect(state.resolvedClaudeFlags(for: inherited) == "--project")
+        #expect(state.claudeCommand(for: inherited).contains("--project"))
+
+        let overridden = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            claudeFlags: "--model fable"
+        )
+        #expect(state.resolvedClaudeFlags(for: overridden) == "--model fable")
+        #expect(state.claudeCommand(for: overridden) == "claude --model fable")
+    }
+
+    /// "" is a real state meaning "no flags", distinct from inheriting.
+    @Test func resolvedFlagsPreserveExplicitlyEmpty() {
+        let state = makeState()
+        state.settings.claudeFlags = "--global"
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp", claudeFlags: "")
+        #expect(state.resolvedClaudeFlags(for: session).isEmpty)
+    }
+
+    /// Every backend needs a name, and they must be distinct -- Session Info
+    /// showing the same string for two backends would be worse than useless.
+    @Test func everySandboxBackendHasADistinctDisplayName() {
+        let all: [SandboxBackend] = [.off, .claudeNative, .dockerSbx, .appleContainer]
+        let names = all.map(\.displayName)
+        #expect(Set(names).count == all.count)
+        #expect(!names.contains(where: { $0.isEmpty }))
+    }
+
+    /// The row must report the RESOLVED backend, override included -- that is
+    /// the whole question being answered.
+    @Test func displayedSandboxReflectsTheSessionOverride() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        let project = Project(name: "p", repositoryPath: "/tmp", sandboxBackend: .dockerSbx)
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            sandboxBackend: .claudeNative
+        )
+
+        #expect(state.sandboxBackend(for: session).displayName == "Claude sandbox (Bash only)")
+    }
+
 }

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -473,4 +473,53 @@ struct SessionSandboxTests {
         #expect(state.sandboxBackend(for: session).displayName == "Claude sandbox (Bash only)")
     }
 
+
+    /// Session Info must show what the session actually launches with, not
+    /// just the configured chain. A worktree session also gets --add-dir, so
+    /// reporting only the resolved chain could read "None" for a command that
+    /// carries flags.
+    @Test func effectiveFlagsIncludeInjectedAddDir() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = ""
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/wt",
+            projectId: project.id,
+            worktreePath: "/Users/x/dev/wt"
+        )
+
+        #expect(state.resolvedClaudeFlags(for: session).isEmpty)
+        #expect(state.effectiveClaudeFlags(for: session).contains("--add-dir '/Users/x/dev/repo'"))
+    }
+
+    /// The displayed flags and the launched command must not diverge.
+    @Test func effectiveFlagsAreExactlyWhatTheCommandCarries() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--permission-mode auto"
+        let project = Project(name: "p", repositoryPath: "/Users/x/dev/repo")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/Users/x/dev/wt",
+            projectId: project.id,
+            worktreePath: "/Users/x/dev/wt"
+        )
+
+        #expect(state.claudeCommand(for: session)
+                == "claude \(state.effectiveClaudeFlags(for: session))")
+    }
+
+    /// A non-worktree session injects nothing, so both agree trivially.
+    @Test func effectiveFlagsMatchResolvedForPlainSessions() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--permission-mode auto"
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp")
+
+        #expect(state.effectiveClaudeFlags(for: session)
+                == state.resolvedClaudeFlags(for: session))
+    }
+
 }


### PR DESCRIPTION
Stacked on #72. Split out of that PR so it can be reviewed on its own.

Came out of manual testing: *"I'm missing a feature to figure out if a session is sandboxed or not."*

## The gap

`SessionInfoSheet` showed name, created, type, tokens and models — **nothing about how the session is actually isolated**. Both things that decide that are now per-session overridable, and both were invisible once the session started:

- `sandboxBackend` — session → project → global, chosen in the New Worktree sheet and never shown again
- `claudeFlags` — same three tiers (added in #67), so `--permission-mode` and `--model` are equally invisible

## Why it's more than a nicety

The resolved value can differ from what was picked, **silently**:

- `WorktreeSheet` falls back to the *project default* when `SandboxChecker` reports the chosen backend unavailable
- `SettingsView.verifySandbox` resets the picker to `.off` on the same condition
- an unknown `sandboxBackend` raw value (settings written by a newer Canopy, then downgraded) decodes to `.off` — **silently unsandboxed**

So a session could run with weaker isolation than the user believed, with no way to check. That's the same failure mode as the `allowUnsandboxedCommands` bug in #70: promising protection that isn't there.

## Change

Two rows, using the resolvers that already exist:

```
Sandbox        Apple container
Claude Flags   --permission-mode auto
```

- Flag resolution was **inline** in `claudeCommand(for:)`; extracted to `resolvedClaudeFlags(for:)` so the value shown and the value sent come from one chain. A test pins that they agree — resolving in two places is exactly how a display goes confidently wrong.
- Empty flags render as `"None"`. `""` is a real state meaning "no flags" (distinct from inheriting), and a blank row reads as a rendering bug.
- `SandboxBackend` gains `displayName`. Those four picker labels were duplicated across `SettingsView`, `WorktreeSheet`, `AddProjectSheet` and `EditProjectSheet` — duplication that already caused a bug, since `.claudeNative` reached only two of the four.

## Deliberately out of scope

**Where the value came from** ("project default" vs "session override"). It's the obvious follow-up, but it needs an origin enum threaded through both resolvers, and the question asked was "is this sandboxed". Add it when someone asks why.

**Live verification** that the running process is sandboxed. Canopy knows the command it sent; it cannot observe the process's actual Seatbelt profile. Showing resolved configuration is honest and cheap — anything more is a subsystem.

## Verification

- 714 tests across 53 suites.
- `scripts/bundle.sh` archive succeeds; verified in the running app.