### PR TITLE
Per-session claude flags, turn attribution, nested-worktree coverage (#55, #56, #57)

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5B557A590AB2A2D60DD1F4B1 /* SessionCostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D974FBD7BD5BBBDF64BE541 /* SessionCostService.swift */; };
 		5D863827233D39FB0F204643 /* ClaudeTranscriptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C77430DB7DAF98B328FF59 /* ClaudeTranscriptLoaderTests.swift */; };
 		61F597B57855CED664F26FF0 /* WorktreeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB9373875A0B260C472271A /* WorktreeSheet.swift */; };
+		6515580DCA4842D881226FD2 /* NestedWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2504469FA7D78BC1EF7F8727 /* NestedWorktreeTests.swift */; };
 		6C71862F4AA78E6A8389F514 /* SessionTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F4FE53F895955AA9820E15 /* SessionTabBar.swift */; };
 		6D15B75F0C3B73759275DA3F /* TerminalSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03CCFEC213EFB6F02C9FF5A /* TerminalSearchBar.swift */; };
 		7403E7DA09BC3CAD7004D877 /* SessionCostServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */; };
@@ -124,6 +125,7 @@
 		211150E144900E5C953921DB /* canopy-logo.svg */ = {isa = PBXFileReference; path = "canopy-logo.svg"; sourceTree = "<group>"; };
 		2117D13FD29C493DD7750CC7 /* MergeHookIsolationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeHookIsolationTests.swift; sourceTree = "<group>"; };
 		22E1669D32944FC23A8BA7E8 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		2504469FA7D78BC1EF7F8727 /* NestedWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedWorktreeTests.swift; sourceTree = "<group>"; };
 		262AFCFA524B74DDBCA9DB1D /* ContainerImageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerImageBuilder.swift; sourceTree = "<group>"; };
 		27744AE57F084B3F805FCE26 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		2A50AE6A4115D9E40781BA5E /* BundleScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleScriptTests.swift; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 				2117D13FD29C493DD7750CC7 /* MergeHookIsolationTests.swift */,
 				E928FA92524418DF6045AD6C /* MergeWorktreeTests.swift */,
 				96866F8C0F3D4596B7B10674 /* ModelTypeTests.swift */,
+				2504469FA7D78BC1EF7F8727 /* NestedWorktreeTests.swift */,
 				B94D69DB49FB6F3E798C7A07 /* NotificationServiceTests.swift */,
 				BF1E52AC47F359BF1AE8577B /* ProjectColorTests.swift */,
 				46D422E570979B7E618CD81A /* ProjectResolutionTests.swift */,
@@ -563,6 +566,7 @@
 				7BBD2482BE31DC61293CBFD7 /* MergeHookIsolationTests.swift in Sources */,
 				2C645C1A5FA86061FE955BDB /* MergeWorktreeTests.swift in Sources */,
 				EE189F53348D8A0F48F1BE51 /* ModelTypeTests.swift in Sources */,
