### PR TITLE
Derive the model family from the ID instead of a hardcoded list

### DIFF
--- a/Canopy/Services/ActivityDataService.swift
+++ b/Canopy/Services/ActivityDataService.swift
@@ -252,13 +252,33 @@ enum ActivityDataService {
 
     // MARK: - Helpers
 
+    /// Family name for a model ID, so version bumps merge into one row --
+    /// claude-sonnet-4-5 and claude-sonnet-4-6 both report as "Sonnet".
+    ///
+    /// Derived from the ID's shape rather than a hardcoded list of families.
+    /// A list cannot keep up: Fable shipped after this function was written
+    /// and fell through to a catch-all "Claude" branch, so 1.2M tokens were
+    /// filed under a label that named no model -- and every *future* family
+    /// would have joined it in that same bucket, merging distinct models into
+    /// one row. That is the exact failure this function exists to prevent.
+    ///
+    /// Handles both of Anthropic's naming eras, since old transcripts persist:
+    ///   claude-opus-4-7             -> Opus
+    ///   claude-fable-5              -> Fable
+    ///   claude-sonnet-4-5-20250929  -> Sonnet
+    ///   claude-3-5-sonnet-20241022  -> Sonnet   (family follows the version)
     static func modelFamily(_ modelId: String) -> String {
-        let lower = modelId.lowercased()
-        if lower.contains("opus") { return "Opus" }
-        if lower.contains("sonnet") { return "Sonnet" }
-        if lower.contains("haiku") { return "Haiku" }
-        if lower.contains("claude") { return "Claude" }
-        return modelId
+        let components = modelId.lowercased()
+            .split(separator: "-")
+            .map(String.init)
+            .filter { $0 != "claude" }
+
+        // The first component carrying a letter is the family; everything
+        // before it is version or date digits, in either naming era.
+        guard let family = components.first(where: { $0.contains(where: \.isLetter) })
+        else { return modelId }
+
+        return family.prefix(1).uppercased() + family.dropFirst()
     }
 
     // MARK: - File Discovery

--- a/Canopy/Services/ActivityDataService.swift
+++ b/Canopy/Services/ActivityDataService.swift
@@ -268,6 +268,13 @@ enum ActivityDataService {
     ///   claude-sonnet-4-5-20250929  -> Sonnet
     ///   claude-3-5-sonnet-20241022  -> Sonnet   (family follows the version)
     static func modelFamily(_ modelId: String) -> String {
+        // Sentinels, not model IDs: parseJsonlData substitutes "unknown" when
+        // an entry has no model, and Claude Code writes "<synthetic>" for its
+        // own error rows. Title-casing those would rename an existing bucket,
+        // and this change is meant to move Fable and nothing else.
+        guard !modelId.isEmpty, modelId != "unknown", modelId != "<synthetic>"
+        else { return modelId }
+
         let components = modelId.lowercased()
             .split(separator: "-")
             .map(String.init)

--- a/Tests/ActivityDataTests.swift
+++ b/Tests/ActivityDataTests.swift
@@ -664,11 +664,15 @@ struct ActivityCacheTests {
         #expect(ActivityDataService.modelFamily("claude-newthing-9") == "Newthing")
     }
 
-    /// Degenerate inputs must not crash or produce an empty label.
-    @Test(arguments: ["", "claude", "unknown", "<synthetic>"])
-    func handlesDegenerateModelIds(_ modelId: String) {
-        let family = ActivityDataService.modelFamily(modelId)
-        #expect(family == modelId || !family.isEmpty)
+    /// The sentinels our own code produces are not model IDs and must pass
+    /// through untouched: parseJsonlData substitutes "unknown" when an entry
+    /// has no model, and Claude Code writes "<synthetic>". Title-casing those
+    /// would rename an existing bucket, and this change is meant to move
+    /// Fable and nothing else. Exact equality on purpose -- an `||` here would
+    /// let the empty case pass vacuously.
+    @Test(arguments: ["", "unknown", "<synthetic>"])
+    func sentinelsPassThroughUnchanged(_ modelId: String) {
+        #expect(ActivityDataService.modelFamily(modelId) == modelId)
     }
 
 }

--- a/Tests/ActivityDataTests.swift
+++ b/Tests/ActivityDataTests.swift
@@ -611,4 +611,64 @@ struct ActivityCacheTests {
         let daysAgo = Calendar.current.dateComponents([.day], from: parsed, to: Date()).day!
         #expect(daysAgo >= 82 && daysAgo <= 86) // 12 weeks = 84 days, ±2 for edge
     }
+
+    // MARK: - Model family derivation
+
+    /// The regression this replaced a hardcoded list for. Fable shipped after
+    /// modelFamily was written and fell through to a catch-all "Claude"
+    /// branch, filing real usage under a label that names no model.
+    @Test func fableReportsItsOwnFamily() {
+        #expect(ActivityDataService.modelFamily("claude-fable-5") == "Fable")
+    }
+
+    /// Every model ID observed in real transcripts.
+    @Test(arguments: [
+        ("claude-opus-5", "Opus"),
+        ("claude-opus-4-8", "Opus"),
+        ("claude-opus-4-7", "Opus"),
+        ("claude-fable-5", "Fable"),
+        ("claude-sonnet-4-5-20250929", "Sonnet"),
+        ("claude-haiku-4-5-20251001", "Haiku"),
+    ])
+    func derivesFamilyFromRealModelIds(_ modelId: String, _ expected: String) {
+        #expect(ActivityDataService.modelFamily(modelId) == expected)
+    }
+
+    /// Anthropic's older IDs put the version BEFORE the family. Old
+    /// transcripts persist, so both eras must resolve identically.
+    @Test(arguments: [
+        ("claude-3-5-sonnet-20241022", "Sonnet"),
+        ("claude-3-opus-20240229", "Opus"),
+        ("claude-3-haiku-20240307", "Haiku"),
+    ])
+    func derivesFamilyFromLegacyModelIds(_ modelId: String, _ expected: String) {
+        #expect(ActivityDataService.modelFamily(modelId) == expected)
+    }
+
+    /// The whole point of the function: versions of one family merge into a
+    /// single row rather than fragmenting the breakdown.
+    @Test func versionsOfOneFamilyMerge() {
+        let opus = ["claude-opus-4-7", "claude-opus-4-8", "claude-opus-5"]
+            .map(ActivityDataService.modelFamily)
+        #expect(Set(opus).count == 1)
+    }
+
+    /// And the inverse, which the old catch-all got wrong: two DIFFERENT
+    /// families must never share a bucket, including families that do not
+    /// exist yet. This is what silently merged Fable with everything unknown.
+    @Test func differentFamiliesNeverShareABucket() {
+        let families = ["claude-opus-5", "claude-fable-5", "claude-sonnet-4-5",
+                        "claude-haiku-4-5", "claude-newthing-9"]
+            .map(ActivityDataService.modelFamily)
+        #expect(Set(families).count == 5)
+        #expect(ActivityDataService.modelFamily("claude-newthing-9") == "Newthing")
+    }
+
+    /// Degenerate inputs must not crash or produce an empty label.
+    @Test(arguments: ["", "claude", "unknown", "<synthetic>"])
+    func handlesDegenerateModelIds(_ modelId: String) {
+        let family = ActivityDataService.modelFamily(modelId)
+        #expect(family == modelId || !family.isEmpty)
+    }
+
 }


### PR DESCRIPTION
**Does Fable show up in the Activity view?** It does — as **"Claude"**.

## What's wrong

`modelFamily` exists to merge version bumps into one row (its own comment: *"so that e.g. claude-sonnet-4-5 and claude-sonnet-4-6 are merged"*). It did that with a list of known families plus a catch-all:

```swift
if lower.contains("opus")   { return "Opus" }
if lower.contains("sonnet") { return "Sonnet" }
if lower.contains("haiku")  { return "Haiku" }
if lower.contains("claude") { return "Claude" }   // ← everything else
```

Fable shipped after this was written, matches none of the first three, and lands in the catch-all. Simulated against real transcripts on this machine:

```
Opus       12,030,567   from: claude-opus-4-7, claude-opus-4-8, claude-opus-5
Claude      1,234,856   from: claude-fable-5          ← 2nd heaviest, mislabelled
Sonnet        616,421   from: claude-sonnet-4-5-20250929
Haiku         116,917   from: claude-haiku-4-5-20251001
```

**The catch-all is the actual defect, not the missing entry.** It's a *shared* bucket — every future family joins Fable there, merging distinct models into one row, which is exactly the outcome the function was written to prevent. Adding `"fable"` to the list fixes today and re-breaks on the next model release.

## The fix

Read the family from the ID's shape: the first dash-separated component carrying a letter, after dropping `claude`. No list to maintain.

Handles both naming eras, which matters because old transcripts persist:

| ID | → |
|---|---|
| `claude-opus-4-7` | Opus |
| `claude-fable-5` | **Fable** |
| `claude-sonnet-4-5-20250929` | Sonnet |
| `claude-3-5-sonnet-20241022` | Sonnet *(version precedes family)* |

Existing rows are unchanged — Opus/Sonnet/Haiku map exactly as before, so historical breakdowns don't shift. Only Fable moves, out of "Claude" and into its own row.

## Tests

Every model ID observed in real transcripts, both naming eras, that versions of one family merge, that different families never share a bucket (including `claude-newthing-9`, which doesn't exist), and degenerate inputs (`""`, `claude`, `unknown`, `<synthetic>`).

Mutation-checked: restoring the old implementation fails **8** of them.

## Notes

Pre-existing — not introduced by 1.2.0. Found by asking whether Fable appeared in the Activity view.

- 729 tests across 53 suites (was 723).
- `scripts/bundle.sh` archive succeeds.