### PR TITLE
Show the model, effort, and live context size of the active session

### DIFF
--- a/Canopy.xcodeproj/project.pbxproj
+++ b/Canopy.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		B5EBB6002FC4E7AE9B88B3B2 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */; };
 		B62F0F2D8BE2D11A6C3AD942 /* AgentReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBA8013125A94627C67870D /* AgentReconciliationTests.swift */; };
 		B7E313D2316AD76F2C7CF7F9 /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC34A1B34310D4ECCF8BA6E /* StatusBar.swift */; };
+		B8ECA754A053808C134179B1 /* SessionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A65A3346496DD2A6BFD3B4 /* SessionContextTests.swift */; };
 		BADE4D87BE6EAAE9DFC0CF9F /* WorktreeCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1731FEC2A46A90F44E14EB1 /* WorktreeCollisionTests.swift */; };
 		C03B5B8ACB810576799B8653 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4608E6506BCC0DD38B91D /* AppStateTests.swift */; };
 		C1ADFB5A6E22400C85855B41 /* ClaudeAgentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9311D7F235BE554139C28AD /* ClaudeAgentsServiceTests.swift */; };
@@ -123,6 +124,7 @@
 /* Begin PBXFileReference section */
 		028C5B5137B3ECE6C957B6EC /* AddProjectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProjectSheet.swift; sourceTree = "<group>"; };
 		051E40D7278741B7C4B2DACC /* GitServiceBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBranchTests.swift; sourceTree = "<group>"; };
+		06A65A3346496DD2A6BFD3B4 /* SessionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextTests.swift; sourceTree = "<group>"; };
 		09AE664951393052235EDCBA /* AppStateIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateIsolation.swift; sourceTree = "<group>"; };
 		0E948527D5D146F27269411E /* SessionSandboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSandboxTests.swift; sourceTree = "<group>"; };
 		0ECA322FF097B59B49F68737 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 				DB01F64B012648D641FF741D /* ProjectTests.swift */,
 				71B9ED338BECE4C5A45CEF2F /* PromptLibraryTests.swift */,
 				850B26424BF5B827D9AC5AB2 /* SandboxCheckerTests.swift */,
+				06A65A3346496DD2A6BFD3B4 /* SessionContextTests.swift */,
 				4102FA193C043697E08EFD91 /* SessionCostFilteringTests.swift */,
 				4B876C5FDA76283957B8E9C5 /* SessionCostServiceTests.swift */,
 				774CEE75403401F0A7DE18E9 /* SessionNameTests.swift */,
@@ -600,6 +603,7 @@
 				2C1B79B946E6AD50EB0EC424 /* ProjectTests.swift in Sources */,
 				5095CCFA8207BB832FE7702F /* PromptLibraryTests.swift in Sources */,
 				257BE9FBDC281CB300ADD349 /* SandboxCheckerTests.swift in Sources */,
