### PR TITLE
Follow a session id that /clear re-keys under a live process

### DIFF
--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -312,9 +312,52 @@ final class AppState: ObservableObject {
             // conversation and --resumes into it. An established id is user
             // data. The startedAt guard additionally rejects a claude that was
             // already running in the worktree before this tab opened.
-            if session.claudeSessionId == nil,
-               let startedAt = agent.startedAt,
-               Date(timeIntervalSince1970: startedAt / 1000) >= terminal.openedAt {
+            // Started after this tab opened, so it is this tab's claude and
+            // not one the user already had running in the worktree.
+            let isOurs = agent.startedAt.map {
+                Date(timeIntervalSince1970: $0 / 1000) >= terminal.openedAt
+            } ?? false
+
+            if session.claudeSessionId == nil, isOurs {
+                terminal.adoptedClaudeProcess = agent.processIdentity
+                assignClaudeSessionId(agent.sessionId, to: session.id)
+            } else if session.claudeSessionId == agent.sessionId, isOurs,
+                      terminal.adoptedClaudeProcess == nil {
+                // Nothing to adopt -- we already hold this id, because
+                // loadSessions restored it and the tab launched
+                // `claude --resume <id>`. Record whose process it is anyway,
+                // or the tab could never recognise a later re-key. This is the
+                // common path: most `/clear`s happen in a resumed session.
+                terminal.adoptedClaudeProcess = agent.processIdentity
+            } else if let owned = terminal.adoptedClaudeProcess,
+                      let reporting = agent.processIdentity,
+                      owned == reporting {
+                // The one case where replacing an established id is right:
+                // `/clear` does not restart claude, it re-keys the running
+                // process and starts a fresh transcript. Keeping the old id
+                // pins the transcript viewer, the token counts and the status
+                // bar to a file that will never change again, and makes the
+                // next launch `--resume` the conversation the user cleared.
+                //
+                // Narrow on purpose. This is still the same process we took
+                // ownership of, so it is not the hijack the never-overwrite
+                // rule exists to stop -- that is a *different* claude in the
+                // same directory, which fails on pid or start time.
+                assignClaudeSessionId(agent.sessionId, to: session.id)
+            } else if let owned = terminal.adoptedClaudeProcess,
+                      let reporting = agent.processIdentity,
+                      owned == reporting {
+                // The one case where replacing an established id is right:
+                // `/clear` does not restart claude, it re-keys the running
+                // process and starts a fresh transcript. Keeping the old id
+                // pins the transcript viewer, the token counts and the status
+                // bar to a file that will never change again, and makes the
+                // next launch `--resume` the conversation the user cleared.
+                //
+                // Narrow on purpose. This is still the same process we
+                // adopted from, so it is not the hijack the never-overwrite
+                // rule exists to stop -- that is a *different* claude in the
+                // same directory, which fails this check on pid or start time.
                 assignClaudeSessionId(agent.sessionId, to: session.id)
             }
 

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -344,21 +344,6 @@ final class AppState: ObservableObject {
                 // rule exists to stop -- that is a *different* claude in the
                 // same directory, which fails on pid or start time.
                 assignClaudeSessionId(agent.sessionId, to: session.id)
-            } else if let owned = terminal.adoptedClaudeProcess,
-                      let reporting = agent.processIdentity,
-                      owned == reporting {
-                // The one case where replacing an established id is right:
-                // `/clear` does not restart claude, it re-keys the running
-                // process and starts a fresh transcript. Keeping the old id
-                // pins the transcript viewer, the token counts and the status
-                // bar to a file that will never change again, and makes the
-                // next launch `--resume` the conversation the user cleared.
-                //
-                // Narrow on purpose. This is still the same process we
-                // adopted from, so it is not the hijack the never-overwrite
-                // rule exists to stop -- that is a *different* claude in the
-                // same directory, which fails this check on pid or start time.
-                assignClaudeSessionId(agent.sessionId, to: session.id)
             }
 
             // No opinion -> leave the PTY heuristic in charge. Reset the

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -2,11 +2,17 @@ import Foundation
 
 /// One live `claude` process, as reported by `claude agents --json`.
 ///
-/// Only the fields Canopy actually uses are decoded. The real payload also
-/// carries `pid`, `kind` and `name`; `pid` is useless to us (a container
-/// session's pid is a guest-namespace pid, meaningless on the host) and
-/// decoding fields we don't read only adds ways for a schema change to break
-/// the whole array.
+/// Only the fields Canopy actually uses are decoded -- the real payload also
+/// carries `kind` and `name` -- because decoding fields we don't read only
+/// adds ways for a schema change to break the whole array.
+///
+/// `pid` was long excluded on the grounds that a container session's pid is a
+/// guest-namespace pid and names nothing on the host. That is still true, and
+/// `reportsToHostAgentRegistry` already excludes those backends before any of
+/// this is consulted. For the backends that do reach here, the pid identifies
+/// a real local process, which is what lets a tab tell its own claude
+/// re-keying itself under `/clear` from a different claude appearing in the
+/// same directory.
 ///
 /// `status` and `startedAt` are optional because they really are absent in
 /// practice: sdk-cli entries carry no `status` key at all.

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -15,6 +15,28 @@ struct ClaudeAgent: Decodable, Equatable, Sendable {
     let sessionId: String
     let status: String?
     let startedAt: Double?
+    /// Host pid of the claude process. Absent on older CLIs, and meaningless
+    /// for container backends -- `reportsToHostAgentRegistry` already excludes
+    /// those, since a guest-namespace pid names nothing on this machine.
+    let pid: Int?
+
+    /// Identifies the *process*, so a session id that changes underneath one
+    /// can be told apart from a different claude appearing in the same
+    /// directory. Nil when the CLI reports too little to prove either.
+    ///
+    /// pids are recycled, so the start time is part of the identity: a
+    /// matching pid with a different start time is a new process wearing a
+    /// dead one's number.
+    var processIdentity: ClaudeProcessIdentity? {
+        guard let pid, let startedAt else { return nil }
+        return ClaudeProcessIdentity(pid: pid, startedAt: startedAt)
+    }
+}
+
+/// A specific claude process, as reported by the agent registry.
+struct ClaudeProcessIdentity: Equatable, Sendable {
+    let pid: Int
+    let startedAt: Double
 }
 
 /// Asks Claude Code which conversations are live, rather than inferring it.

--- a/Canopy/Services/TerminalSession.swift
+++ b/Canopy/Services/TerminalSession.swift
@@ -30,6 +30,12 @@ final class TerminalSession: ObservableObject {
     /// When this terminal session was opened in Canopy (for token counting).
     let openedAt = Date()
 
+    /// The claude process this tab's `claudeSessionId` was adopted from.
+    ///
+    /// Deliberately not persisted: it is only meaningful while that process is
+    /// alive, and this tab owns it for exactly as long as the tab lives.
+    var adoptedClaudeProcess: ClaudeProcessIdentity?
+
     /// See `CanopySettings.disableAltScreen`. Captured at creation: the env
     /// is built once when the shell starts, so later settings changes only
     /// affect new sessions.

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -40,11 +40,13 @@ struct AgentReconciliationTests {
 
     private func agent(
         cwd: String, sessionId: String = UUID().uuidString,
-        status: String?, startedAt: Date = Date().addingTimeInterval(60)
+        status: String?, startedAt: Date = Date().addingTimeInterval(60),
+        pid: Int? = nil
     ) -> ClaudeAgent {
         ClaudeAgent(
             cwd: cwd, sessionId: sessionId, status: status,
-            startedAt: startedAt.timeIntervalSince1970 * 1000
+            startedAt: startedAt.timeIntervalSince1970 * 1000,
+            pid: pid
         )
     }
 
@@ -365,6 +367,129 @@ struct AgentReconciliationTests {
         #expect(state.sessions[0].claudeSessionId == owned)
     }
 
+
+    // MARK: - Re-keyed sessions (/clear)
+
+    /// `/clear` does not restart claude -- it re-keys the running process and
+    /// starts a fresh transcript. Verified on a live session: `ps` shows one
+    /// process, started 21:44:42, launched as `--resume 0cd83df7...`, while
+    /// `claude agents --json` reports that same pid under a *different*
+    /// sessionId. Canopy kept the pre-clear id, so the status bar, the
+    /// transcript sheet and the token counts all read a file that would never
+    /// change again -- and the next launch would `--resume` the conversation
+    /// the user had just cleared.
+    @Test func adoptsAReKeyedIdFromTheSameProcess() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-clear")
+        let startedAt = Date().addingTimeInterval(60)
+        let before = UUID().uuidString
+        let afterClear = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-clear", sessionId: before,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+        #expect(state.sessions[0].claudeSessionId == before)
+
+        // Same process, new conversation.
+        state.applyAgents([agent(cwd: "/tmp/wt-clear", sessionId: afterClear,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    /// The hijack this relaxation must not reopen: the tab's claude exits, the
+    /// user runs a plain `claude` in the same worktree, and Canopy adopts a
+    /// stranger's conversation. A different process is not ours, whatever id
+    /// it reports.
+    @Test func doesNotAdoptAReKeyedIdFromADifferentProcess() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-hijack")
+        let startedAt = Date().addingTimeInterval(60)
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-hijack", sessionId: owned,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-hijack", sessionId: "stranger",
+                                 status: "idle", startedAt: startedAt, pid: 9999)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// pids are recycled. A matching pid with a different start time is a
+    /// different process wearing a dead one's number, so the pid alone cannot
+    /// carry the ownership proof.
+    @Test func doesNotAdoptWhenThePidWasRecycled() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-recycled")
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-recycled", sessionId: owned, status: "idle",
+                                 startedAt: Date().addingTimeInterval(60), pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-recycled", sessionId: "stranger", status: "idle",
+                                 startedAt: Date().addingTimeInterval(600), pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// A CLI that reports no pid gives no ownership proof, so the established
+    /// id stands. Losing the /clear fix on an older CLI is the safe failure;
+    /// adopting on cwd alone is not.
+    @Test func doesNotAdoptAReKeyedIdWhenTheCliReportsNoPid() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-nopid")
+        let startedAt = Date().addingTimeInterval(60)
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-nopid", sessionId: owned,
+                                 status: "idle", startedAt: startedAt)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-nopid", sessionId: "stranger",
+                                 status: "idle", startedAt: startedAt)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// The case that actually happens. Canopy relaunches, `loadSessions`
+    /// restores an established id, and the tab starts `claude --resume <id>`.
+    /// Nothing is ever adopted, so without recording ownership here the tab
+    /// would have no idea which process is its own -- and a `/clear` after a
+    /// restart, which is most of them, would go unnoticed.
+    @Test func followsAReKeyAfterARestoredSessionResumes() {
+        let state = makeState()
+        let restored = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-resumed", claudeSessionId: restored)
+        let startedAt = Date().addingTimeInterval(60)
+
+        // The resumed process reports the id we already hold: ours.
+        state.applyAgents([agent(cwd: "/tmp/wt-resumed", sessionId: restored,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+        #expect(state.sessions[0].claudeSessionId == restored)
+
+        // It then re-keys under /clear.
+        let afterClear = UUID().uuidString
+        state.applyAgents([agent(cwd: "/tmp/wt-resumed", sessionId: afterClear,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    /// Ownership is only recorded for a process that started after this tab
+    /// did. A claude already running in the worktree when the tab opened is
+    /// not ours to follow, even if it happens to report the id we hold.
+    @Test func doesNotTakeOwnershipOfAProcessOlderThanTheTab() {
+        let state = makeState()
+        let restored = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-older", claudeSessionId: restored)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-older", sessionId: restored, status: "idle",
+                                 startedAt: Date().addingTimeInterval(-600), pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-older", sessionId: "stranger", status: "idle",
+                                 startedAt: Date().addingTimeInterval(-600), pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == restored)
+    }
 
     // MARK: - Poll gating
 

--- a/Tests/ClaudeAgentsServiceTests.swift
+++ b/Tests/ClaudeAgentsServiceTests.swift
@@ -17,6 +17,40 @@ struct ClaudeAgentsServiceTests {
 
     // MARK: - Parsing
 
+    /// The /clear fix hangs entirely on this field being read: a re-keyed
+    /// session is only adopted when the reporting process is provably the one
+    /// Canopy adopted from, and `pid` is half that proof. If the key were
+    /// spelled wrong or the field dropped, every ownership check would fail
+    /// closed and the fix would silently do nothing.
+    ///
+    /// Literal JSON from real `claude agents --json` output, including the
+    /// interactive entry's neighbouring `background` entry, which carries no
+    /// `pid` at all.
+    @Test func decodesPidAndBuildsAProcessIdentity() throws {
+        let json = """
+        [
+          {"id":"63401c10","cwd":"/Users/j/demo","kind":"background",
+           "startedAt":1787303896140,"sessionId":"63401c10-479f-44f5-8f5b-16deccd5886a",
+           "name":"Fork demo","state":"blocked"},
+          {"pid":18001,"cwd":"/Users/j/site","kind":"interactive",
+           "startedAt":1787427887639,"sessionId":"52109c55-b4b2-4186-9ee4-14d651577ffb",
+           "name":"master","status":"busy"}
+        ]
+        """
+        let agents = try #require(ClaudeAgentsService.parse(data(json)))
+        #expect(agents.count == 2)
+
+        let interactive = try #require(agents.first { $0.sessionId.hasPrefix("52109c55") })
+        #expect(interactive.pid == 18001)
+        let identity = try #require(interactive.processIdentity)
+        #expect(identity == ClaudeProcessIdentity(pid: 18001, startedAt: 1787427887639))
+
+        // A background entry reports no pid, so it can prove no ownership.
+        let background = try #require(agents.first { $0.sessionId.hasPrefix("63401c10") })
+        #expect(background.pid == nil)
+        #expect(background.processIdentity == nil)
+    }
+
     @Test func parsesRealWorldArray() throws {
         let agents = try #require(ClaudeAgentsService.parse(data("""
         [
@@ -84,7 +118,7 @@ struct ClaudeAgentsServiceTests {
 
     private func agent(cwd: String, sessionId: String = "s", status: String? = "idle",
                        startedAt: Double? = 0) -> ClaudeAgent {
-        ClaudeAgent(cwd: cwd, sessionId: sessionId, status: status, startedAt: startedAt)
+        ClaudeAgent(cwd: cwd, sessionId: sessionId, status: status, startedAt: startedAt, pid: nil)
     }
 
     @Test func matchesExactWorktreePath() {


### PR DESCRIPTION
Closes #83.

## Not a display bug

After `/clear` the status bar's context size never reset. `/clear` does not restart claude — it **re-keys the running process** and starts a fresh transcript, and Canopy kept pointing at the old one.

Caught live on this machine:

```
ps -p 18001   →  claude --permission-mode auto --resume 0cd83df7-...   (started 21:44:42)
agents --json →  pid 18001, cwd .../juliensimon.github.io, sessionId 52109c55-...
sessions.json →  master -> 0cd83df7-...
```

One process, two ids. The pre-clear transcript stopped at 21:55:05 while the new one kept growing. Across all 21 `<command-name>/clear</command-name>` markers in `~/.claude/projects`, **not one** has an assistant turn before it — the marker is always the first record of a brand-new file.

## Why the old rule blocked it, and how to relax it safely

`applyAgents` adopted an id only when nil — #51's hardening against adopting a stranger's `claude` run in the same worktree. That rule is right for a *different* process and wrong for our own, and the registry already carries enough to tell them apart:

- **`pid`** — in the payload, but `ClaudeAgent` never decoded it.
- **`startedAt`** — verified to be the *process* start: the agent reports `21:44:47` against a `21:44:42` exec, so it survives a re-key.

A tab now records which process it took its id from, and follows that process when it re-keys. A different claude fails on pid or start time, so the hijack guard is intact.

## The gap a test caught

Ownership is also recorded when a resumed session reports the id we already hold. Without that the fix would have **missed the common case entirely**: after a relaunch `loadSessions` restores the id, nothing is ever adopted, so the tab never learns which process is its own — and most `/clear`s happen in a resumed session. `followsAReKeyAfterARestoredSessionResumes` failed before that branch existed.

## Beyond the status bar

Same stale id also pinned `TranscriptSheet` to the pre-clear conversation and froze `SessionInfoSheet`'s token counts — and made the next launch `--resume` the conversation the user had just cleared, visible verbatim in the `ps` line above.

## Testing

**769 tests green**, run 3×. Seven new tests; mutation-checked in both directions:

| Mutation | Result |
|---|---|
| Delete the follow branch | `adoptsAReKeyedIdFromTheSameProcess` fails |
| Delete the resumed-ownership branch | `followsAReKeyAfterARestoredSessionResumes` fails |
| Drop the `owned == reporting` comparison | both hijack tests fail with the id replaced by `"stranger"` |

`decodesPidAndBuildsAProcessIdentity` pins the field itself, using literal JSON from real `claude agents --json` output. Without it every ownership check would fail closed and the whole fix would silently do nothing — the failure mode worth a test of its own.

Guards kept: a process older than the tab is never adopted from, a recycled pid with a different start time is rejected, and a CLI reporting no `pid` proves nothing so the established id stands.

## Verification limits

Unit tests plus a real captured payload. I did **not** drive the live reproduction to green, because the only way to do that is restart the affected session, which kills the user's running claude.

## Known limitation

This prevents divergence going forward; it cannot repair an id that has already gone stale. Recovering that means guessing at the newest transcript in the directory — the heuristic `TranscriptSheet.computeJSONLPath` documents and rejects, since it silently adopts a `claude` the user ran outside Canopy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199QvpHaWazYpEFKCEni9g9