+				6515580DCA4842D881226FD2 /* NestedWorktreeTests.swift in Sources */,
 				0CF73FE281E458EC93F52840 /* NotificationServiceTests.swift in Sources */,
 				C20B1FD7CDB479CD9E788FA3 /* ProjectColorTests.swift in Sources */,
 				F947F0BD6885AEF08CEF331A /* ProjectResolutionTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -482,7 +482,9 @@ final class AppState: ObservableObject {
     /// 5. Launches a terminal session in the worktree
     /// Creates a session in an existing worktree directory (no git worktree
     /// add), resuming the most recent Claude session found for it.
-    /// `sandboxBackend` nil = inherit project/global, like everywhere else.
+    /// `sandboxBackend` and `claudeFlags` both nil = inherit project/global,
+    /// like everywhere else. For flags, nil ("inherit") and "" ("no flags")
+    /// are deliberately different values.
     func openWorktreeSession(project: Project, worktreePath: String, branch: String?, claudeFlags: String? = nil, sandboxBackend: SandboxBackend? = nil) {
         let sessionId = ClaudeSessionFinder.findLatestSessionId(for: worktreePath)
         let session = SessionInfo(

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -483,7 +483,7 @@ final class AppState: ObservableObject {
     /// Creates a session in an existing worktree directory (no git worktree
     /// add), resuming the most recent Claude session found for it.
     /// `sandboxBackend` nil = inherit project/global, like everywhere else.
-    func openWorktreeSession(project: Project, worktreePath: String, branch: String?, sandboxBackend: SandboxBackend? = nil) {
+    func openWorktreeSession(project: Project, worktreePath: String, branch: String?, claudeFlags: String? = nil, sandboxBackend: SandboxBackend? = nil) {
         let sessionId = ClaudeSessionFinder.findLatestSessionId(for: worktreePath)
         let session = SessionInfo(
             name: branch ?? "session",
@@ -492,6 +492,7 @@ final class AppState: ObservableObject {
             branchName: branch,
             worktreePath: worktreePath,
             claudeSessionId: sessionId,
+            claudeFlags: claudeFlags,
             sandboxBackend: sandboxBackend
         )
         sessions.append(session)
@@ -535,7 +536,10 @@ final class AppState: ObservableObject {
         // verified on CLI 2.1.224, reading a main-repo file from a worktree
         // session under `--permission-mode manual` is refused outright.
         // --add-dir grants it, using the path we already resolved above.
-        var resolvedFlags = project?.claudeFlags ?? settings.claudeFlags
+        // session → project → global, mirroring sandboxBackend(for:) above.
+        // `??` and not a blank check: a session that explicitly sets "" means
+        // "no flags", which is different from inheriting.
+        var resolvedFlags = session.claudeFlags ?? project?.claudeFlags ?? settings.claudeFlags
         for path in extraMounts {
             let resolved = SandboxBackend.realResolvedPath(path)
             if !resolved.isEmpty {
@@ -556,6 +560,7 @@ final class AppState: ObservableObject {
         project: Project,
         branchName: String,
         baseBranch: String,
+        claudeFlags: String? = nil,
         sandboxBackend: SandboxBackend? = nil
     ) async throws {
         worktreeSetupInProgress = true
@@ -618,6 +623,7 @@ final class AppState: ObservableObject {
                 projectId: project.id,
                 branchName: branchName,
                 worktreePath: worktreePath,
+                claudeFlags: claudeFlags,
                 sandboxBackend: sandboxBackend
             )
             withAnimation(.easeOut(duration: 0.25)) {
@@ -990,6 +996,14 @@ struct SessionInfo: Identifiable, Codable {
     /// nil = inherit the project/global setting.
     var sandboxBackend: SandboxBackend?
 
+    /// Per-session `claude` flags chosen at creation time, mirroring the
+    /// sandbox override's session → project → global chain.
+    ///
+    /// nil (inherit) and "" (explicitly no flags) are DIFFERENT: collapsing
+    /// them with `?? ""` reintroduces the bug ClaudeOverrideDefaults exists to
+    /// prevent, where a seeded value silently becomes an override.
+    var claudeFlags: String?
+
     init(
         id: UUID = UUID(),
         name: String,
@@ -998,6 +1012,7 @@ struct SessionInfo: Identifiable, Codable {
         branchName: String? = nil,
         worktreePath: String? = nil,
         claudeSessionId: String? = nil,
+        claudeFlags: String? = nil,
         sandboxBackend: SandboxBackend? = nil,
         createdAt: Date = Date()
     ) {
@@ -1008,6 +1023,7 @@ struct SessionInfo: Identifiable, Codable {
         self.branchName = branchName
         self.worktreePath = worktreePath
         self.claudeSessionId = claudeSessionId
+        self.claudeFlags = claudeFlags
         self.sandboxBackend = sandboxBackend
         self.createdAt = createdAt
     }

--- a/Canopy/Services/ClaudeTranscriptLoader.swift
+++ b/Canopy/Services/ClaudeTranscriptLoader.swift
@@ -20,11 +20,41 @@ struct TranscriptMessage: Equatable, Identifiable {
     let id: String
     let role: Role
     let blocks: [Block]
+    /// Model that produced this turn, e.g. `claude-opus-5`. Assistant-only,
+    /// and nil for Claude Code's own `<synthetic>` error/interrupt entries.
+    let model: String?
+    /// Reasoning effort for this turn, e.g. `xhigh`. Assistant-only, and
+    /// legitimately absent both on CLIs older than ~2.1.212 and for models
+    /// with no effort concept (sonnet-4-5, haiku-4-5, opus-4-8), so
+    /// half-populated attribution is a valid state, not a parse failure.
+    let effort: String?
 
-    init(id: String = UUID().uuidString, role: Role, blocks: [Block]) {
+    init(
+        id: String = UUID().uuidString,
+        role: Role,
+        blocks: [Block],
+        model: String? = nil,
+        effort: String? = nil
+    ) {
         self.id = id
         self.role = role
         self.blocks = blocks
+        self.model = model
+        self.effort = effort
+    }
+
+    /// Compact attribution for display, e.g. `opus-5 · xhigh`. Nil when
+    /// neither field is present, so old transcripts render exactly as before.
+    var attribution: String? {
+        let shortModel = model.map {
+            $0.hasPrefix("claude-") ? String($0.dropFirst("claude-".count)) : $0
+        }
+        switch (shortModel, effort) {
+        case let (model?, effort?): return "\(model) · \(effort)"
+        case let (model?, nil): return model
+        case let (nil, effort?): return effort
+        case (nil, nil): return nil
+        }
     }
 }
 
@@ -69,12 +99,21 @@ enum ClaudeTranscriptLoader {
     static func plainText(messages: [TranscriptMessage]) -> String {
         var lines: [String] = []
         var currentRole: TranscriptMessage.Role?
+        var currentAttribution: String?
         for message in messages {
-            if message.role != currentRole {
+            // A new header on attribution change as well as role change: the
+            // model can switch mid-transcript via /model, and a transcript
+            // pasted into an issue must say which model produced which turn.
+            if message.role != currentRole || message.attribution != currentAttribution {
                 if !lines.isEmpty { lines.append("") }
-                lines.append("## " + (message.role == .user ? "You" : "Claude"))
+                var header = "## " + (message.role == .user ? "You" : "Claude")
+                if let attribution = message.attribution {
+                    header += " — \(attribution)"
+                }
+                lines.append(header)
                 lines.append("")
                 currentRole = message.role
+                currentAttribution = message.attribution
             }
             for block in message.blocks {
                 switch block {
@@ -124,7 +163,19 @@ enum ClaudeTranscriptLoader {
         } else {
             id = "synth-" + fnv1a(line)
         }
-        return TranscriptMessage(id: id, role: role, blocks: blocks)
+        // `effort` is TOP-LEVEL on assistant entries -- a sibling of type/uuid,
+        // NOT inside `message` (verified: 4,170 real entries carry it at the
+        // top level, zero carry `message.effort`). `model` is inside `message`.
+        // Attribution is assistant-only; a user turn has no model.
+        var model: String?
+        var effort: String?
+        if role == .assistant {
+            // Claude Code's own error/interrupt entries claim `<synthetic>`.
+            let raw = message["model"] as? String
+            model = raw == "<synthetic>" ? nil : raw
+            effort = obj["effort"] as? String
+        }
+        return TranscriptMessage(id: id, role: role, blocks: blocks, model: model, effort: effort)
     }
 
     /// Deterministic 64-bit FNV-1a hash for synthetic ids. Stable across

--- a/Canopy/Views/TranscriptSheet.swift
+++ b/Canopy/Views/TranscriptSheet.swift
@@ -329,6 +329,14 @@ struct TranscriptMessageView: View {
                 Text(message.role == .user ? "You" : "Claude")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.secondary)
+                // Per-message, never a session-level header: the model can
+                // change mid-transcript via /model, and effort is absent both
+                // on older CLIs and for models with no effort concept.
+                if let attribution = message.attribution {
+                    Text(attribution)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                }
             }
             ForEach(Array(message.blocks.enumerated()), id: \.offset) { _, block in
                 blockView(block)

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -36,7 +36,12 @@ struct WorktreeSheet: View {
     private var claudeFlagsPlaceholder: String {
         let inherited = (selectedProject?.claudeFlags ?? appState.settings.claudeFlags)
             .trimmingCharacters(in: .whitespaces)
-        return inherited.isEmpty ? "--model fable" : "\(inherited) (inherited)"
+        // Naming an example flag when nothing is inherited would read as a
+        // real default -- say plainly that nothing is inherited, and keep the
+        // example only as a format hint.
+        return inherited.isEmpty
+            ? "No flags inherited — e.g. --model fable"
+            : "\(inherited) (inherited)"
     }
 
     /// Blank means "inherit", so store nil rather than letting an empty string

--- a/Canopy/Views/WorktreeSheet.swift
+++ b/Canopy/Views/WorktreeSheet.swift
@@ -15,6 +15,7 @@ struct WorktreeSheet: View {
     @State private var baseBranch = ""
     @State private var branches: [BranchInfo] = []
     @State private var sandboxOverride: SandboxBackend?
+    @State private var claudeFlags = ""
     @State private var sandboxStatus: SandboxChecker.Status?
     @State private var checkingSandbox = false
     @State private var errorMessage: String?
@@ -28,6 +29,21 @@ struct WorktreeSheet: View {
 
     var selectedProject: Project? {
         appState.projects.first { $0.id == selectedProjectId }
+    }
+
+    /// Shows the value this session would inherit, so an empty field is
+    /// obviously "same as the project" rather than "no flags".
+    private var claudeFlagsPlaceholder: String {
+        let inherited = (selectedProject?.claudeFlags ?? appState.settings.claudeFlags)
+            .trimmingCharacters(in: .whitespaces)
+        return inherited.isEmpty ? "--model fable" : "\(inherited) (inherited)"
+    }
+
+    /// Blank means "inherit", so store nil rather than letting an empty string
+    /// become an override that suppresses the project/global flags.
+    private func nilIfBlank(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private var isProjectLocked: Bool { preselectedProjectId != nil }
@@ -168,6 +184,19 @@ struct WorktreeSheet: View {
                 }
             }
 
+            // Per-session claude flags override
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Claude Flags")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                TextField(claudeFlagsPlaceholder, text: $claudeFlags)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                Text("Any `claude` flag, e.g. --model fable, --effort xhigh. Empty inherits.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
             // Config summary
             if let project = selectedProject {
                 VStack(alignment: .leading, spacing: 4) {
@@ -257,6 +286,7 @@ struct WorktreeSheet: View {
                     project: project,
                     branchName: branchName,
                     baseBranch: baseBranch,
+                    claudeFlags: nilIfBlank(claudeFlags),
                     sandboxBackend: sandboxOverride
                 )
                 await MainActor.run { dismiss() }

--- a/Tests/ClaudeTranscriptLoaderTests.swift
+++ b/Tests/ClaudeTranscriptLoaderTests.swift
@@ -52,6 +52,129 @@ struct ClaudeTranscriptLoaderTests {
         return String(arr.dropFirst().dropLast())
     }
 
+    // MARK: - Model & effort attribution
+
+    /// `effort` is a TOP-LEVEL field on assistant entries -- a sibling of
+    /// `type`/`uuid`/`version` -- while `model` lives inside `message`.
+    /// Surveyed across 60 real transcripts: 4,170 assistant entries carry a
+    /// top-level `effort`, zero carry `message.effort`. Reading it from the
+    /// wrong nesting level is the one thing easy to get wrong here, so assert
+    /// the level, not just the value.
+    @Test func parsesEffortFromTopLevelAssistantField() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","effort":"xhigh","message":{"role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"hi"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let messages = try ClaudeTranscriptLoader.load(path: path)
+        #expect(messages.first?.effort == "xhigh")
+        #expect(messages.first?.model == "claude-opus-5")
+    }
+
+    /// A CLI older than ~2.1.212 emits no `effort` at all. Old transcripts
+    /// must render exactly as they did before this feature existed.
+    @Test func effortAbsentOnOlderTranscriptsYieldsNil() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","version":"2.1.196","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"hi"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let messages = try ClaudeTranscriptLoader.load(path: path)
+        #expect(messages.first?.effort == nil)
+        #expect(messages.first?.model == "claude-fable-5")
+    }
+
+    /// Some models have no effort concept even on a current CLI (sonnet-4-5,
+    /// haiku-4-5, opus-4-8 all observed this way). Half-populated is a VALID
+    /// state, which is why this is per-message and never a session header.
+    @Test func effortAbsentForModelsWithoutEffort() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","version":"2.1.215","message":{"role":"assistant","model":"claude-sonnet-4-5-20250929","content":[{"type":"text","text":"hi"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let messages = try ClaudeTranscriptLoader.load(path: path)
+        #expect(messages.first?.model == "claude-sonnet-4-5-20250929")
+        #expect(messages.first?.effort == nil)
+    }
+
+    /// Claude Code writes `<synthetic>` for its own error/interrupt entries.
+    /// Rendering that as a model name would be noise, not attribution.
+    @Test func syntheticModelSuppressesBadge() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","message":{"role":"assistant","model":"<synthetic>","content":[{"type":"text","text":"Request interrupted"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(try ClaudeTranscriptLoader.load(path: path).first?.model == nil)
+    }
+
+    @Test func userMessagesCarryNoModelOrEffort() throws {
+        let path = tempJSONL([userTextLine("hello")])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let message = try #require(try ClaudeTranscriptLoader.load(path: path).first)
+        #expect(message.model == nil)
+        #expect(message.effort == nil)
+    }
+
+    /// The copied transcript is what gets pasted into a GitHub issue. Losing
+    /// the model attribution there defeats the point of showing it at all.
+    @Test func plainTextRecordsModelAndEffortInClaudeHeader() throws {
+        let path = tempJSONL([
+            userTextLine("question"),
+            #"{"type":"assistant","effort":"xhigh","message":{"role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"answer"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let text = ClaudeTranscriptLoader.plainText(
+            messages: try ClaudeTranscriptLoader.load(path: path)
+        )
+        #expect(text.contains("## Claude — opus-5 · xhigh"))
+        #expect(text.contains("## You"))
+    }
+
+    /// Both fields absent -> the header is byte-identical to today's output.
+    @Test func plainTextHeaderUnchangedWithoutAttribution() throws {
+        let path = tempJSONL([assistantTextLine("answer")])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let text = ClaudeTranscriptLoader.plainText(
+            messages: try ClaudeTranscriptLoader.load(path: path)
+        )
+        #expect(text.hasPrefix("## Claude\n"))
+    }
+
+    /// Model present, effort absent must not leave a dangling separator.
+    @Test func plainTextOmitsSeparatorWhenEffortMissing() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"a"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let text = ClaudeTranscriptLoader.plainText(
+            messages: try ClaudeTranscriptLoader.load(path: path)
+        )
+        #expect(text.hasPrefix("## Claude — sonnet-4-5\n"))
+        #expect(!text.contains("·"))
+    }
+
+    /// The model can change mid-transcript via `/model`, so a new header must
+    /// be emitted when attribution changes even though the role has not.
+    @Test func plainTextStartsNewHeaderWhenModelChangesMidTranscript() throws {
+        let path = tempJSONL([
+            #"{"type":"assistant","effort":"xhigh","message":{"role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"a"}]}}"#,
+            #"{"type":"assistant","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"b"}]}}"#
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let text = ClaudeTranscriptLoader.plainText(
+            messages: try ClaudeTranscriptLoader.load(path: path)
+        )
+        #expect(text.contains("## Claude — opus-5 · xhigh"))
+        #expect(text.contains("## Claude — fable-5"))
+    }
+
     // MARK: - Empty / malformed
 
     @Test func parseEmptyFileYieldsEmptyTranscript() throws {

--- a/Tests/NestedWorktreeTests.swift
+++ b/Tests/NestedWorktreeTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Claude Code creates git worktrees by itself now -- `claude -w/--worktree`,
+/// `/fork`, and subagents with `isolation: worktree`. They land in
+/// `.claude/worktrees/<name>` on branch `worktree-<name>`, **inside** the
+/// repository, unlike Canopy's sibling layout
+/// (`<parent>/canopy-worktrees/<project>/<branch>`).
+///
+/// Upstream's management story is a sweep that skips anything with work in it
+/// and never removes `--worktree` worktrees, so these accumulate with real
+/// commits and nothing watching them. That makes Canopy's cross-worktree
+/// collision pre-flight *more* valuable, not less -- and it would be
+/// unfortunate if the worktrees most likely to surprise you were the ones
+/// Canopy filtered out.
+///
+/// `parseWorktreeList` handles `git worktree list --porcelain` generically, so
+/// all of this *should* already work. These tests exist to prove it, and to
+/// fail loudly if a future change starts assuming worktrees live outside the
+/// repo. All shell out to real `git`.
+@Suite("Claude-created nested worktrees")
+struct NestedWorktreeTests {
+    private let git = GitService()
+    private let fm = FileManager.default
+
+    /// A nested path must not be filtered out of the worktree list, and must
+    /// not be mistaken for the main checkout by the `samePath` comparison that
+    /// `isMainWorktree` and session lookup both use.
+    @Test func listsWorktreesNestedInsideRepository() async throws {
+        try await withRepo { repo in
+            try shell("git worktree add .claude/worktrees/foo -b worktree-foo", in: repo)
+
+            let worktrees = try await git.listWorktrees(repoPath: repo)
+            let nested = try #require(worktrees.first { $0.branch == "worktree-foo" })
+
+            #expect(nested.path.hasSuffix(".claude/worktrees/foo"))
+            #expect(!nested.isBare)
+            // Must not collapse onto the main checkout.
+            #expect(!GitService.samePath(nested.path, repo))
+            #expect(worktrees.contains { GitService.samePath($0.path, repo) })
+        }
+    }
+
+    /// The collision pre-flight is Canopy's differentiator precisely because
+    /// Claude creates worktrees nobody is watching. A Claude-style nested
+    /// worktree and a Canopy-style sibling one touching the same shared
+    /// surface must be reported.
+    @Test func nestedWorktreeParticipatesInCollisionReports() async throws {
+        try await withRepo { repo in
+            let sibling = "\(repo)-wt-canopy-style"
+            defer { try? fm.removeItem(atPath: sibling) }
+
+            try shell("git worktree add .claude/worktrees/foo -b worktree-foo", in: repo)
+            try await git.createWorktree(
+                repoPath: repo, worktreePath: sibling, branch: "feat/canopy",
+                baseBranch: "main", createBranch: true
+            )
+
+            // Different files on the SAME surface: merge-tree sees nothing.
+            try commit("{\"a\":1}\n", to: "apps/web/package.json",
+                       in: "\(repo)/.claude/worktrees/foo")
+            try commit("{\"b\":2}\n", to: "services/api/package.json", in: sibling)
+
+            let report = await git.collisionReport(
+                for: "worktree-foo", against: ["feat/canopy"], base: "main", repoPath: repo
+            )
+            let collision = try #require(report.collisions.first { $0.branch == "feat/canopy" })
+            #expect(collision.sharedSurfaceFiles.contains("apps/web/package.json"))
+        }
+    }
+
+    /// `worktree-<name>` branches are cut from `origin/HEAD`, so deleting one
+    /// must hit the base-branch *detection* path rather than a hardcoded
+    /// branch name -- otherwise Canopy would delete a Claude worktree that
+    /// still has unmerged commits in it without warning.
+    @Test func nestedWorktreeUnmergedCommitsWarnBeforeDelete() async throws {
+        try await withRepo { repo in
+            try shell("git worktree add .claude/worktrees/foo -b worktree-foo", in: repo)
+            try commit("work in progress\n", to: "feature.txt",
+                       in: "\(repo)/.claude/worktrees/foo")
+
+            let hasUnmerged = await git.branchHasUnmergedCommits(
+                repoPath: repo, branch: "worktree-foo", baseBranch: nil
+            )
+            #expect(hasUnmerged)
+        }
+    }
+
+    /// The inverse, so the test above can't pass by the warn-side default that
+    /// `branchHasUnmergedCommits` falls back to when the base can't be resolved.
+    @Test func nestedWorktreeWithNoCommitsDoesNotWarn() async throws {
+        try await withRepo { repo in
+            try shell("git worktree add .claude/worktrees/foo -b worktree-foo", in: repo)
+
+            let hasUnmerged = await git.branchHasUnmergedCommits(
+                repoPath: repo, branch: "worktree-foo", baseBranch: nil
+            )
+            #expect(!hasUnmerged)
+        }
+    }
+
+    // MARK: - Fixture
+
+    /// A repo on `main` with one commit. Nested worktrees live inside it, so
+    /// removing the repo removes them too.
+    private func withRepo(_ body: (_ repo: String) async throws -> Void) async throws {
+        let repo = NSTemporaryDirectory() + "canopy-nested-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: repo, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: repo) }
+
+        try shell("git init -b main && git config user.email 'test@test.com' && git config user.name 'Test'", in: repo)
+        try "base\n".write(toFile: "\(repo)/file.txt", atomically: true, encoding: .utf8)
+        try shell("git add -A && git commit -m 'initial'", in: repo)
+
+        try await body(repo)
+    }
+
+    private func commit(_ contents: String, to file: String, in dir: String) throws {
+        let full = (dir as NSString).appendingPathComponent(file)
+        try fm.createDirectory(
+            atPath: (full as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try contents.write(toFile: full, atomically: true, encoding: .utf8)
+        try shell("git add -A && git commit -m 'edit'", in: dir)
+    }
+
+    @discardableResult
+    private func shell(_ command: String, in dir: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = URL(fileURLWithPath: dir)
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw NSError(domain: "test", code: Int(process.terminationStatus),
+                          userInfo: [NSLocalizedDescriptionKey: String(data: data, encoding: .utf8) ?? ""])
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/SessionSandboxTests.swift
+++ b/Tests/SessionSandboxTests.swift
@@ -123,6 +123,145 @@ struct SessionSandboxTests {
         #expect(!state.claudeCommand(for: session).contains(#"--volume "/Users/x/dev/repo""#))
     }
 
+    // MARK: - Per-session Claude flags
+
+    /// The sandbox backend already resolves session → project → global, but
+    /// claudeFlags stopped at project → global. That is the wrong asymmetry
+    /// for an app whose premise is N agents on N worktrees: "opus on the hard
+    /// branch, fable on the chore branch" required editing a PROJECT-wide
+    /// setting that hit every sibling session.
+    @Test func sessionFlagsOverrideProjectFlags() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--global"
+        let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--project")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            claudeFlags: "--model fable"
+        )
+
+        #expect(state.claudeCommand(for: session) == "claude --model fable")
+    }
+
+    @Test func sessionWithoutFlagsFallsBackToProject() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--global"
+        let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--project")
+        state.projects = [project]
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp", projectId: project.id)
+
+        #expect(state.claudeCommand(for: session) == "claude --project")
+    }
+
+    @Test func sessionWithoutFlagsOrProjectFallsBackToGlobal() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--global"
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        let session = SessionInfo(name: "s", workingDirectory: "/tmp", projectId: project.id)
+
+        #expect(state.claudeCommand(for: session) == "claude --global")
+    }
+
+    /// nil (inherit) and "" (explicitly no flags) must stay distinct. This is
+    /// the ClaudeOverrideDefaults bug class documented in Project.swift, and
+    /// it fails the moment someone "simplifies" the override to `?? ""`.
+    @Test func sessionEmptyFlagsMeansNoFlagsNotInherit() {
+        let state = makeState()
+        state.settings.sandboxBackend = .off
+        state.settings.claudeFlags = "--global"
+        let project = Project(name: "p", repositoryPath: "/tmp", claudeFlags: "--verbose")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            claudeFlags: ""
+        )
+
+        #expect(state.claudeCommand(for: session) == "claude")
+    }
+
+    @Test func sessionFlagsRoundTripThroughSessionsJSON() throws {
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", claudeFlags: "--model fable"
+        )
+        let data = try JSONEncoder().encode(session)
+        let decoded = try JSONDecoder().decode(SessionInfo.self, from: data)
+        #expect(decoded.claudeFlags == "--model fable")
+    }
+
+    /// Sessions saved before the field existed must decode to nil (inherit),
+    /// not "" (no flags) -- assert it rather than assuming the synthesized
+    /// Codable does the right thing.
+    @Test func sessionsJSONWithoutClaudeFlagsDecodesToNil() throws {
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "old",
+            "workingDirectory": "/tmp",
+            "createdAt": 0
+        }
+        """
+        let session = try JSONDecoder().decode(SessionInfo.self, from: json.data(using: .utf8)!)
+        #expect(session.claudeFlags == nil)
+    }
+
+    /// The picker and the resolution chain are useless if the sheet's value
+    /// never reaches the stored session -- that is the silent-drop the
+    /// sandbox override already had (see openWorktreeSessionStoresOverride).
+    @Test func openWorktreeSessionStoresClaudeFlags() {
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        state.openWorktreeSession(
+            project: project, worktreePath: "/tmp/wt", branch: "b",
+            claudeFlags: "--model fable"
+        )
+
+        #expect(state.sessions.first?.claudeFlags == "--model fable")
+    }
+
+    /// Per-session flags are new untrusted input reaching the
+    /// security-load-bearing escape at Settings.swift:97.
+    @Test func sessionFlagsWithSingleQuoteAreEscapedInContainerWrapper() {
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            claudeFlags: "--model 'o'pus",
+            sandboxBackend: .appleContainer
+        )
+
+        let command = state.claudeCommand(for: session)
+        #expect(command.contains(#"'\''"#))
+        // The wrapper's own closing quote is still the last one.
+        #expect(command.hasSuffix(#""$@"' claude"#))
+    }
+
+    /// --resume is appended AFTER claudeCommand builds the string, so it lands
+    /// outside the wrapper and reaches claude through "$@". Per-session flags
+    /// must not disturb that composition.
+    @Test func sessionFlagsCompoundWithResumeForContainer() throws {
+        let state = makeState()
+        let project = Project(name: "p", repositoryPath: "/tmp")
+        state.projects = [project]
+        let session = SessionInfo(
+            name: "s", workingDirectory: "/tmp", projectId: project.id,
+            claudeFlags: "--model fable",
+            sandboxBackend: .appleContainer
+        )
+
+        let uuid = UUID().uuidString
+        let command = state.claudeCommand(for: session) + " --resume \(uuid)"
+        let wrapperEnd = try #require(command.range(of: "' claude"))
+        let resume = try #require(command.range(of: "--resume"))
+        #expect(resume.lowerBound > wrapperEnd.lowerBound)
+        #expect(command.contains(#"exec claude --model fable "$@""#))
+    }
+
     // MARK: - Main-repo tool access (--add-dir)
 
     /// Mounting the main repo fixes the *filesystem*; Claude Code's own tool


### PR DESCRIPTION
**Replaces #67**, which GitHub auto-closed when its base branch (`milestone-1.2.0-phase0`) was deleted on merging #65. Same branch, same commits, now correctly based on `master`. The Copilot review and all replies are on #67 — all three threads were addressed there (two fixed, one rejected with evidence that `git worktree add` does create intermediate directories).

Three independent items from milestone 1.2.0.

## #55 — per-session `claude` flags

`sandboxBackend` already resolved session → project → global. `claudeFlags` stopped at project → global, which is the wrong asymmetry for an app whose premise is N agents on N worktrees: *"opus on the hard branch, fable on the chore branch"* required editing a **project-wide** setting that hit every sibling session.

Free text rather than structured pickers, deliberately — the CLI already has `/model`, `/effort` and `/permissions` in-session, and every enum the CLI owns is a maintenance subscription (`--permission-mode` gained `dontAsk` and renamed `default`→`manual` in 2.1.200).

`nil` (inherit) and `""` (explicitly no flags) stay distinct, with a test pinning it — the `ClaudeOverrideDefaults` bug class, which fails the moment someone simplifies the chain to `?? ""`.

## #56 — model and reasoning effort per turn

Surveyed 60 real transcripts before writing the parser: **4,170** assistant entries carry a *top-level* `effort`, **zero** carry `message.effort`. `model` lives inside `message`. Reading it from the wrong nesting level is the one easy mistake, so a test asserts the level, not just the value.

`effort` is legitimately absent both on CLIs older than ~2.1.212 and for models with no effort concept (observed: sonnet-4-5, haiku-4-5, opus-4-8), so attribution is per-message and half-populated is valid. `<synthetic>` entries render no badge.

## #57 — Claude-created worktrees under `.claude/worktrees/`

Filed as **verify, don't build** — and the hypothesis held: all four tests passed against unmodified code. The deliverable is the tests, pinning that a nested worktree is listed, is not mistaken for the main checkout by `samePath`, participates in collision reports, and hits base-branch *detection* before delete.

## Verification

- 626 tests across 49 suites; CI green on the previous incarnation of this branch (#67).