+				B8ECA754A053808C134179B1 /* SessionContextTests.swift in Sources */,
 				DF5DB9329C647A612F38E808 /* SessionCostFilteringTests.swift in Sources */,
 				7403E7DA09BC3CAD7004D877 /* SessionCostServiceTests.swift in Sources */,
 				A2E3315C93FEA826BF12CBCF /* SessionNameTests.swift in Sources */,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -73,6 +73,11 @@ final class AppState: ObservableObject {
     /// Git status for the currently active session.
     @Published var activeGitStatus: GitStatusInfo?
 
+    /// Model, reasoning effort, and context size of the active session's most
+    /// recent Claude turn. Nil when that session has never run Claude, or has
+    /// not written a transcript yet.
+    @Published var activeSessionContext: SessionContext?
+
     /// Git diff stats per session, keyed by session ID. Used by sidebar rows.
     @Published var sessionDiffStats: [UUID: GitDiffStat] = [:]
 
@@ -279,7 +284,8 @@ final class AppState: ObservableObject {
     /// their status cannot be trusted. `.dockerSbx` shares nothing at all.
     func applyAgents(_ agents: [ClaudeAgent]) {
         for session in sessions {
-            guard sandboxBackend(for: session).reportsToHostAgentRegistry,
+            let backend = sandboxBackend(for: session)
+            guard backend.reportsHostRegistryIdentity,
                   let terminal = terminalSessions[session.id] else { continue }
 
             // Ambiguous means two claudes under one directory (a split
@@ -287,7 +293,8 @@ final class AppState: ObservableObject {
             // which is this tab's, and guessing binds it to the wrong
             // transcript -- so keep the existing behaviour.
             guard case .one(let agent) = ClaudeAgentsService.agent(
-                forWorktree: session.workingDirectory, in: agents
+                forWorktree: session.workingDirectory, in: agents,
+                preferring: terminal.adoptedClaudeProcess
             ) else {
                 agentIdleObservations[session.id] = 0
                 // No live agent speaks for this tab. .needsInput is sticky
@@ -307,9 +314,42 @@ final class AppState: ObservableObject {
             // conversation and --resumes into it. An established id is user
             // data. The startedAt guard additionally rejects a claude that was
             // already running in the worktree before this tab opened.
-            if session.claudeSessionId == nil,
-               let startedAt = agent.startedAt,
-               Date(timeIntervalSince1970: startedAt / 1000) >= terminal.openedAt {
+            // Started after this tab opened, so it is this tab's claude and
+            // not one the user already had running in the worktree.
+            let isOurs = agent.startedAt.map {
+                Date(timeIntervalSince1970: $0 / 1000) >= terminal.openedAt
+            } ?? false
+
+            // Adopting an *unknown* id stays host-only. A container session is
+            // always launched with `--session-id`, so it has nothing to adopt,
+            // and taking an id from an entry whose process we cannot verify is
+            // the hijack the never-overwrite rule exists to stop.
+            if session.claudeSessionId == nil, isOurs,
+               backend.reportsToHostAgentRegistry {
+                terminal.adoptedClaudeProcess = agent.processIdentity
+                assignClaudeSessionId(agent.sessionId, to: session.id)
+            } else if session.claudeSessionId == agent.sessionId, isOurs,
+                      terminal.adoptedClaudeProcess == nil {
+                // Nothing to adopt -- we already hold this id, because
+                // loadSessions restored it and the tab launched
+                // `claude --resume <id>`. Record whose process it is anyway,
+                // or the tab could never recognise a later re-key. This is the
+                // common path: most `/clear`s happen in a resumed session.
+                terminal.adoptedClaudeProcess = agent.processIdentity
+            } else if let owned = terminal.adoptedClaudeProcess,
+                      let reporting = agent.processIdentity,
+                      owned == reporting {
+                // The one case where replacing an established id is right:
+                // `/clear` does not restart claude, it re-keys the running
+                // process and starts a fresh transcript. Keeping the old id
+                // pins the transcript viewer, the token counts and the status
+                // bar to a file that will never change again, and makes the
+                // next launch `--resume` the conversation the user cleared.
+                //
+                // Narrow on purpose. This is still the same process we took
+                // ownership of, so it is not the hijack the never-overwrite
+                // rule exists to stop -- that is a *different* claude in the
+                // same directory, which fails on pid or start time.
                 assignClaudeSessionId(agent.sessionId, to: session.id)
             }
 
@@ -318,6 +358,11 @@ final class AppState: ObservableObject {
             // Keeping a stale count across an opinion-less poll lets an idle
             // from before the gap pair with one after it and confirm a finish
             // that never happened.
+            // Everything above is identity. Status is a different claim, and a
+            // container cannot make it: its peer socket is unreachable, so a
+            // reported busy/idle would make the activity dots lie.
+            guard backend.reportsToHostAgentRegistry else { continue }
+
             guard let reported = ClaudeAgentsService.activity(for: agent.status) else {
                 agentIdleObservations[session.id] = 0
                 continue
@@ -357,7 +402,7 @@ final class AppState: ObservableObject {
     /// sandboxed -- the poll's subprocess would be pure waste on a 2-second
     /// loop, so the cycle skips it entirely.
     var hasReconcilableSessions: Bool {
-        sessions.contains { sandboxBackend(for: $0).reportsToHostAgentRegistry }
+        sessions.contains { sandboxBackend(for: $0).reportsHostRegistryIdentity }
     }
 
     /// Polls Claude Code for live session state. Separate from the 10 s git
@@ -467,11 +512,52 @@ final class AppState: ObservableObject {
     /// wrong as a stale write and previously had no coverage.
     ///
     /// Split out from the read so the guard can be tested without racing the
-    /// scheduler: driving it through `refreshGitStatus` means landing a tab
-    /// switch inside a subprocess call, which is a margin, not a guarantee.
+    /// scheduler. See `applySessionContext(_:readFor:)` for why that matters.
     func applyGitStatus(_ status: GitStatusInfo?, readFor sessionId: UUID) {
         guard activeSessionId == sessionId else { return }
         activeGitStatus = status
+    }
+
+    /// Reads the active session's newest Claude turn for the status bar.
+    ///
+    /// Keyed strictly on `claudeSessionId`, never on "newest transcript in this
+    /// directory" -- that fallback would report a `claude` run the user started
+    /// outside Canopy in the same cwd, which is the trap TranscriptSheet
+    /// documents.
+    func refreshActiveSessionContext() async {
+        guard let session = activeSession,
+              let claudeSessionId = session.claudeSessionId else {
+            activeSessionContext = nil
+            return
+        }
+        let sessionId = session.id
+        let path = ClaudeTranscriptLoader.sessionFilePath(
+            workingDirectory: session.workingDirectory,
+            sessionId: claudeSessionId
+        )
+
+        // Off the main actor: this runs on a timer and touches the filesystem,
+        // and the terminal shares this actor.
+        let context = await Task.detached {
+            SessionCostService.lastTurnContext(path: path)
+        }.value
+
+        applySessionContext(context, readFor: sessionId)
+    }
+
+    /// Publishes a context that was read for `sessionId`, unless the user has
+    /// switched sessions in the meantime -- issue #28 was this exact race in
+    /// the git maps, one session's numbers landing under another's name.
+    ///
+    /// Split out from the read so the guard can be tested without racing the
+    /// scheduler. Driving it through `refreshActiveSessionContext` means
+    /// arranging for a tab switch to land inside a file read, which is a
+    /// contest between a microsecond of I/O and a single assignment; the test
+    /// for it passed locally, failed under CI load, and was then broken
+    /// outright by making the read faster. A named seam is deterministic.
+    func applySessionContext(_ context: SessionContext?, readFor sessionId: UUID) {
+        guard activeSessionId == sessionId else { return }
+        activeSessionContext = context
     }
 
     /// Refreshes diff stats and commits-ahead for all sessions (sidebar indicators).
@@ -547,6 +633,7 @@ final class AppState: ObservableObject {
             while !Task.isCancelled {
                 guard let self else { return }
                 await self.refreshGitStatus()
+                await self.refreshActiveSessionContext()
                 await self.refreshAllSessionDiffStats()
                 await self.refreshAllSessionPRCounts()
                 try? await Task.sleep(for: .seconds(10))
@@ -869,6 +956,18 @@ final class AppState: ObservableObject {
               sessions[index].claudeSessionId != claudeSessionId else { return }
         sessions[index].claudeSessionId = claudeSessionId
         saveSessions()
+
+        // The status bar reads the transcript this id names, and the id is
+        // followed on the 2 s agent poll while the segment refreshes on the
+        // 10 s one. Without this the bar would keep showing the *previous*
+        // conversation's numbers for up to ten more seconds after a `/clear` --
+        // the exact stale reading the segment exists to avoid. Dropping it
+        // synchronously makes the worst case a briefly absent segment rather
+        // than a confidently wrong one.
+        if sessionId == activeSessionId {
+            activeSessionContext = nil
+            Task { await refreshActiveSessionContext() }
+        }
     }
 
     /// The `claude` flags a session runs with: session → project → global,

--- a/Canopy/App/AppState.swift
+++ b/Canopy/App/AppState.swift
@@ -277,11 +277,19 @@ final class AppState: ObservableObject {
     /// declared such sessions finished mid-turn and then decayed them to a
     /// grey dot indistinguishable from an empty prompt.
     ///
-    /// Gated on backends that run Claude as a host process (`.off` and
-    /// `.claudeNative` -- see `reportsToHostAgentRegistry`). Container sessions
-    /// write their registry entry into the bind-mounted host ~/.claude, but
-    /// `pid` is a guest namespace pid and the peer socket is unreachable, so
-    /// their status cannot be trusted. `.dockerSbx` shares nothing at all.
+    /// Two gates, not one, because the registry makes two different claims.
+    ///
+    /// *Identity* -- which conversation a tab is running -- is read for every
+    /// backend whose entry lands on the host (`reportsHostRegistryIdentity`:
+    /// `.off`, `.claudeNative`, `.appleContainer`). A container bind-mounts
+    /// ~/.claude, which is the same reason its transcript is readable at all.
+    ///
+    /// *Status* -- whether it is busy, idle or blocked -- is read only for
+    /// backends that run Claude as a host process (`reportsToHostAgentRegistry`:
+    /// `.off`, `.claudeNative`). A container's peer socket is unreachable from
+    /// the host, so believing its status would make the activity dots lie.
+    ///
+    /// `.dockerSbx` shares nothing of ~/.claude and is excluded from both.
     func applyAgents(_ agents: [ClaudeAgent]) {
         for session in sessions {
             let backend = sandboxBackend(for: session)
@@ -361,7 +369,16 @@ final class AppState: ObservableObject {
             // Everything above is identity. Status is a different claim, and a
             // container cannot make it: its peer socket is unreachable, so a
             // reported busy/idle would make the activity dots lie.
-            guard backend.reportsToHostAgentRegistry else { continue }
+            //
+            // Reset the idle counter on the way out, as every other early
+            // return here does. A session's backend can change under it -- the
+            // project or global setting is editable while a tab is open -- and
+            // a count left over from when it was a host backend would count
+            // towards a confirmed finish the moment host status resumed.
+            guard backend.reportsToHostAgentRegistry else {
+                agentIdleObservations[session.id] = 0
+                continue
+            }
 
             guard let reported = ClaudeAgentsService.activity(for: agent.status) else {
                 agentIdleObservations[session.id] = 0
@@ -542,7 +559,7 @@ final class AppState: ObservableObject {
             SessionCostService.lastTurnContext(path: path)
         }.value
 
-        applySessionContext(context, readFor: sessionId)
+        applySessionContext(context, readFor: sessionId, transcript: claudeSessionId)
     }
 
     /// Publishes a context that was read for `sessionId`, unless the user has
@@ -555,8 +572,21 @@ final class AppState: ObservableObject {
     /// contest between a microsecond of I/O and a single assignment; the test
     /// for it passed locally, failed under CI load, and was then broken
     /// outright by making the read faster. A named seam is deterministic.
-    func applySessionContext(_ context: SessionContext?, readFor sessionId: UUID) {
-        guard activeSessionId == sessionId else { return }
+    func applySessionContext(
+        _ context: SessionContext?,
+        readFor sessionId: UUID,
+        transcript claudeSessionId: String
+    ) {
+        // Two things can change underneath a read, and the guard has to cover
+        // both. A tab switch is the obvious one. The other is the transcript
+        // itself: `/clear` re-keys the conversation while the tab's UUID stays
+        // exactly the same, so a read still in flight against the pre-clear
+        // file would sail through an activeSessionId check and republish the
+        // dead conversation's numbers over the reset.
+        guard activeSessionId == sessionId,
+              sessions.first(where: { $0.id == sessionId })?.claudeSessionId == claudeSessionId
+        else { return }
+
         activeSessionContext = context
     }
 

--- a/Canopy/Models/Settings.swift
+++ b/Canopy/Models/Settings.swift
@@ -62,6 +62,27 @@ enum SandboxBackend: String, Codable {
     /// nothing of ~/.claude at all.
     var reportsToHostAgentRegistry: Bool { self == .off || self == .claudeNative }
 
+    /// Whether the registry entry this backend writes can be trusted to say
+    /// *which conversation* a session is running, as opposed to how busy it is.
+    ///
+    /// A wider set than `reportsToHostAgentRegistry`, because that gate covers
+    /// only half of what it was doing. `.appleContainer` bind-mounts
+    /// ~/.claude, so its entry and its transcript both land on the host --
+    /// which is precisely why Canopy can read its transcript at all. What
+    /// cannot be trusted there is status: the peer socket is unreachable.
+    ///
+    /// The guest-namespace pid is no obstacle to identity. Nothing here
+    /// resolves a pid to a host process; it only compares one against a pid
+    /// the same entry reported earlier, and a guest pid is stable for the
+    /// process that owns it. `startedAt` is namespace-independent, so the pair
+    /// works as an opaque equality token inside a container exactly as outside.
+    ///
+    /// `.dockerSbx` shares nothing of ~/.claude, so nothing about it can be
+    /// believed -- not status, and not identity either.
+    var reportsHostRegistryIdentity: Bool {
+        reportsToHostAgentRegistry || self == .appleContainer
+    }
+
     /// Whether `--resume` works for this backend. Session JSONLs must
     /// persist on the host: sbx microVMs are ephemeral, while the Apple
     /// container backend bind-mounts ~/.claude from the host.

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -7,12 +7,14 @@ import Foundation
 /// adds ways for a schema change to break the whole array.
 ///
 /// `pid` was long excluded on the grounds that a container session's pid is a
-/// guest-namespace pid and names nothing on the host. That is still true, and
-/// `reportsToHostAgentRegistry` already excludes those backends before any of
-/// this is consulted. For the backends that do reach here, the pid identifies
-/// a real local process, which is what lets a tab tell its own claude
-/// re-keying itself under `/clear` from a different claude appearing in the
-/// same directory.
+/// guest-namespace pid and names nothing on the host. That remains true, and
+/// remains irrelevant here: nothing in Canopy resolves this pid to a process.
+/// It is compared only against a pid the *same registry entry* reported
+/// earlier, and a guest pid is perfectly stable for the process that owns it.
+/// Paired with `startedAt`, which is namespace-independent, it works as an
+/// opaque equality token in a container exactly as it does on the host -- and
+/// that is what lets a tab tell its own claude re-keying itself under `/clear`
+/// from a different claude appearing in the same directory.
 ///
 /// `status` and `startedAt` are optional because they really are absent in
 /// practice: sdk-cli entries carry no `status` key at all.
@@ -21,9 +23,12 @@ struct ClaudeAgent: Decodable, Equatable, Sendable {
     let sessionId: String
     let status: String?
     let startedAt: Double?
-    /// Host pid of the claude process. Absent on older CLIs, and meaningless
-    /// for container backends -- `reportsToHostAgentRegistry` already excludes
-    /// those, since a guest-namespace pid names nothing on this machine.
+    /// The pid as the registry reports it: a host pid for host backends, a
+    /// guest-namespace pid for a container. Absent on older CLIs.
+    ///
+    /// Deliberately not described as a host pid. It is never resolved to a
+    /// process -- only compared against an earlier reading from the same entry
+    /// -- so which namespace it belongs to does not matter.
     let pid: Int?
 
     /// Identifies the *process*, so a session id that changes underneath one

--- a/Canopy/Services/ClaudeAgentsService.swift
+++ b/Canopy/Services/ClaudeAgentsService.swift
@@ -2,11 +2,17 @@ import Foundation
 
 /// One live `claude` process, as reported by `claude agents --json`.
 ///
-/// Only the fields Canopy actually uses are decoded. The real payload also
-/// carries `pid`, `kind` and `name`; `pid` is useless to us (a container
-/// session's pid is a guest-namespace pid, meaningless on the host) and
-/// decoding fields we don't read only adds ways for a schema change to break
-/// the whole array.
+/// Only the fields Canopy actually uses are decoded -- the real payload also
+/// carries `kind` and `name` -- because decoding fields we don't read only
+/// adds ways for a schema change to break the whole array.
+///
+/// `pid` was long excluded on the grounds that a container session's pid is a
+/// guest-namespace pid and names nothing on the host. That is still true, and
+/// `reportsToHostAgentRegistry` already excludes those backends before any of
+/// this is consulted. For the backends that do reach here, the pid identifies
+/// a real local process, which is what lets a tab tell its own claude
+/// re-keying itself under `/clear` from a different claude appearing in the
+/// same directory.
 ///
 /// `status` and `startedAt` are optional because they really are absent in
 /// practice: sdk-cli entries carry no `status` key at all.
@@ -15,6 +21,28 @@ struct ClaudeAgent: Decodable, Equatable, Sendable {
     let sessionId: String
     let status: String?
     let startedAt: Double?
+    /// Host pid of the claude process. Absent on older CLIs, and meaningless
+    /// for container backends -- `reportsToHostAgentRegistry` already excludes
+    /// those, since a guest-namespace pid names nothing on this machine.
+    let pid: Int?
+
+    /// Identifies the *process*, so a session id that changes underneath one
+    /// can be told apart from a different claude appearing in the same
+    /// directory. Nil when the CLI reports too little to prove either.
+    ///
+    /// pids are recycled, so the start time is part of the identity: a
+    /// matching pid with a different start time is a new process wearing a
+    /// dead one's number.
+    var processIdentity: ClaudeProcessIdentity? {
+        guard let pid, let startedAt else { return nil }
+        return ClaudeProcessIdentity(pid: pid, startedAt: startedAt)
+    }
+}
+
+/// A specific claude process, as reported by the agent registry.
+struct ClaudeProcessIdentity: Equatable, Sendable {
+    let pid: Int
+    let startedAt: Double
 }
 
 /// Asks Claude Code which conversations are live, rather than inferring it.
@@ -78,7 +106,18 @@ enum ClaudeAgentsService {
     /// on macOS and claude reports its resolved cwd. Matches "at or under" the
     /// worktree, mirroring the CLI's own `--cwd` semantics -- but never
     /// upward, since a claude in the parent directory is a different session.
-    static func agent(forWorktree worktree: String, in agents: [ClaudeAgent]) -> Match {
+    /// - Parameter preferring: the process this tab took its session id from,
+    ///   when it has one. Two claudes under a directory normally make the tab
+    ///   give up, because picking the wrong one binds it to a stranger's
+    ///   transcript -- but a tab that knows its own process is not guessing,
+    ///   and giving up costs it a `/clear` it would otherwise follow along
+    ///   with its live status. Only an exact match counts: if our process is
+    ///   not in the set, the result is still ambiguous.
+    static func agent(
+        forWorktree worktree: String,
+        in agents: [ClaudeAgent],
+        preferring preferred: ClaudeProcessIdentity? = nil
+    ) -> Match {
         let target = SandboxBackend.realResolvedPath(worktree)
         guard !target.isEmpty else { return .none }
 
@@ -89,7 +128,13 @@ enum ClaudeAgentsService {
         switch matches.count {
         case 0: return .none
         case 1: return .one(matches[0])
-        default: return .ambiguous
+        default:
+            // Exactly one of them being ours resolves it. Two would mean the
+            // registry reported one process twice, which is not something to
+            // guess through.
+            guard let preferred else { return .ambiguous }
+            let ours = matches.filter { $0.processIdentity == preferred }
+            return ours.count == 1 ? .one(ours[0]) : .ambiguous
         }
     }
 

--- a/Canopy/Services/ClaudeTranscriptLoader.swift
+++ b/Canopy/Services/ClaudeTranscriptLoader.swift
@@ -46,15 +46,7 @@ struct TranscriptMessage: Equatable, Identifiable {
     /// Compact attribution for display, e.g. `opus-5 · xhigh`. Nil when
     /// neither field is present, so old transcripts render exactly as before.
     var attribution: String? {
-        let shortModel = model.map {
-            $0.hasPrefix("claude-") ? String($0.dropFirst("claude-".count)) : $0
-        }
-        switch (shortModel, effort) {
-        case let (model?, effort?): return "\(model) · \(effort)"
-        case let (model?, nil): return model
-        case let (nil, effort?): return effort
-        case (nil, nil): return nil
-        }
+        ClaudeTranscriptLoader.attributionLabel(model: model, effort: effort)
     }
 }
 
@@ -74,6 +66,25 @@ enum ClaudeTranscriptLoader {
     /// Cap on tool-result preview length. Larger values bloat the transcript;
     /// the full output is still available in `getFullText()` via the raw view.
     private static let toolResultMaxLength = 600
+
+    /// Renders a model id and reasoning effort as one compact label, e.g.
+    /// `claude-opus-5` + `xhigh` -> `opus-5 · xhigh`. Nil when neither is
+    /// present; a half-populated pair is valid and renders the half it has.
+    ///
+    /// Lives here rather than on `TranscriptMessage` because the status bar
+    /// shows the same pairing from an entirely different parse. Two copies of
+    /// this formatting would drift apart the first time either changed.
+    static func attributionLabel(model: String?, effort: String?) -> String? {
+        let shortModel = model.map {
+            $0.hasPrefix("claude-") ? String($0.dropFirst("claude-".count)) : $0
+        }
+        switch (shortModel, effort) {
+        case let (model?, effort?): return "\(model) · \(effort)"
+        case let (model?, nil): return model
+        case let (nil, effort?): return effort
+        case (nil, nil): return nil
+        }
+    }
 
     static func load(path: String) throws -> [TranscriptMessage] {
         let data = try Data(contentsOf: URL(fileURLWithPath: path))

--- a/Canopy/Services/SessionCostService.swift
+++ b/Canopy/Services/SessionCostService.swift
@@ -12,6 +12,14 @@ struct TokenUsage {
     var formattedOutput: String { outputTokens.formatted() }
 }
 
+/// The Claude run's state as of its most recent turn: which model, at what
+/// reasoning effort, and how much context that turn had to read.
+struct SessionContext: Equatable {
+    let model: String?
+    let effort: String?
+    let contextTokens: Int
+}
+
 /// Parses Claude Code JSONL session files for token usage data.
 enum SessionCostService {
 
@@ -60,4 +68,104 @@ enum SessionCostService {
         }
         return parseTokenUsage(from: content, since: since)
     }
+
+    /// Compact-JSON marker for the assistant-entry fast path. Claude Code
+    /// writes JSONL without spaces after the colon, which is what makes this
+    /// substring reliable; ActivityDataService relies on the same shape.
+    private static let assistantMarker = Data("\"type\":\"assistant\"".utf8)
+
+    /// One line -> a context reading, or nil if this line is not a real turn.
+    ///
+    /// Takes raw bytes rather than a String on purpose. The window handed to
+    /// the scan routinely holds a user entry carrying a multi-megabyte tool
+    /// result, and decoding that to a String purely to discover it is not an
+    /// assistant entry costs more than everything else here combined. The
+    /// marker is only a pre-filter. The structural checks below decide: a tool
+    /// result quoting the marker gets parsed and then rejected for having no
+    /// assistant-shaped `message.usage`, so the fast path can never promote a
+    /// user entry.
+    private static func context(fromLine line: Data) -> SessionContext? {
+        guard line.range(of: assistantMarker) != nil else { return nil }
+        guard let obj = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+              obj["type"] as? String == "assistant",
+              let message = obj["message"] as? [String: Any],
+              let usageDict = message["usage"] as? [String: Any] else {
+            return nil
+        }
+        // Skip synthetic harness entries, matching parseTokenUsage. They
+        // trail real turns, so letting one win reports the wrong turn.
+        let model = message["model"] as? String
+        if model == "<synthetic>" { return nil }
+
+        return SessionContext(
+            model: model,
+            effort: obj["effort"] as? String,
+            contextTokens: (usageDict["input_tokens"] as? Int ?? 0)
+                + (usageDict["cache_creation_input_tokens"] as? Int ?? 0)
+                + (usageDict["cache_read_input_tokens"] as? Int ?? 0)
+        )
+    }
+
+    /// Context as of the LAST assistant entry -- deliberately not a sum.
+    /// `parseTokenUsage` above accumulates `cache_read_input_tokens` over every
+    /// turn, which is the right number for spend and several times too large
+    /// for context: the same window is re-read each turn and counted again.
+    /// Same fields, different reduction.
+    ///
+    /// `effort` is TOP-LEVEL on assistant entries, a sibling of `type` -- not
+    /// inside `message`. See the verified note in ClaudeTranscriptLoader.
+    static func parseLastTurnContext(from jsonlContent: String) -> SessionContext? {
+        parseLastTurnContext(from: Data(jsonlContent.utf8))
+    }
+
+    /// Backwards: the newest eligible entry IS the answer, so the first hit
+    /// going in reverse ends the scan instead of parsing every older entry
+    /// only to overwrite the result.
+    static func parseLastTurnContext(from jsonlData: Data) -> SessionContext? {
+        for line in jsonlData.split(separator: UInt8(ascii: "\n")).reversed() {
+            if let context = context(fromLine: line) { return context }
+        }
+        return nil
+    }
+
+    /// Context from the newest assistant entry, found by scanning backwards
+    /// from EOF in a doubling window.
+    ///
+    /// Backwards because this is polled and transcripts reach 14 MB -- a
+    /// forward scan re-reads the whole file on every tick. A *growing* window
+    /// rather than one fixed tail read because entry sizes are wildly
+    /// asymmetric: assistant entries top out near 19 KB, but a single user
+    /// entry carrying a large tool result was measured at 1.36 MB. A fixed
+    /// 256 KB tail steps clean over the assistant entry behind one of those.
+    ///
+    /// A window almost always starts part-way through an entry. That needs no
+    /// remainder bookkeeping: truncated JSON never parses, so the damaged
+    /// leading line is skipped like any other malformed line. Staying in raw
+    /// bytes covers the same hazard for free -- a window can also cut a
+    /// multi-byte character, and that degrades to one unparseable line rather
+    /// than poisoning a decode of the whole window.
+    static func lastTurnContext(
+        path: String,
+        chunkBytes: Int = 256 * 1024,
+        maxScanBytes: Int = 8 * 1024 * 1024
+    ) -> SessionContext? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd(), end > 0 else { return nil }
+        let size = Int(end)
+
+        var window = max(1, chunkBytes)
+        while true {
+            let capped = min(window, size)
+            guard (try? handle.seek(toOffset: UInt64(size - capped))) != nil,
+                  let data = try? handle.readToEnd() else { return nil }
+
+            if let context = parseLastTurnContext(from: data) { return context }
+            // Whole file already read, or the scan budget is spent: this
+            // transcript has no reportable turn near its end.
+            if capped >= size || window >= maxScanBytes { return nil }
+            window *= 2
+        }
+    }
+
 }

--- a/Canopy/Services/TerminalSession.swift
+++ b/Canopy/Services/TerminalSession.swift
@@ -30,6 +30,12 @@ final class TerminalSession: ObservableObject {
     /// When this terminal session was opened in Canopy (for token counting).
     let openedAt = Date()
 
+    /// The claude process this tab's `claudeSessionId` was adopted from.
+    ///
+    /// Deliberately not persisted: it is only meaningful while that process is
+    /// alive, and this tab owns it for exactly as long as the tab lives.
+    var adoptedClaudeProcess: ClaudeProcessIdentity?
+
     /// See `CanopySettings.disableAltScreen`. Captured at creation: the env
     /// is built once when the shell starts, so later settings changes only
     /// affect new sessions.

--- a/Canopy/Views/MainWindow.swift
+++ b/Canopy/Views/MainWindow.swift
@@ -49,8 +49,10 @@ struct MainWindow: View {
             }
             .onChange(of: appState.activeSessionId) { _, _ in
                 appState.activeGitStatus = nil
+                appState.activeSessionContext = nil
                 Task {
                     await appState.refreshGitStatus()
+                    await appState.refreshActiveSessionContext()
                     await appState.refreshAllSessionDiffStats()
                     await appState.refreshAllSessionPRCounts()
                 }

--- a/Canopy/Views/StatusBar.swift
+++ b/Canopy/Views/StatusBar.swift
@@ -65,6 +65,23 @@ struct StatusBar: View {
                 if let status = appState.activeGitStatus {
                     gitIndicators(status)
                 }
+
+                // Claude model / effort / live context size
+                if let context = appState.activeSessionContext,
+                   let label = Self.contextLabel(context) {
+                    Divider()
+                        .frame(height: 12)
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "cpu")
+                            .font(.system(size: 9))
+                        Text(label)
+                            .font(.system(size: 11))
+                            .lineLimit(1)
+                    }
+                    .foregroundStyle(.secondary)
+                    .tooltip(Self.contextTooltip(context))
+                }
             }
 
             Spacer()
@@ -218,6 +235,43 @@ struct StatusBar: View {
             parts.append("\(total - accounted) idle")
         }
         return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Claude Session Context
+
+    /// `opus-5 · high · 71.3K` -- model, reasoning effort, and how much context
+    /// the newest turn had to read.
+    ///
+    /// Nil when the turn says nothing worth a segment, so the bar drops it
+    /// entirely rather than showing a zero -- the same `if`-wrapped treatment
+    /// every git segment gets.
+    ///
+    /// Deliberately no percentage: `claude-opus-5` and `claude-opus-5[1m]` are
+    /// indistinguishable in the transcript, so a share-of-window figure would
+    /// be silently five times wrong for long-context sessions.
+    nonisolated static func contextLabel(_ context: SessionContext) -> String? {
+        var parts: [String] = []
+        if let attribution = ClaudeTranscriptLoader.attributionLabel(
+            model: context.model, effort: context.effort
+        ) {
+            parts.append(attribution)
+        }
+        if context.contextTokens > 0 {
+            parts.append(abbreviatedTokenCount(context.contextTokens))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// The segment is abbreviated to fit a 24pt bar, so the exact figure lives
+    /// here -- otherwise the number could not be checked against the transcript.
+    nonisolated static func contextTooltip(_ context: SessionContext) -> String {
+        var lines: [String] = []
+        if let model = context.model { lines.append(model) }
+        if let effort = context.effort { lines.append("Reasoning effort: \(effort)") }
+        if context.contextTokens > 0 {
+            lines.append("\(context.contextTokens.formatted()) tokens of context as of the last turn")
+        }
+        return lines.joined(separator: "\n")
     }
 
     // MARK: - Helpers

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -40,11 +40,13 @@ struct AgentReconciliationTests {
 
     private func agent(
         cwd: String, sessionId: String = UUID().uuidString,
-        status: String?, startedAt: Date = Date().addingTimeInterval(60)
+        status: String?, startedAt: Date = Date().addingTimeInterval(60),
+        pid: Int? = nil
     ) -> ClaudeAgent {
         ClaudeAgent(
             cwd: cwd, sessionId: sessionId, status: status,
-            startedAt: startedAt.timeIntervalSince1970 * 1000
+            startedAt: startedAt.timeIntervalSince1970 * 1000,
+            pid: pid
         )
     }
 
@@ -366,20 +368,250 @@ struct AgentReconciliationTests {
     }
 
 
+    // MARK: - Re-keyed sessions (/clear)
+
+    /// `/clear` does not restart claude -- it re-keys the running process and
+    /// starts a fresh transcript. Verified on a live session: `ps` shows one
+    /// process, started 21:44:42, launched as `--resume 0cd83df7...`, while
+    /// `claude agents --json` reports that same pid under a *different*
+    /// sessionId. Canopy kept the pre-clear id, so the status bar, the
+    /// transcript sheet and the token counts all read a file that would never
+    /// change again -- and the next launch would `--resume` the conversation
+    /// the user had just cleared.
+    @Test func adoptsAReKeyedIdFromTheSameProcess() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-clear")
+        let startedAt = Date().addingTimeInterval(60)
+        let before = UUID().uuidString
+        let afterClear = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-clear", sessionId: before,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+        #expect(state.sessions[0].claudeSessionId == before)
+
+        // Same process, new conversation.
+        state.applyAgents([agent(cwd: "/tmp/wt-clear", sessionId: afterClear,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    /// The hijack this relaxation must not reopen: the tab's claude exits, the
+    /// user runs a plain `claude` in the same worktree, and Canopy adopts a
+    /// stranger's conversation. A different process is not ours, whatever id
+    /// it reports.
+    @Test func doesNotAdoptAReKeyedIdFromADifferentProcess() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-hijack")
+        let startedAt = Date().addingTimeInterval(60)
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-hijack", sessionId: owned,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-hijack", sessionId: "stranger",
+                                 status: "idle", startedAt: startedAt, pid: 9999)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// pids are recycled. A matching pid with a different start time is a
+    /// different process wearing a dead one's number, so the pid alone cannot
+    /// carry the ownership proof.
+    @Test func doesNotAdoptWhenThePidWasRecycled() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-recycled")
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-recycled", sessionId: owned, status: "idle",
+                                 startedAt: Date().addingTimeInterval(60), pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-recycled", sessionId: "stranger", status: "idle",
+                                 startedAt: Date().addingTimeInterval(600), pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// A CLI that reports no pid gives no ownership proof, so the established
+    /// id stands. Losing the /clear fix on an older CLI is the safe failure;
+    /// adopting on cwd alone is not.
+    @Test func doesNotAdoptAReKeyedIdWhenTheCliReportsNoPid() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-nopid")
+        let startedAt = Date().addingTimeInterval(60)
+        let owned = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-nopid", sessionId: owned,
+                                 status: "idle", startedAt: startedAt)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-nopid", sessionId: "stranger",
+                                 status: "idle", startedAt: startedAt)])
+
+        #expect(state.sessions[0].claudeSessionId == owned)
+    }
+
+    /// The case that actually happens. Canopy relaunches, `loadSessions`
+    /// restores an established id, and the tab starts `claude --resume <id>`.
+    /// Nothing is ever adopted, so without recording ownership here the tab
+    /// would have no idea which process is its own -- and a `/clear` after a
+    /// restart, which is most of them, would go unnoticed.
+    @Test func followsAReKeyAfterARestoredSessionResumes() {
+        let state = makeState()
+        let restored = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-resumed", claudeSessionId: restored)
+        let startedAt = Date().addingTimeInterval(60)
+
+        // The resumed process reports the id we already hold: ours.
+        state.applyAgents([agent(cwd: "/tmp/wt-resumed", sessionId: restored,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+        #expect(state.sessions[0].claudeSessionId == restored)
+
+        // It then re-keys under /clear.
+        let afterClear = UUID().uuidString
+        state.applyAgents([agent(cwd: "/tmp/wt-resumed", sessionId: afterClear,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    /// Ownership is only recorded for a process that started after this tab
+    /// did. A claude already running in the worktree when the tab opened is
+    /// not ours to follow, even if it happens to report the id we hold.
+    @Test func doesNotTakeOwnershipOfAProcessOlderThanTheTab() {
+        let state = makeState()
+        let restored = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-older", claudeSessionId: restored)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-older", sessionId: restored, status: "idle",
+                                 startedAt: Date().addingTimeInterval(-600), pid: 4242)])
+
+        state.applyAgents([agent(cwd: "/tmp/wt-older", sessionId: "stranger", status: "idle",
+                                 startedAt: Date().addingTimeInterval(-600), pid: 4242)])
+
+        #expect(state.sessions[0].claudeSessionId == restored)
+    }
+
+    /// End to end: a tab that knows its own process keeps working when a
+    /// second claude appears in the same worktree. Before, the whole tab went
+    /// dark -- no id following, and `releaseNeedsInput` on every poll.
+    @Test func keepsFollowingItsOwnProcessWhenASecondClaudeAppears() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-two")
+        let startedAt = Date().addingTimeInterval(60)
+        let mine = UUID().uuidString
+
+        state.applyAgents([agent(cwd: "/tmp/wt-two", sessionId: mine,
+                                 status: "idle", startedAt: startedAt, pid: 4242)])
+        #expect(state.sessions[0].claudeSessionId == mine)
+
+        // A second claude shows up in the same directory, and ours re-keys.
+        let afterClear = UUID().uuidString
+        state.applyAgents([
+            agent(cwd: "/tmp/wt-two", sessionId: "stranger", status: "busy",
+                  startedAt: Date().addingTimeInterval(120), pid: 9999),
+            agent(cwd: "/tmp/wt-two", sessionId: afterClear, status: "idle",
+                  startedAt: startedAt, pid: 4242),
+        ])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    // MARK: - Container identity
+
+    /// The gate that kept `.appleContainer` out of reconciliation covers only
+    /// half of what it does. A container's *status* genuinely cannot be
+    /// trusted -- its peer socket is unreachable -- but its *identity* can: it
+    /// bind-mounts ~/.claude, which is the very reason the status bar can read
+    /// its transcript at all. Without this, a `/clear` in a container session
+    /// froze the segment permanently.
+    @Test func containerSessionFollowsAReKey() {
+        let state = makeState()
+        let assigned = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-ctr", backend: .appleContainer,
+                   claudeSessionId: assigned)
+        let startedAt = Date().addingTimeInterval(60)
+
+        // Canopy assigned this id with --session-id, and the container's
+        // registry entry reports it back: ours.
+        state.applyAgents([agent(cwd: "/tmp/wt-ctr", sessionId: assigned,
+                                 status: "busy", startedAt: startedAt, pid: 7)])
+        #expect(state.sessions[0].claudeSessionId == assigned)
+
+        let afterClear = UUID().uuidString
+        state.applyAgents([agent(cwd: "/tmp/wt-ctr", sessionId: afterClear,
+                                 status: "busy", startedAt: startedAt, pid: 7)])
+
+        #expect(state.sessions[0].claudeSessionId == afterClear)
+    }
+
+    /// Identity yes, status no. The container's reported status must still be
+    /// ignored, or the activity dots start lying for those sessions.
+    @Test func containerSessionTakesNoActivityFromTheRegistry() {
+        let state = makeState()
+        let assigned = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-ctr2", backend: .appleContainer,
+                   claudeSessionId: assigned)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-ctr2", sessionId: assigned,
+                                 status: "busy", startedAt: Date().addingTimeInterval(60), pid: 7)])
+
+        #expect(state.terminalSessions[state.sessions[0].id]?.activity != .working)
+    }
+
+    /// `.dockerSbx` shares nothing of ~/.claude, so nothing about it can be
+    /// believed -- not status, and not identity either.
+    @Test func dockerSbxFollowsNothing() {
+        let state = makeState()
+        let assigned = UUID().uuidString
+        addSession(to: state, dir: "/tmp/wt-sbx2", backend: .dockerSbx,
+                   claudeSessionId: assigned)
+        let startedAt = Date().addingTimeInterval(60)
+
+        state.applyAgents([agent(cwd: "/tmp/wt-sbx2", sessionId: assigned,
+                                 status: "busy", startedAt: startedAt, pid: 7)])
+        state.applyAgents([agent(cwd: "/tmp/wt-sbx2", sessionId: "rekeyed",
+                                 status: "busy", startedAt: startedAt, pid: 7)])
+
+        #expect(state.sessions[0].claudeSessionId == assigned)
+    }
+
+    /// Without this the whole container path is dead code: the 2 s poll never
+    /// runs, so `applyAgents` is never called with anything.
+    @Test func containerSessionsKeepThePollAlive() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-ctr3", backend: .appleContainer)
+
+        #expect(state.hasReconcilableSessions)
+    }
+
+    @Test func dockerSbxAloneStillSkipsThePoll() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-sbx3", backend: .dockerSbx)
+
+        #expect(!state.hasReconcilableSessions)
+    }
+
     // MARK: - Poll gating
 
     /// The poll skips its subprocess entirely when nothing could be
     /// reconciled. On a 2-second loop that is the difference between an idle
     /// app and one spawning a process every 2 seconds for no reason.
+    ///
+    /// `.appleContainer` used to belong in the skipped set and no longer does:
+    /// its registry entry names the conversation it is running, so there is
+    /// now something to reconcile even though its *status* is still ignored.
+    /// The assertion that survives -- and the one that was always the point --
+    /// is `.dockerSbx`, which shares nothing of ~/.claude and can never be
+    /// reconciled at all.
     @Test func pollIsSkippedWhenNoSessionQualifies() {
         let state = makeState()
         #expect(!state.hasReconcilableSessions)          // no sessions at all
 
-        addSession(to: state, dir: "/tmp/wt-v", backend: .appleContainer)
-        #expect(!state.hasReconcilableSessions)          // sandboxed: invisible to the host
-
         addSession(to: state, dir: "/tmp/wt-w", backend: .dockerSbx)
-        #expect(!state.hasReconcilableSessions)
+        #expect(!state.hasReconcilableSessions)          // shares nothing: never reconcilable
+
+        addSession(to: state, dir: "/tmp/wt-v", backend: .appleContainer)
+        #expect(state.hasReconcilableSessions)           // identity only, but that is enough
 
         addSession(to: state, dir: "/tmp/wt-x")          // .off
         #expect(state.hasReconcilableSessions)

--- a/Tests/AgentReconciliationTests.swift
+++ b/Tests/AgentReconciliationTests.swift
@@ -591,6 +591,29 @@ struct AgentReconciliationTests {
         #expect(!state.hasReconcilableSessions)
     }
 
+    /// A session's backend is editable while its tab is open -- the project and
+    /// global settings both feed `sandboxBackend(for:)`. Skipping the status
+    /// section for a container must therefore clear the idle counter like
+    /// every other early return here, or a count banked while the session was
+    /// a host backend sits waiting and turns the first idle poll after the
+    /// switch back into a confirmed finish.
+    @Test func switchingToAContainerBackendClearsTheIdleCounter() {
+        let state = makeState()
+        addSession(to: state, dir: "/tmp/wt-swap", claudeSessionId: UUID().uuidString)
+        let id = state.sessions[0].id
+
+        // Host backend, one idle observation banked.
+        state.applyAgents([agent(cwd: "/tmp/wt-swap", status: "idle")])
+        #expect(state.agentIdleObservations[id] == 1)
+
+        // The user switches this session to a container backend.
+        state.sessions[0].sandboxBackend = .appleContainer
+        state.applyAgents([agent(cwd: "/tmp/wt-swap", status: "idle")])
+
+        #expect(state.agentIdleObservations[id] == 0,
+                "a stale idle count survived the switch to a backend whose status is ignored")
+    }
+
     // MARK: - Poll gating
 
     /// The poll skips its subprocess entirely when nothing could be

--- a/Tests/ClaudeAgentsServiceTests.swift
+++ b/Tests/ClaudeAgentsServiceTests.swift
@@ -17,6 +17,103 @@ struct ClaudeAgentsServiceTests {
 
     // MARK: - Parsing
 
+    // MARK: - Disambiguating by adopted process
+
+    /// Two claudes under one directory normally make the tab give up, because
+    /// picking the wrong one binds it to a stranger's transcript. Once a tab
+    /// knows which process it took its id from, that set is no longer
+    /// ambiguous *to that tab* -- and giving up costs it a `/clear` it would
+    /// otherwise follow, plus its live status.
+    @Test func prefersTheAdoptedProcessAmongAmbiguousMatches() {
+        let mine = ClaudeProcessIdentity(pid: 4242, startedAt: 1_000)
+        let agents = [
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "theirs", status: "busy",
+                        startedAt: 2_000, pid: 9999),
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "mine", status: "idle",
+                        startedAt: 1_000, pid: 4242),
+        ]
+
+        let match = ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: agents, preferring: mine)
+
+        guard case .one(let picked) = match else {
+            Issue.record("expected .one, got \(match)"); return
+        }
+        #expect(picked.sessionId == "mine")
+    }
+
+    /// Without an adopted process there is nothing to prefer, so the original
+    /// behaviour stands: Canopy cannot know which is the tab's.
+    @Test func staysAmbiguousWithNoAdoptedProcess() {
+        let agents = [
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "a", status: "busy", startedAt: 1_000, pid: 1),
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "b", status: "busy", startedAt: 2_000, pid: 2),
+        ]
+
+        #expect(ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: agents, preferring: nil)
+                == .ambiguous)
+    }
+
+    /// The tab's own process is gone and two strangers remain. Preferring an
+    /// identity that matches none of them must not pick one at random.
+    @Test func staysAmbiguousWhenTheAdoptedProcessIsAbsent() {
+        let mine = ClaudeProcessIdentity(pid: 4242, startedAt: 1_000)
+        let agents = [
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "a", status: "busy", startedAt: 5_000, pid: 7),
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "b", status: "busy", startedAt: 6_000, pid: 8),
+        ]
+
+        #expect(ClaudeAgentsService.agent(forWorktree: "/tmp/wt", in: agents, preferring: mine)
+                == .ambiguous)
+    }
+
+    /// A single match is still a single match; preferring must not turn a
+    /// lone stranger into "ours" just because our own process is missing.
+    @Test func aLoneAgentIsStillReturnedRegardlessOfPreference() {
+        let mine = ClaudeProcessIdentity(pid: 4242, startedAt: 1_000)
+        let agents = [
+            ClaudeAgent(cwd: "/tmp/wt", sessionId: "only", status: "busy", startedAt: 9_000, pid: 7)
+        ]
+
+        guard case .one(let picked) = ClaudeAgentsService.agent(
+            forWorktree: "/tmp/wt", in: agents, preferring: mine
+        ) else { Issue.record("expected .one"); return }
+        #expect(picked.sessionId == "only")
+    }
+
+    /// The /clear fix hangs entirely on this field being read: a re-keyed
+    /// session is only adopted when the reporting process is provably the one
+    /// Canopy adopted from, and `pid` is half that proof. If the key were
+    /// spelled wrong or the field dropped, every ownership check would fail
+    /// closed and the fix would silently do nothing.
+    ///
+    /// Literal JSON from real `claude agents --json` output, including the
+    /// interactive entry's neighbouring `background` entry, which carries no
+    /// `pid` at all.
+    @Test func decodesPidAndBuildsAProcessIdentity() throws {
+        let json = """
+        [
+          {"id":"63401c10","cwd":"/Users/j/demo","kind":"background",
+           "startedAt":1787303896140,"sessionId":"63401c10-479f-44f5-8f5b-16deccd5886a",
+           "name":"Fork demo","state":"blocked"},
+          {"pid":18001,"cwd":"/Users/j/site","kind":"interactive",
+           "startedAt":1787427887639,"sessionId":"52109c55-b4b2-4186-9ee4-14d651577ffb",
+           "name":"master","status":"busy"}
+        ]
+        """
+        let agents = try #require(ClaudeAgentsService.parse(data(json)))
+        #expect(agents.count == 2)
+
+        let interactive = try #require(agents.first { $0.sessionId.hasPrefix("52109c55") })
+        #expect(interactive.pid == 18001)
+        let identity = try #require(interactive.processIdentity)
+        #expect(identity == ClaudeProcessIdentity(pid: 18001, startedAt: 1787427887639))
+
+        // A background entry reports no pid, so it can prove no ownership.
+        let background = try #require(agents.first { $0.sessionId.hasPrefix("63401c10") })
+        #expect(background.pid == nil)
+        #expect(background.processIdentity == nil)
+    }
+
     @Test func parsesRealWorldArray() throws {
         let agents = try #require(ClaudeAgentsService.parse(data("""
         [
@@ -84,7 +181,7 @@ struct ClaudeAgentsServiceTests {
 
     private func agent(cwd: String, sessionId: String = "s", status: String? = "idle",
                        startedAt: Double? = 0) -> ClaudeAgent {
-        ClaudeAgent(cwd: cwd, sessionId: sessionId, status: status, startedAt: startedAt)
+        ClaudeAgent(cwd: cwd, sessionId: sessionId, status: status, startedAt: startedAt, pid: nil)
     }
 
     @Test func matchesExactWorktreePath() {

--- a/Tests/SessionContextTests.swift
+++ b/Tests/SessionContextTests.swift
@@ -532,6 +532,39 @@ struct SessionContextAppStateTests {
         #expect(state.activeSessionContext == shown)
     }
 
+    /// The guard has to cover *two* things changing underneath a read, not
+    /// one. A tab switch is the obvious one. The other is the transcript
+    /// itself: `/clear` re-keys the session while the tab UUID stays exactly
+    /// the same, so a read already in flight against the pre-clear file
+    /// resumes, passes an activeSessionId check, and republishes the dead
+    /// conversation's numbers over the fresh ones -- undoing the reset this
+    /// feature exists to show.
+    @Test func aContextReadFromASupersededTranscriptIsNotPublished() {
+        let configDir = tempConfigDir()
+        defer { try? fm.removeItem(atPath: configDir) }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "s", directory: "/tmp/s")
+        let tab = state.sessions[0].id
+        state.activeSessionId = tab
+        let before = UUID().uuidString
+        state.assignClaudeSessionId(before, to: tab)
+
+        let stale = SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 402_326)
+        state.applySessionContext(stale, readFor: tab, transcript: before)
+        #expect(state.activeSessionContext == stale)
+
+        // /clear: same tab, new transcript.
+        let afterClear = UUID().uuidString
+        state.assignClaudeSessionId(afterClear, to: tab)
+
+        // The read that started before the re-key now lands.
+        state.applySessionContext(stale, readFor: tab, transcript: before)
+
+        #expect(state.activeSessionContext == nil,
+                "a read of the pre-clear transcript was republished over the reset")
+    }
+
     /// Issue #28 in miniature: a read finishes for one session after the user
     /// has already switched to another, and the stale numbers land under the
     /// new session's name.
@@ -553,18 +586,20 @@ struct SessionContextAppStateTests {
         state.createSession(name: "second", directory: "/tmp/second")
         let first = state.sessions[0].id
         let second = state.sessions[1].id
+        let transcript = UUID().uuidString
+        state.assignClaudeSessionId(transcript, to: first)
         let context = SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 1000)
 
         // A read that completes while its own session is still active applies.
         state.activeSessionId = first
-        state.applySessionContext(context, readFor: first)
+        state.applySessionContext(context, readFor: first, transcript: transcript)
         #expect(state.activeSessionContext == context)
 
         // The user switches tabs; a read still in flight for the old session
         // must not overwrite what the new one shows.
         state.activeSessionId = second
         state.activeSessionContext = nil
-        state.applySessionContext(context, readFor: first)
+        state.applySessionContext(context, readFor: first, transcript: transcript)
 
         #expect(state.activeSessionContext == nil,
                 "a context read for another session was published over the active one")

--- a/Tests/SessionContextTests.swift
+++ b/Tests/SessionContextTests.swift
@@ -1,0 +1,572 @@
+import Testing
+import Foundation
+@testable import Canopy
+
+/// Live context size is a *different reduction* over the same JSONL fields that
+/// `SessionCostService.parseTokenUsage` already reads. Cost sums every turn's
+/// `cache_read_input_tokens`; context is only the newest turn's. Conflating the
+/// two reports a number several times too large, so these tests pin the
+/// distinction rather than merely checking that some integer comes back.
+@Suite("Session context — parsing")
+struct SessionContextParsingTests {
+
+    // MARK: - Helpers
+
+    /// One assistant entry. `effort` is TOP-LEVEL, a sibling of `type` -- not
+    /// inside `message` (see ClaudeTranscriptLoader.swift's verified note).
+    private func assistantLine(
+        model: String = "claude-opus-5",
+        effort: String? = "high",
+        input: Int = 0,
+        cacheCreation: Int = 0,
+        cacheRead: Int = 0,
+        output: Int = 0
+    ) -> String {
+        let effortField = effort.map { #""effort":"\#($0)","# } ?? ""
+        return """
+        {"type":"assistant",\(effortField)"message":{"role":"assistant","model":"\(model)","usage":{"input_tokens":\(input),"cache_creation_input_tokens":\(cacheCreation),"cache_read_input_tokens":\(cacheRead),"output_tokens":\(output)}}}
+        """
+    }
+
+    // MARK: - The last turn, not the sum
+
+    /// The whole reason this function exists next to `parseTokenUsage`. If
+    /// someone routes context through the cost parser, this fails: 100 is the
+    /// newest turn, 160 is the running total, and only one of them is context.
+    @Test func reportsTheNewestTurnNotTheRunningTotal() {
+        let jsonl = [
+            assistantLine(input: 10, cacheCreation: 20, cacheRead: 30),
+            assistantLine(input: 1, cacheCreation: 2, cacheRead: 97),
+        ].joined(separator: "\n")
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.contextTokens == 100)
+        #expect(context?.contextTokens != 160, "summed across turns -- that is cost, not context")
+    }
+
+    /// Context is everything the model had to read: fresh input plus both cache
+    /// tiers. Reading `input_tokens` alone under-reports by orders of magnitude
+    /// on a warm session, which is exactly when the number matters.
+    @Test func sumsFreshInputAndBothCacheTiers() {
+        let jsonl = assistantLine(input: 5, cacheCreation: 50, cacheRead: 500)
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.contextTokens == 555)
+    }
+
+    /// Output tokens are spend, not context: they are not in the window the
+    /// next turn has to read.
+    @Test func excludesOutputTokens() {
+        let jsonl = assistantLine(input: 1, output: 9999)
+
+        #expect(SessionCostService.parseLastTurnContext(from: jsonl)?.contextTokens == 1)
+    }
+
+    // MARK: - Attribution
+
+    @Test func reportsModelAndEffortOfTheNewestTurn() {
+        let jsonl = [
+            assistantLine(model: "claude-sonnet-5", effort: "low", input: 1),
+            assistantLine(model: "claude-opus-5", effort: "xhigh", input: 2),
+        ].joined(separator: "\n")
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.model == "claude-opus-5")
+        #expect(context?.effort == "xhigh")
+    }
+
+    /// CLIs older than ~2.1.212 emit no `effort`, and several models have no
+    /// effort concept at all. That is a half-populated valid state, not a parse
+    /// failure -- the context number must still come through.
+    @Test func missingEffortStillYieldsContext() {
+        let jsonl = assistantLine(effort: nil, input: 7, cacheRead: 3)
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.effort == nil)
+        #expect(context?.contextTokens == 10)
+    }
+
+    // MARK: - Entries that must not win
+
+    /// `<synthetic>` is Claude Code's own error/interrupt row, not a real turn.
+    /// It trails the real entry, so taking "the last assistant line" naively
+    /// would report the wrong turn -- or zero.
+    @Test func syntheticEntriesFallThroughToTheRealTurn() {
+        let jsonl = [
+            assistantLine(model: "claude-opus-5", input: 42),
+            #"{"type":"assistant","message":{"role":"assistant","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0}}}"#,
+        ].joined(separator: "\n")
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.model == "claude-opus-5")
+        #expect(context?.contextTokens == 42)
+    }
+
+    /// A transcript almost always ends with user/tool-result rows after the
+    /// last assistant turn -- that is the normal shape while Claude is working.
+    @Test func trailingUserAndSystemEntriesAreIgnored() {
+        let jsonl = [
+            assistantLine(input: 8),
+            #"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"go on"}]}}"#,
+            #"{"type":"system","content":"hook fired"}"#,
+        ].joined(separator: "\n")
+
+        #expect(SessionCostService.parseLastTurnContext(from: jsonl)?.contextTokens == 8)
+    }
+
+    /// Assistant rows without a `usage` dict exist (streamed partials, some
+    /// harness rows). They carry no context figure, so they must not shadow the
+    /// last row that does.
+    @Test func assistantEntriesWithoutUsageDoNotShadowTheLastRealTurn() {
+        let jsonl = [
+            assistantLine(input: 64),
+            #"{"type":"assistant","message":{"role":"assistant","model":"claude-opus-5","content":[]}}"#,
+        ].joined(separator: "\n")
+
+        #expect(SessionCostService.parseLastTurnContext(from: jsonl)?.contextTokens == 64)
+    }
+
+    /// The reader rejects non-assistant lines on a substring marker before
+    /// paying for JSON parsing. That marker is a pre-filter, not the decision.
+    /// A transcript pasted into a tool result quotes it verbatim, which is not
+    /// hypothetical in this repo, and such an entry must still lose to the real
+    /// assistant turn behind it.
+    ///
+    /// Honest scope: this survives deleting the `type` check on its own,
+    /// because the entry is also rejected for having no `message.usage`. It
+    /// pins the outcome -- no false positive from the fast path -- rather than
+    /// any single guard.
+    @Test func aUserEntryQuotingTheAssistantMarkerDoesNotWin() {
+        let jsonl = [
+            assistantLine(model: "claude-opus-5", input: 33),
+            #"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"pasted a transcript: {"type":"assistant","message":{}}"}]}}"#,
+        ].joined(separator: "\n")
+
+        let context = SessionCostService.parseLastTurnContext(from: jsonl)
+
+        #expect(context?.model == "claude-opus-5")
+        #expect(context?.contextTokens == 33)
+    }
+
+    // MARK: - Nothing to report
+
+    @Test func emptyContentYieldsNil() {
+        #expect(SessionCostService.parseLastTurnContext(from: "") == nil)
+    }
+
+    /// Malformed lines are routine: the reader hands this function a window cut
+    /// mid-file, and Claude Code can be killed mid-write. Skip, never crash.
+    @Test func malformedLinesAreSkippedNotFatal() {
+        let jsonl = [
+            "not json at all",
+            #"{"type":"assistant","message":{"model":"claude-opus-5","usage":{"input_toke"#,
+            assistantLine(input: 3),
+        ].joined(separator: "\n")
+
+        #expect(SessionCostService.parseLastTurnContext(from: jsonl)?.contextTokens == 3)
+    }
+
+    @Test func contentWithNoAssistantTurnYieldsNil() {
+        let jsonl = #"{"type":"user","message":{"role":"user","content":[]}}"#
+
+        #expect(SessionCostService.parseLastTurnContext(from: jsonl) == nil)
+    }
+}
+
+
+/// The reader that feeds the parser above. Transcripts in `~/.claude/projects`
+/// were measured at 14 MB / 3726 lines, and this is polled -- so it scans
+/// backwards from EOF rather than reading the file forwards. The awkward part
+/// is that entry sizes are wildly asymmetric: assistant entries top out around
+/// 19 KB, but a single *user* entry carrying a large tool result was measured
+/// at 1.36 MB. A fixed tail window steps straight over the assistant entry
+/// behind one of those and reports nothing.
+@Suite("Session context — backwards reader")
+struct SessionContextReaderTests {
+
+    private func tempJSONL(_ lines: [String]) -> String {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("canopy-context-\(UUID().uuidString).jsonl")
+        try? lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return url.path
+    }
+
+    private func assistantLine(input: Int) -> String {
+        """
+        {"type":"assistant","effort":"high","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":\(input),"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}}
+        """
+    }
+
+    /// A user entry of a given payload size, standing in for a large tool result.
+    private func bulkyUserLine(bytes: Int) -> String {
+        """
+        {"type":"user","message":{"role":"user","content":[{"type":"text","text":"\(String(repeating: "x", count: bytes))"}]}}
+        """
+    }
+
+    @Test func readsTheLastTurnFromASmallFile() {
+        let path = tempJSONL([assistantLine(input: 11), assistantLine(input: 22)])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let context = SessionCostService.lastTurnContext(path: path)
+
+        #expect(context?.contextTokens == 22)
+        #expect(context?.model == "claude-opus-5")
+        #expect(context?.effort == "high")
+    }
+
+    /// The measurement that shapes the whole design, at default settings: a
+    /// 1.5 MB user entry sits between EOF and the newest assistant turn, so any
+    /// single fixed 256 KB tail read returns nil here.
+    @Test func findsTheTurnBehindAMultiMegabyteUserEntry() {
+        let path = tempJSONL([
+            assistantLine(input: 777),
+            bulkyUserLine(bytes: 1_500_000),
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(SessionCostService.lastTurnContext(path: path)?.contextTokens == 777)
+    }
+
+    /// Every window but the last starts mid-entry. A cut entry is invalid JSON
+    /// and gets skipped, so the window simply grows -- but it must land on the
+    /// *newest* turn, not the one before it, and not nil.
+    @Test func aWindowCuttingMidEntryStillResolvesToTheNewestTurn() {
+        let path = tempJSONL([assistantLine(input: 1), assistantLine(input: 222)])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        // Tiny chunk: the first several windows all begin part-way through the
+        // final entry.
+        let context = SessionCostService.lastTurnContext(path: path, chunkBytes: 50)
+
+        #expect(context?.contextTokens == 222)
+    }
+
+    /// This runs on a timer against a path that may not exist yet -- a session
+    /// whose Claude run has not written a transcript. It must be quiet.
+    @Test func missingFileYieldsNilWithoutThrowing() {
+        let path = NSTemporaryDirectory() + "canopy-absent-\(UUID().uuidString).jsonl"
+
+        #expect(SessionCostService.lastTurnContext(path: path) == nil)
+    }
+
+    @Test func emptyFileYieldsNil() {
+        let path = tempJSONL([])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(SessionCostService.lastTurnContext(path: path) == nil)
+    }
+
+    @Test func fileWithNoAssistantTurnYieldsNil() {
+        let path = tempJSONL([bulkyUserLine(bytes: 10)])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(SessionCostService.lastTurnContext(path: path) == nil)
+    }
+
+    /// The scan is bounded so a pathological transcript cannot turn a 10 s poll
+    /// into a full read of a 14 MB file. Past the cap it gives up rather than
+    /// escalating.
+    @Test func stopsAtMaxScanBytesInsteadOfReadingTheWholeFile() {
+        let path = tempJSONL([
+            assistantLine(input: 5),
+            bulkyUserLine(bytes: 40_000),
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let capped = SessionCostService.lastTurnContext(
+            path: path, chunkBytes: 256, maxScanBytes: 1024
+        )
+        #expect(capped == nil)
+
+        // Same file, cap lifted -- proves the nil above is the cap talking and
+        // not a broken fixture.
+        let uncapped = SessionCostService.lastTurnContext(
+            path: path, chunkBytes: 256, maxScanBytes: 1_000_000
+        )
+        #expect(uncapped?.contextTokens == 5)
+    }
+}
+
+
+/// The strings the status bar actually shows. Kept as pure statics on the view
+/// so they are assertable without a view host -- the same shape as
+/// `ProjectDetailView.collisionSummaryText`.
+@Suite("Session context — status bar label")
+struct SessionContextLabelTests {
+
+    @Test func rendersModelEffortAndAbbreviatedContext() {
+        let label = StatusBar.contextLabel(
+            SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 71_338)
+        )
+
+        #expect(label == "opus-5 · high · 71.3K")
+    }
+
+    /// Several models have no effort concept, and older CLIs emit none. The
+    /// label drops the missing half rather than showing a gap or a placeholder.
+    @Test func omitsEffortWhenAbsent() {
+        let label = StatusBar.contextLabel(
+            SessionContext(model: "claude-sonnet-5", effort: nil, contextTokens: 2_000)
+        )
+
+        #expect(label == "sonnet-5 · 2.0K")
+    }
+
+    @Test func showsContextAloneWhenTheTurnCarriesNoAttribution() {
+        let label = StatusBar.contextLabel(
+            SessionContext(model: nil, effort: nil, contextTokens: 1_500_000)
+        )
+
+        #expect(label == "1.5M")
+    }
+
+    /// Every other segment in this bar is wrapped in an `if` and disappears
+    /// when it has nothing to say. A "0" or an empty segment would be noise in
+    /// a 24pt bar that already carries five of them.
+    @Test func yieldsNilWhenThereIsNothingToShow() {
+        #expect(StatusBar.contextLabel(
+            SessionContext(model: nil, effort: nil, contextTokens: 0)
+        ) == nil)
+    }
+
+    @Test func showsAttributionAloneWhenTheTurnReportedNoTokens() {
+        let label = StatusBar.contextLabel(
+            SessionContext(model: "claude-opus-5", effort: "xhigh", contextTokens: 0)
+        )
+
+        #expect(label == "opus-5 · xhigh")
+    }
+
+    /// The segment is abbreviated to fit; the exact figure has to be reachable
+    /// somewhere, or the number cannot be checked against anything.
+    @Test func tooltipCarriesTheUnabbreviatedCount() {
+        let tooltip = StatusBar.contextTooltip(
+            SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 71_338)
+        )
+
+        #expect(tooltip.contains(71_338.formatted()))
+        #expect(!tooltip.contains("71.3K"))
+        #expect(tooltip.contains("claude-opus-5"))
+        #expect(tooltip.contains("high"))
+    }
+
+    /// No percentage anywhere: `claude-opus-5` and `claude-opus-5[1m]` are
+    /// indistinguishable in the transcript, so a "% of window" figure would be
+    /// silently 5x wrong for long-context sessions.
+    @Test func neitherLabelNorTooltipClaimsAPercentage() {
+        let context = SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 71_338)
+
+        #expect(StatusBar.contextLabel(context)?.contains("%") == false)
+        #expect(!StatusBar.contextTooltip(context).contains("%"))
+    }
+}
+
+
+/// Wiring: the bar reads one published property, refreshed on the existing
+/// 10 s git poll. Isolated with `AppState(configDir:)` so it never touches the
+/// developer's real ~/.config/canopy, and keyed on a unique working directory
+/// so the seeded transcript cannot collide with a real one.
+@Suite("Session context — AppState")
+@MainActor
+struct SessionContextAppStateTests {
+
+    private let fm = FileManager.default
+
+    private func tempConfigDir() -> String {
+        NSTemporaryDirectory() + "canopy-ctx-config-\(UUID().uuidString)"
+    }
+
+    /// Seeds a transcript where Claude Code would write one, for a working
+    /// directory that exists nowhere else.
+    private func makeWorkingDirWithTranscript(
+        claudeSessionId: String, lines: [String]
+    ) throws -> String {
+        let workingDirectory = NSTemporaryDirectory() + "canopy-ctx-wd-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true)
+        let transcript = ClaudeTranscriptLoader.sessionFilePath(
+            workingDirectory: workingDirectory, sessionId: claudeSessionId
+        )
+        try fm.createDirectory(
+            atPath: (transcript as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try lines.joined(separator: "\n").write(toFile: transcript, atomically: true, encoding: .utf8)
+        return workingDirectory
+    }
+
+    private func cleanUp(workingDirectory: String, claudeSessionId: String) {
+        let transcript = ClaudeTranscriptLoader.sessionFilePath(
+            workingDirectory: workingDirectory, sessionId: claudeSessionId
+        )
+        try? fm.removeItem(atPath: (transcript as NSString).deletingLastPathComponent)
+        try? fm.removeItem(atPath: workingDirectory)
+    }
+
+    private let assistantLine = """
+    {"type":"assistant","effort":"xhigh","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":100,"cache_creation_input_tokens":200,"cache_read_input_tokens":700,"output_tokens":9}}}
+    """
+
+    @Test func activeSessionTranscriptPopulatesContext() async throws {
+        let claudeSessionId = UUID().uuidString
+        let workingDirectory = try makeWorkingDirWithTranscript(
+            claudeSessionId: claudeSessionId, lines: [assistantLine]
+        )
+        let configDir = tempConfigDir()
+        defer {
+            cleanUp(workingDirectory: workingDirectory, claudeSessionId: claudeSessionId)
+            try? fm.removeItem(atPath: configDir)
+        }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "ctx", directory: workingDirectory)
+        state.activeSessionId = state.sessions[0].id
+        state.assignClaudeSessionId(claudeSessionId, to: state.sessions[0].id)
+
+        await state.refreshActiveSessionContext()
+
+        #expect(state.activeSessionContext?.contextTokens == 1000)
+        #expect(state.activeSessionContext?.model == "claude-opus-5")
+        #expect(state.activeSessionContext?.effort == "xhigh")
+    }
+
+    /// A session that has never launched Claude has no session id to look up.
+    /// It must report nothing rather than guessing at the newest transcript in
+    /// the directory -- that would show an unrelated `claude` run started
+    /// outside Canopy, the same trap TranscriptSheet documents.
+    @Test func sessionWithoutClaudeSessionIdReportsNoContext() async throws {
+        let configDir = tempConfigDir()
+        let workingDirectory = NSTemporaryDirectory() + "canopy-ctx-wd-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fm.removeItem(atPath: workingDirectory)
+            try? fm.removeItem(atPath: configDir)
+        }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "fresh", directory: workingDirectory)
+        state.activeSessionId = state.sessions[0].id
+
+        await state.refreshActiveSessionContext()
+
+        #expect(state.activeSessionContext == nil)
+    }
+
+    /// Claude assigns the id before the transcript exists, so there is a real
+    /// window where the id is set and the file is not yet there.
+    @Test func missingTranscriptFileReportsNoContext() async throws {
+        let configDir = tempConfigDir()
+        let workingDirectory = NSTemporaryDirectory() + "canopy-ctx-wd-\(UUID().uuidString)"
+        try fm.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fm.removeItem(atPath: workingDirectory)
+            try? fm.removeItem(atPath: configDir)
+        }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "pending", directory: workingDirectory)
+        state.activeSessionId = state.sessions[0].id
+        state.assignClaudeSessionId(UUID().uuidString, to: state.sessions[0].id)
+
+        await state.refreshActiveSessionContext()
+
+        #expect(state.activeSessionContext == nil)
+    }
+
+    @Test func noActiveSessionClearsContext() async {
+        let configDir = tempConfigDir()
+        defer { try? fm.removeItem(atPath: configDir) }
+
+        let state = AppState(configDir: configDir)
+        state.activeSessionContext = SessionContext(
+            model: "claude-opus-5", effort: "high", contextTokens: 500
+        )
+
+        await state.refreshActiveSessionContext()
+
+        #expect(state.activeSessionContext == nil)
+    }
+
+    /// The id is followed on the 2 s agent poll but the segment is refreshed
+    /// on the 10 s one, so after a `/clear` the bar would go on showing the
+    /// dead transcript's numbers for up to ten more seconds -- the exact stale
+    /// reading this feature exists to avoid. Clearing synchronously means the
+    /// worst case is a briefly absent segment rather than a wrong one.
+    @Test func changingTheActiveSessionsIdDropsTheStaleContext() {
+        let configDir = tempConfigDir()
+        defer { try? fm.removeItem(atPath: configDir) }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "s", directory: "/tmp/s")
+        state.activeSessionId = state.sessions[0].id
+        state.activeSessionContext = SessionContext(
+            model: "claude-opus-5", effort: "high", contextTokens: 400_000
+        )
+
+        state.assignClaudeSessionId(UUID().uuidString, to: state.sessions[0].id)
+
+        #expect(state.activeSessionContext == nil)
+    }
+
+    /// Another tab re-keying is not this tab's business. Clearing on every
+    /// assignment would blank the visible segment whenever any background
+    /// session churned.
+    @Test func anotherSessionsIdChangeLeavesTheActiveContextAlone() {
+        let configDir = tempConfigDir()
+        defer { try? fm.removeItem(atPath: configDir) }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "active", directory: "/tmp/a")
+        state.createSession(name: "other", directory: "/tmp/b")
+        state.activeSessionId = state.sessions[0].id
+        let shown = SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 1_234)
+        state.activeSessionContext = shown
+
+        state.assignClaudeSessionId(UUID().uuidString, to: state.sessions[1].id)
+
+        #expect(state.activeSessionContext == shown)
+    }
+
+    /// Issue #28 in miniature: a read finishes for one session after the user
+    /// has already switched to another, and the stale numbers land under the
+    /// new session's name.
+    ///
+    /// Asserted through `applySessionContext` rather than by racing
+    /// `refreshActiveSessionContext`, because that race cannot be won
+    /// reliably. The earlier version of this test arranged for a tab switch to
+    /// land inside the file read and needed 4 MB of filler to make the read
+    /// slow enough; it passed locally, failed under CI load, and was finally
+    /// broken outright by an optimisation that made the read four times
+    /// faster. A test whose correctness depends on losing a scheduling race is
+    /// a test that will fail for reasons unrelated to the code it covers.
+    @Test func aContextReadForAnotherSessionIsNotPublished() {
+        let configDir = tempConfigDir()
+        defer { try? fm.removeItem(atPath: configDir) }
+
+        let state = AppState(configDir: configDir)
+        state.createSession(name: "first", directory: "/tmp/first")
+        state.createSession(name: "second", directory: "/tmp/second")
+        let first = state.sessions[0].id
+        let second = state.sessions[1].id
+        let context = SessionContext(model: "claude-opus-5", effort: "high", contextTokens: 1000)
+
+        // A read that completes while its own session is still active applies.
+        state.activeSessionId = first
+        state.applySessionContext(context, readFor: first)
+        #expect(state.activeSessionContext == context)
+
+        // The user switches tabs; a read still in flight for the old session
+        // must not overwrite what the new one shows.
+        state.activeSessionId = second
+        state.activeSessionContext = nil
+        state.applySessionContext(context, readFor: first)
+
+        #expect(state.activeSessionContext == nil,
+                "a context read for another session was published over the active one")
+    }
+}


### PR DESCRIPTION
Adds one segment to the status bar: `opus-5 · xhigh · 402.3K` — which model produced the session's last turn, at what reasoning effort, and how much context that turn had to read.

Re-lands #78 and #84, reverted in #85 so this could go in complete rather than as a third increment. Everything they contained is here unchanged; what is new is the three paths an audit found still broken.

## Reading the transcript

**Live context is a different reduction than cost.** `parseTokenUsage` sums `cache_read_input_tokens` over every turn — right for spend, several times too large for context, since the same window is re-read each turn and counted again. Context is the newest turn's `input + cache_read + cache_creation`.

Reading it needs care:

- Transcripts here measure **14 MB / 3726 lines**, and this is polled — so `lastTurnContext` scans backwards from EOF in a doubling window.
- It stays in **raw bytes** and rejects non-assistant lines on a `"type":"assistant"` marker before paying for `JSONSerialization`, the same fast path `ActivityDataService` uses. Entry sizes are wildly asymmetric: assistant entries top out near 19 KB, but a single *user* entry carrying a large tool result was measured at **1.36 MB**, and decoding one of those to a `String` purely to discover it is not an assistant entry cost more than everything else combined (162 ms → 40 ms once fixed).

**No percentage.** `claude-opus-5` and `claude-opus-5[1m]` are indistinguishable in the transcript, so a share-of-window figure would be silently 5× wrong. One real session here reads `991.5K`, which a 200k assumption would render as **496%**.

## Following the conversation

`/clear` does not restart claude — it **re-keys the running process** and starts a fresh transcript. Caught live:

```
ps -p 18001   →  claude --permission-mode auto --resume 0cd83df7-...   (started 21:44:42)
agents --json →  pid 18001, sessionId 52109c55-...
sessions.json →  master -> 0cd83df7-...
```

One process, two ids. A tab now records which process it took its id from — `pid` plus `startedAt`, the latter being the *process* start (agent reports 21:44:47 against a 21:44:42 exec) and so surviving a re-key — and follows that process. A different claude fails on either, so #51's hijack guard is intact.

## The three paths the increments missed

**Ambiguity is now resolvable.** Two claudes under one worktree made the tab give up entirely, losing both the re-key and its live status. A tab that knows its own process is not guessing, so `agent(forWorktree:in:preferring:)` picks ours out of the set. With nothing to prefer it still reports `.ambiguous`.

**Container sessions follow a re-key.** `reportsToHostAgentRegistry` was doing two jobs and only justified one. A container's *status* genuinely cannot be trusted — its peer socket is unreachable — but its *identity* can: it bind-mounts `~/.claude`, which is exactly why the segment can read its transcript at all. The gate is split. The old objection to its pid does not apply to identity: nothing resolves a pid to a host process, it is only compared against one the same entry reported earlier, and `startedAt` is namespace-independent. Adopting an *unknown* id stays host-only; `.dockerSbx` still follows nothing.

**The segment no longer lags the id.** It was followed on the 2 s agent poll but refreshed on the 10 s one, so after a `/clear` the bar showed the previous conversation's numbers for up to ten more seconds.

## One test amended, not deleted

`pollIsSkippedWhenNoSessionQualifies` asserted that a container-only workspace skips the poll. That becomes wrong by design — an `.appleContainer` session now has something to reconcile — so it is amended to keep the assertion that was always its real point: `.dockerSbx` shares nothing of `~/.claude` and can never be reconciled.

## Testing

**781 tests green, run 3×.** Every new guard mutation-checked:

| Mutation | Killed by |
|---|---|
| Ignore `preferring` | `prefersTheAdoptedProcessAmongAmbiguousMatches`, `keepsFollowingItsOwnProcessWhenASecondClaudeAppears` |
| Drop the activity host-gate | `containerSessionTakesNoActivityFromTheRegistry` |
| Identity gate back to host-only | `containerSessionFollowsAReKey` |
| Let containers adopt an unknown id | `sandboxedSessionIgnoresAgentData` |
| Delete the re-key branch | `adoptsAReKeyedIdFromTheSameProcess`, `followsAReKeyAfterARestoredSessionResumes` |
| Drop the ownership comparison | both hijack tests, with the id replaced by `"stranger"` |

Also verified: subagents cannot corrupt the reading — `isSidechain` is present on all **11,307** assistant entries across the 130 transcripts on this machine and is `false` on every one, so subagents get their own files.

## Verification limits

The container path is unit-tested against real captured payloads but not exercised end-to-end; `ContainerSandboxE2ETests` is runtime-gated and does not run `claude agents --json` inside a container. `/compact` could not be tested — zero compaction markers exist in those 130 transcripts. Both of its branches are safe by construction: keep the id and context drops naturally, re-key and the pid path covers it. That is reasoning, not evidence.

## Known limitation

An id that has **already** gone stale is not repaired. Recovering one means guessing at the newest transcript in the directory — the heuristic `TranscriptSheet.computeJSONLPath` documents and rejects, since it silently adopts a `claude` run outside Canopy. Closing and reopening the tab realigns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199QvpHaWazYpEFKCEni9g9